### PR TITLE
Sync architecture headers with u1

### DIFF
--- a/lites-1.1.1/include/i386/Makefile
+++ b/lites-1.1.1/include/i386/Makefile
@@ -16,7 +16,10 @@
 # WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
 #
 # HISTORY
-# $Log: $
+# $Log: Makefile,v $
+# Revision 1.1.1.1  1995/03/02  21:49:33  mike
+# Initial Lites release from hut.fi
+#
 # $EndLog$
 #
 #	File:	 include/i386/Makefile

--- a/lites-1.1.1/include/ns532/Makefile
+++ b/lites-1.1.1/include/ns532/Makefile
@@ -16,7 +16,10 @@
 # WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
 #
 # HISTORY
-# $Log: $
+# $Log: Makefile,v $
+# Revision 1.1.1.1  1995/03/02  21:49:36  mike
+# Initial Lites release from hut.fi
+#
 # $EndLog$
 #
 #	File:	 include/ns532/Makefile

--- a/lites-1.1.1/include/parisc/Makefile
+++ b/lites-1.1.1/include/parisc/Makefile
@@ -16,7 +16,10 @@
 # WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
 #
 # HISTORY
-# $Log: $
+# $Log: Makefile,v $
+# Revision 1.1.1.1  1995/03/02  21:49:38  mike
+# Initial Lites release from hut.fi
+#
 # $EndLog$
 #
 #	File:	 include/ns532/Makefile

--- a/lites-1.1.1/include/parisc/cpu.h
+++ b/lites-1.1.1/include/parisc/cpu.h
@@ -19,7 +19,10 @@
  */
 /*
  * HISTORY
- * $Log: $
+ * $Log: cpu.h,v $
+ * Revision 1.1.1.1  1995/03/02  21:49:38  mike
+ * Initial Lites release from hut.fi
+ *
  */
 
 /*

--- a/lites-1.1.1/include/parisc/limits.h
+++ b/lites-1.1.1/include/parisc/limits.h
@@ -19,7 +19,10 @@
  */
 /*
  * HISTORY
- * $Log: $
+ * $Log: limits.h,v $
+ * Revision 1.1.1.1  1995/03/02  21:49:38  mike
+ * Initial Lites release from hut.fi
+ *
  */
 
 /*

--- a/lites-1.1.1/include/parisc/param.h
+++ b/lites-1.1.1/include/parisc/param.h
@@ -19,7 +19,13 @@
  */
 /*
  * HISTORY
- * $Log: $
+ * $Log: param.h,v $
+ * Revision 1.2  1995/03/10  17:18:27  mike
+ * Changes to make it compile/link in the new build environment
+ *
+ * Revision 1.1.1.1  1995/03/02  21:49:38  mike
+ * Initial Lites release from hut.fi
+ *
  */
 
 /*

--- a/lites-1.1.1/include/parisc/proc.h
+++ b/lites-1.1.1/include/parisc/proc.h
@@ -19,7 +19,10 @@
  */
 /*
  * HISTORY
- * $Log: $
+ * $Log: proc.h,v $
+ * Revision 1.1.1.1  1995/03/02  21:49:38  mike
+ * Initial Lites release from hut.fi
+ *
  */
 /*
  * Copyright (c) 1992, 1993

--- a/lites-1.1.1/include/parisc/regalias.h
+++ b/lites-1.1.1/include/parisc/regalias.h
@@ -19,7 +19,10 @@
  */
 /*
  * HISTORY
- * $Log: $
+ * $Log: regalias.h,v $
+ * Revision 1.1.1.1  1995/03/02  21:49:38  mike
+ * Initial Lites release from hut.fi
+ *
  */
 
 #ifndef	ASSEMBLER

--- a/lites-1.1.1/include/parisc/signal.h
+++ b/lites-1.1.1/include/parisc/signal.h
@@ -19,7 +19,10 @@
  */
 /*
  * HISTORY
- * $Log: $
+ * $Log: signal.h,v $
+ * Revision 1.1.1.1  1995/03/02  21:49:38  mike
+ * Initial Lites release from hut.fi
+ *
  */
 
 /*

--- a/lites-1.1.1/include/parisc/trap.h
+++ b/lites-1.1.1/include/parisc/trap.h
@@ -19,7 +19,10 @@
  */
 /*
  * HISTORY
- * $Log: $
+ * $Log: trap.h,v $
+ * Revision 1.1.1.1  1995/03/02  21:49:38  mike
+ * Initial Lites release from hut.fi
+ *
  */
 
 /*

--- a/lites-1.1.1/include/parisc/vmparam.h
+++ b/lites-1.1.1/include/parisc/vmparam.h
@@ -19,7 +19,10 @@
  */
 /*
  * HISTORY
- * $Log: $
+ * $Log: vmparam.h,v $
+ * Revision 1.1.1.1  1995/03/02  21:49:38  mike
+ * Initial Lites release from hut.fi
+ *
  */
 
 #ifndef _PARISC_BSD_VMPARAM_H_


### PR DESCRIPTION
## Summary
- update `i386` headers with u1 snapshot
- sync `ns532` headers with u1
- align `parisc` headers with u1

## Testing
- `diff -ruN lites-1.1.1/include/i386 lites-1.1.u1/include/i386`
- `diff -ruN lites-1.1.1/include/ns532 lites-1.1.u1/include/ns532`
- `diff -ruN lites-1.1.1/include/parisc lites-1.1.u1/include/parisc`
