### PR TITLE
Clean CVS keywords

### DIFF
--- a/lites-1.1.1/server/netiso/clnp_frag.c
+++ b/lites-1.1.1/server/netiso/clnp_frag.c
@@ -59,7 +59,7 @@ SOFTWARE.
 /*
  * ARGO Project, Computer Sciences Dept., University of Wisconsin - Madison
  */
-/* $Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/clnp_frag.c,v 1.1.1.1 1995/03/02 21:49:57 mike Exp $ */
+/* Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/clnp_frag.c,v 1.1.1.1 1995/03/02 21:49:57 mike Exp  */
 /* $Source: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/clnp_frag.c,v $ */
 
 #include <sys/param.h>

--- a/lites-1.1.1/server/netiso/cons.h
+++ b/lites-1.1.1/server/netiso/cons.h
@@ -60,7 +60,7 @@ SOFTWARE.
  * ARGO Project, Computer Sciences Dept., University of Wisconsin - Madison
  */
 /*
- * $Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/cons.h,v 1.1.1.1 1995/03/02 21:49:57 mike Exp $
+ * Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/cons.h,v 1.1.1.1 1995/03/02 21:49:57 mike Exp 
  * $Source: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/cons.h,v $
  *
  * interface between TP and CONS

--- a/lites-1.1.1/server/netiso/iso.h
+++ b/lites-1.1.1/server/netiso/iso.h
@@ -59,7 +59,7 @@ SOFTWARE.
 /*
  * ARGO Project, Computer Sciences Dept., University of Wisconsin - Madison
  */
-/* $Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/iso.h,v 1.1.1.1 1995/03/02 21:49:56 mike Exp $ */
+/* Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/iso.h,v 1.1.1.1 1995/03/02 21:49:56 mike Exp  */
 /* $Source: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/iso.h,v $ */
 
 #ifndef __ISO__

--- a/lites-1.1.1/server/netiso/iso_var.h
+++ b/lites-1.1.1/server/netiso/iso_var.h
@@ -59,7 +59,7 @@ SOFTWARE.
 /*
  * ARGO Project, Computer Sciences Dept., University of Wisconsin - Madison
  */
-/* $Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/iso_var.h,v 1.1.1.1 1995/03/02 21:49:56 mike Exp $
+/* Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/iso_var.h,v 1.1.1.1 1995/03/02 21:49:56 mike Exp 
  * $Source: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/iso_var.h,v $
  */
 

--- a/lites-1.1.1/server/netiso/tp.trans
+++ b/lites-1.1.1/server/netiso/tp.trans
@@ -60,7 +60,7 @@ SOFTWARE.
 /*
  * ARGO Project, Computer Sciences Dept., University of Wisconsin - Madison
  */
-/* $Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp.trans,v 1.1.1.1 1995/03/02 21:49:57 mike Exp $
+/* Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp.trans,v 1.1.1.1 1995/03/02 21:49:57 mike Exp 
  *
  * Transition file for TP.
  *

--- a/lites-1.1.1/server/netiso/tp_driver.c
+++ b/lites-1.1.1/server/netiso/tp_driver.c
@@ -1,7 +1,7 @@
-/* $Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp_driver.c,v 1.1.1.1 1995/03/02 21:49:56 mike Exp $ */
+/* Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp_driver.c,v 1.1.1.1 1995/03/02 21:49:56 mike Exp  */
 /* $Source: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp_driver.c,v $ */
 #ifndef lint
-static char *rcsid = "$Header/**/$";
+static char *rcsid = "Header/**/";
 #endif lint
 #define _XEBEC_PG static
 

--- a/lites-1.1.1/server/netiso/tp_output.c
+++ b/lites-1.1.1/server/netiso/tp_output.c
@@ -62,7 +62,7 @@ SOFTWARE.
 /* 
  * ARGO TP
  *
- * $Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp_output.c,v 1.1.1.1 1995/03/02 21:49:56 mike Exp $
+ * Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp_output.c,v 1.1.1.1 1995/03/02 21:49:56 mike Exp 
  * $Source: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp_output.c,v $
  *
  * In here is tp_ctloutput(), the guy called by [sg]etsockopt(),

--- a/lites-1.1.1/server/netiso/tp_pcb.h
+++ b/lites-1.1.1/server/netiso/tp_pcb.h
@@ -62,7 +62,7 @@ SOFTWARE.
 /* 
  * ARGO TP
  *
- * $Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp_pcb.h,v 1.1.1.1 1995/03/02 21:49:56 mike Exp $
+ * Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp_pcb.h,v 1.1.1.1 1995/03/02 21:49:56 mike Exp 
  * $Source: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp_pcb.h,v $
  *
  * 

--- a/lites-1.1.1/server/netiso/tp_stat.h
+++ b/lites-1.1.1/server/netiso/tp_stat.h
@@ -62,7 +62,7 @@ SOFTWARE.
 /* 
  * ARGO TP
  *
- * $Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp_stat.h,v 1.1.1.1 1995/03/02 21:49:56 mike Exp $
+ * Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp_stat.h,v 1.1.1.1 1995/03/02 21:49:56 mike Exp 
  * $Source: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp_stat.h,v $
  *
  * Here are the data structures in which the global

--- a/lites-1.1.1/server/netiso/tp_usrreq.c
+++ b/lites-1.1.1/server/netiso/tp_usrreq.c
@@ -62,7 +62,7 @@ SOFTWARE.
 /* 
  * ARGO TP
  *
- * $Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp_usrreq.c,v 1.1.1.1 1995/03/02 21:49:55 mike Exp $
+ * Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp_usrreq.c,v 1.1.1.1 1995/03/02 21:49:55 mike Exp 
  * $Source: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/tp_usrreq.c,v $
  *
  * tp_usrreq(), the fellow that gets called from most of the socket code.


### PR DESCRIPTION
## Summary
- remove CVS keyword markers from netiso files

## Testing
- `make -C lites-1.1.1` *(fails: missing separator)*