### PR TITLE
Fix __P macros in Lites 1.1.1 headers

### DIFF
--- a/lites-1.1.1/include/dirent.h
+++ b/lites-1.1.1/include/dirent.h
@@ -75,17 +75,17 @@ typedef struct _dirdesc {
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS
-DIR *opendir __P((const char *));
-struct dirent *readdir __P((DIR *));
-void rewinddir __P((DIR *));
-int closedir __P((DIR *));
+DIR *opendir (const char *);
+struct dirent *readdir (DIR *);
+void rewinddir (DIR *);
+int closedir (DIR *);
 #ifndef _POSIX_SOURCE
-long telldir __P((const DIR *));
-void seekdir __P((DIR *, long));
-int scandir __P((const char *, struct dirent ***,
-    int (*)(struct dirent *), int (*)(const void *, const void *)));
-int alphasort __P((const void *, const void *));
-int getdirentries __P((int, char *, int, long *));
+long telldir (const DIR *);
+void seekdir (DIR *, long);
+int scandir (const char *, struct dirent ***,
+    int (*)(struct dirent *), int (*)(const void *, const void *));
+int alphasort (const void *, const void *);
+int getdirentries (int, char *, int, long *);
 #endif /* not POSIX */
 __END_DECLS
 

--- a/lites-1.1.1/include/i386/endian.h
+++ b/lites-1.1.1/include/i386/endian.h
@@ -61,10 +61,10 @@
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS
-unsigned long	htonl __P((unsigned long));
-unsigned short	htons __P((unsigned short));
-unsigned long	ntohl __P((unsigned long));
-unsigned short	ntohs __P((unsigned short));
+unsigned long	htonl (unsigned long);
+unsigned short	htons (unsigned short);
+unsigned long	ntohl (unsigned long);
+unsigned short	ntohs (unsigned short);
 __END_DECLS
 
 /*

--- a/lites-1.1.1/include/mips/endian.h
+++ b/lites-1.1.1/include/mips/endian.h
@@ -61,10 +61,10 @@
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS
-unsigned int	htonl __P((unsigned int));
-unsigned short	htons __P((unsigned short));
-unsigned int	ntohl __P((unsigned int));
-unsigned short	ntohs __P((unsigned short));
+unsigned int	htonl (unsigned int);
+unsigned short	htons (unsigned short);
+unsigned int	ntohl (unsigned int);
+unsigned short	ntohs (unsigned short);
 __END_DECLS
 
 /*

--- a/lites-1.1.1/include/ns532/endian.h
+++ b/lites-1.1.1/include/ns532/endian.h
@@ -61,10 +61,10 @@
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS
-unsigned long	htonl __P((unsigned long));
-unsigned short	htons __P((unsigned short));
-unsigned long	ntohl __P((unsigned long));
-unsigned short	ntohs __P((unsigned short));
+unsigned long	htonl (unsigned long);
+unsigned short	htons (unsigned short);
+unsigned long	ntohl (unsigned long);
+unsigned short	ntohs (unsigned short);
 __END_DECLS
 
 /*

--- a/lites-1.1.1/include/parisc/endian.h
+++ b/lites-1.1.1/include/parisc/endian.h
@@ -62,10 +62,10 @@
 
 #if BYTE_ORDER != BIG_ENDIAN || defined(lint)
 __BEGIN_DECLS
-unsigned long	htonl __P((unsigned long));
-unsigned short	htons __P((unsigned short));
-unsigned long	ntohl __P((unsigned long));
-unsigned short	ntohs __P((unsigned short));
+unsigned long	htonl (unsigned long);
+unsigned short	htons (unsigned short);
+unsigned long	ntohl (unsigned long);
+unsigned short	ntohs (unsigned short);
 __END_DECLS
 #endif
 

--- a/lites-1.1.1/include/sys/conf.h
+++ b/lites-1.1.1/include/sys/conf.h
@@ -88,15 +88,15 @@ struct vnode;
 struct bdevsw {
         char    *d_name;
 	int	d_flags;
-	int	(*d_open)	__P((dev_t dev, int oflags, int devtype,
-				     struct proc *p));
-	int	(*d_close)	__P((dev_t dev, int fflag, int devtype,
-				     struct proc *p));
-	int	(*d_strategy)	__P((struct buf *bp));
-	int	(*d_ioctl)	__P((dev_t dev, ioctl_cmd_t cmd, caddr_t data,
-				     int fflag, struct proc *p));
+	int	(*d_open)	(dev_t dev, int oflags, int devtype,
+				     struct proc *p);
+	int	(*d_close)	(dev_t dev, int fflag, int devtype,
+				     struct proc *p);
+	int	(*d_strategy)	(struct buf *bp);
+	int	(*d_ioctl)	(dev_t dev, ioctl_cmd_t cmd, caddr_t data,
+				     int fflag, struct proc *p);
 	int	(*d_dump)	();	/* parameters vary by architecture */
-	int	(*d_psize)	__P((dev_t dev));
+	int	(*d_psize)	(dev_t dev);
 };
 
 #ifdef KERNEL
@@ -106,23 +106,23 @@ extern struct bdevsw bdevsw[];
 struct cdevsw {
         char    *d_name;
 	int	d_flags;
-	int	(*d_open)	__P((dev_t dev, int oflags, int devtype,
-				     struct proc *p));
-	int	(*d_close)	__P((dev_t dev, int fflag, int devtype,
-				     struct proc *));
-	int	(*d_read)	__P((dev_t dev, struct uio *uio, int ioflag));
-	int	(*d_write)	__P((dev_t dev, struct uio *uio, int ioflag));
-	int	(*d_ioctl)	__P((dev_t dev, ioctl_cmd_t cmd, caddr_t data,
-				     int fflag, struct proc *p));
-	int	(*d_stop)	__P((struct tty *tp, int rw));
-	int	(*d_reset)	__P((int uban));	/* XXX */
-	struct	tty *(*d_tty)	__P((dev_t dev));
-	int	(*d_select)	__P((dev_t dev, int which, struct proc *p));
+	int	(*d_open)	(dev_t dev, int oflags, int devtype,
+				     struct proc *p);
+	int	(*d_close)	(dev_t dev, int fflag, int devtype,
+				     struct proc *);
+	int	(*d_read)	(dev_t dev, struct uio *uio, int ioflag);
+	int	(*d_write)	(dev_t dev, struct uio *uio, int ioflag);
+	int	(*d_ioctl)	(dev_t dev, ioctl_cmd_t cmd, caddr_t data,
+				     int fflag, struct proc *p);
+	int	(*d_stop)	(struct tty *tp, int rw);
+	int	(*d_reset)	(int uban);	/* XXX */
+	struct	tty *(*d_tty)	(dev_t dev);
+	int	(*d_select)	(dev_t dev, int which, struct proc *p);
 	/* return pager port. eg. device_map */
-	kern_return_t (*d_mmap)	__P((mach_port_t, vm_prot_t, vm_offset_t,
-				     vm_size_t, mach_port_t *, int));
-	int	(*d_strategy)	__P((struct buf *bp));
-	mach_port_t (*d_port)	__P((dev_t));
+	kern_return_t (*d_mmap)	(mach_port_t, vm_prot_t, vm_offset_t,
+				     vm_size_t, mach_port_t *, int);
+	int	(*d_strategy)	(struct buf *bp);
+	mach_port_t (*d_port)	(dev_t);
 };
 
 #ifdef KERNEL
@@ -134,17 +134,17 @@ extern char devioc[], devcls[];
 #endif
 
 struct linesw {
-	int	(*l_open)	__P((dev_t dev, struct tty *tp));
-	int	(*l_close)	__P((struct tty *tp, int flag));
-	int	(*l_read)	__P((struct tty *tp, struct uio *uio,
-				     int flag));
-	int	(*l_write)	__P((struct tty *tp, struct uio *uio,
-				     int flag));
-	int	(*l_ioctl)	__P((struct tty *tp, ioctl_cmd_t cmd,
-				     caddr_t data, int flag, struct proc *p));
-	int	(*l_rint)	__P((int c, struct tty *tp));
-	int	(*l_start)	__P((struct tty *tp));
-	int	(*l_modem)	__P((struct tty *tp, int flag));
+	int	(*l_open)	(dev_t dev, struct tty *tp);
+	int	(*l_close)	(struct tty *tp, int flag);
+	int	(*l_read)	(struct tty *tp, struct uio *uio,
+				     int flag);
+	int	(*l_write)	(struct tty *tp, struct uio *uio,
+				     int flag);
+	int	(*l_ioctl)	(struct tty *tp, ioctl_cmd_t cmd,
+				     caddr_t data, int flag, struct proc *p);
+	int	(*l_rint)	(int c, struct tty *tp);
+	int	(*l_start)	(struct tty *tp);
+	int	(*l_modem)	(struct tty *tp, int flag);
 };
 
 #ifdef KERNEL

--- a/lites-1.1.1/include/sys/device.h
+++ b/lites-1.1.1/include/sys/device.h
@@ -91,7 +91,7 @@ struct cfdata {
 #define	FSTATE_FOUND	1	/* has been found */
 #define	FSTATE_STAR	2	/* duplicable */
 
-typedef int (*cfmatch_t) __P((struct device *, struct cfdata *, void *));
+typedef int (*cfmatch_t) (struct device *, struct cfdata *, void *);
 
 /*
  * `configuration' driver (what the machine-independent autoconf uses).
@@ -105,7 +105,7 @@ struct cfdriver {
 	void	**cd_devs;		/* devices found */
 	char	*cd_name;		/* device name */
 	cfmatch_t cd_match;		/* returns a match level */
-	void	(*cd_attach) __P((struct device *, struct device *, void *));
+	void	(*cd_attach) (struct device *, struct device *, void *);
 	enum	devclass cd_class;	/* device classification */
 	size_t	cd_devsize;		/* size of dev data (for malloc) */
 	void	*cd_aux;		/* additional driver, if any */
@@ -118,7 +118,7 @@ struct cfdriver {
  * of the parent device.  The return value is ignored if the device was
  * configured, so most functions can return UNCONF unconditionally.
  */
-typedef int (*cfprint_t) __P((void *, char *));
+typedef int (*cfprint_t) (void *, char *);
 #define	QUIET	0		/* print nothing */
 #define	UNCONF	1		/* print " not configured\n" */
 #define	UNSUPP	2		/* print " not supported\n" */
@@ -127,17 +127,17 @@ typedef int (*cfprint_t) __P((void *, char *));
  * Pseudo-device attach information (function + number of pseudo-devs).
  */
 struct pdevinit {
-	void	(*pdev_attach) __P((int));
+	void	(*pdev_attach) (int);
 	int	pdev_count;
 };
 
 struct	device *alldevs;	/* head of list of all devices */
 struct	evcnt *allevents;	/* head of list of all events */
 
-struct cfdata *config_search __P((cfmatch_t, struct device *, void *));
-struct cfdata *config_rootsearch __P((cfmatch_t, char *, void *));
-int config_found __P((struct device *, void *, cfprint_t));
-int config_rootfound __P((char *, void *));
-void config_attach __P((struct device *, struct cfdata *, void *, cfprint_t));
-void evcnt_attach __P((struct device *, const char *, struct evcnt *));
+struct cfdata *config_search (cfmatch_t, struct device *, void *);
+struct cfdata *config_rootsearch (cfmatch_t, char *, void *);
+int config_found (struct device *, void *, cfprint_t);
+int config_rootfound (char *, void *);
+void config_attach (struct device *, struct cfdata *, void *, cfprint_t);
+void evcnt_attach (struct device *, const char *, struct evcnt *);
 #endif /* !_SYS_DEVICE_H_ */

--- a/lites-1.1.1/include/sys/ioctl.h
+++ b/lites-1.1.1/include/sys/ioctl.h
@@ -68,7 +68,7 @@ struct ttysize {
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS
-int	ioctl __P((int, unsigned int, ...));
+int	ioctl (int, unsigned int, ...);
 __END_DECLS
 #endif /* KERNEL */
 #endif /* !_SYS_IOCTL_H_ */

--- a/lites-1.1.1/include/sys/ktrace.h
+++ b/lites-1.1.1/include/sys/ktrace.h
@@ -150,7 +150,7 @@ struct ktr_csw {
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS
-int	ktrace __P((const char *, int, int, pid_t));
+int	ktrace (const char *, int, int, pid_t);
 __END_DECLS
 
 #endif	/* !KERNEL */

--- a/lites-1.1.1/include/sys/map.h
+++ b/lites-1.1.1/include/sys/map.h
@@ -76,7 +76,7 @@ struct mapent {
 struct	map *kmemmap, *mbmap, *swapmap;
 int	nswapmap;
 
-long	rmalloc __P((struct map *, long));
-void	rmfree __P((struct map *, long, long));
-void	rminit __P((struct map *, long, long, char *, int));
+long	rmalloc (struct map *, long);
+void	rmfree (struct map *, long, long);
+void	rminit (struct map *, long, long, char *, int);
 #endif

--- a/lites-1.1.1/include/sys/namei.h
+++ b/lites-1.1.1/include/sys/namei.h
@@ -168,8 +168,8 @@ struct	namecache {
 
 #ifdef KERNEL
 u_long	nextvnodeid;
-int	namei __P((struct nameidata *ndp));
-int	lookup __P((struct nameidata *ndp));
+int	namei (struct nameidata *ndp);
+int	lookup (struct nameidata *ndp);
 #endif
 
 /*

--- a/lites-1.1.1/include/sys/proc.h
+++ b/lites-1.1.1/include/sys/proc.h
@@ -353,16 +353,16 @@ typedef struct proc_invocation {
 
 void    proc_exit(struct proc *p, int);
 
-struct proc *pfind __P((pid_t));	/* Find process by id. */
-struct pgrp *pgfind __P((pid_t));	/* Find process group by id. */
+struct proc *pfind (pid_t);	/* Find process by id. */
+struct pgrp *pgfind (pid_t);	/* Find process group by id. */
 
-void	mi_switch __P((void));
-void	resetpriority __P((struct proc *));
-void	setrunnable __P((struct proc *));
-void	setrunqueue __P((struct proc *));
-void	sleep __P((void *chan, int pri));
-int	tsleep __P((void *chan, int pri, char *wmesg, int timo));
-void	unsleep __P((struct proc *));
-void	wakeup __P((void *chan));
+void	mi_switch (void);
+void	resetpriority (struct proc *);
+void	setrunnable (struct proc *);
+void	setrunqueue (struct proc *);
+void	sleep (void *chan, int pri);
+int	tsleep (void *chan, int pri, char *wmesg, int timo);
+void	unsleep (struct proc *);
+void	wakeup (void *chan);
 #endif	/* KERNEL */
 #endif	/* !_SYS_PROC_H_ */

--- a/lites-1.1.1/include/sys/resourcevar.h
+++ b/lites-1.1.1/include/sys/resourcevar.h
@@ -82,9 +82,9 @@ struct plimit {
 	    (p)->p_stats->p_prof.pr_addr, (p)->p_stats->p_prof.pr_ticks)
 
 #ifdef KERNEL
-void	 addupc_intr __P((struct proc *p, u_long pc, u_int ticks));
-void	 addupc_task __P((struct proc *p, u_long pc, u_int ticks));
+void	 addupc_intr (struct proc *p, u_long pc, u_int ticks);
+void	 addupc_task (struct proc *p, u_long pc, u_int ticks);
 struct plimit
-	*limcopy __P((struct plimit *lim));
+	*limcopy (struct plimit *lim);
 #endif
 #endif	/* !_SYS_RESOURCEVAR_H_ */

--- a/lites-1.1.1/include/sys/time.h
+++ b/lites-1.1.1/include/sys/time.h
@@ -121,12 +121,12 @@ typedef struct mapped_timezone {
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS
-int	adjtime __P((const struct timeval *, struct timeval *));
-int	getitimer __P((int, struct itimerval *));
-int	gettimeofday __P((struct timeval *, struct timezone *));
-int	setitimer __P((int, const struct itimerval *, struct itimerval *));
-int	settimeofday __P((const struct timeval *, const struct timezone *));
-int	utimes __P((const char *, const struct timeval *));
+int	adjtime (const struct timeval *, struct timeval *);
+int	getitimer (int, struct itimerval *);
+int	gettimeofday (struct timeval *, struct timezone *);
+int	setitimer (int, const struct itimerval *, struct itimerval *);
+int	settimeofday (const struct timeval *, const struct timezone *);
+int	utimes (const char *, const struct timeval *);
 __END_DECLS
 #endif /* !POSIX */
 

--- a/lites-1.1.1/include/sys/times.h
+++ b/lites-1.1.1/include/sys/times.h
@@ -59,7 +59,7 @@ struct tms {
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS
-clock_t	times __P((struct tms *));
+clock_t	times (struct tms *);
 __END_DECLS
 #endif
 #endif /* !_SYS_TIMES_H_ */

--- a/lites-1.1.1/include/sys/tty.h
+++ b/lites-1.1.1/include/sys/tty.h
@@ -84,11 +84,11 @@ struct tty {
 	struct	termios t_termios;	/* Termios state. */
 	struct	winsize t_winsize;	/* Window size. */
 					/* Start output. */
-	void	(*t_oproc) __P((struct tty *));
+	void	(*t_oproc) (struct tty *);
 					/* Stop output. */
-	void	(*t_stop) __P((struct tty *, int));
+	void	(*t_stop) (struct tty *, int);
 					/* Set hardware state. */
-	int	(*t_param) __P((struct tty *, struct termios *));
+	int	(*t_param) (struct tty *, struct termios *);
 	void	*t_sc;			/* XXX: net/if_sl.c:sl_softc. */
 	short	t_column;		/* Tty output column. */
 	short	t_rocount, t_rocol;	/* Tty. */
@@ -191,45 +191,45 @@ extern	struct ttychars ttydefaults;
 /* Symbolic sleep message strings. */
 extern	 char ttyin[], ttyout[], ttopen[], ttclos[], ttybg[], ttybuf[];
 
-int	 b_to_q __P((char *cp, int cc, struct clist *q));
-void	 catq __P((struct clist *from, struct clist *to));
-void	 clist_init __P((void));
-int	 getc __P((struct clist *q));
-void	 ndflush __P((struct clist *q, int cc));
-int	 ndqb __P((struct clist *q, int flag));
-char	*nextc __P((struct clist *q, char *cp, int *c));
-int	 putc __P((int c, struct clist *q));
-int	 q_to_b __P((struct clist *q, char *cp, int cc));
-int	 unputc __P((struct clist *q));
+int	 b_to_q (char *cp, int cc, struct clist *q);
+void	 catq (struct clist *from, struct clist *to);
+void	 clist_init (void);
+int	 getc (struct clist *q);
+void	 ndflush (struct clist *q, int cc);
+int	 ndqb (struct clist *q, int flag);
+char	*nextc (struct clist *q, char *cp, int *c);
+int	 putc (int c, struct clist *q);
+int	 q_to_b (struct clist *q, char *cp, int cc);
+int	 unputc (struct clist *q);
 
-int	 nullmodem __P((struct tty *tp, int flag));
-int	 tputchar __P((int c, struct tty *tp));
-int	 ttioctl __P((struct tty *tp, ioctl_cmd_t com, void *data, int flag));
-int	 ttread __P((struct tty *tp, struct uio *uio, int flag));
-void	 ttrstrt __P((void *tp));
-int	 ttselect __P((dev_t device, int rw, struct proc *p));
-void	 ttsetwater __P((struct tty *tp));
-int	 ttspeedtab __P((int speed, struct speedtab *table));
-int	 ttstart __P((struct tty *tp));
-void	 ttwakeup __P((struct tty *tp));
-int	 ttwrite __P((struct tty *tp, struct uio *uio, int flag));
-void	 ttychars __P((struct tty *tp));
-int	 ttycheckoutq __P((struct tty *tp, int wait));
-int	 ttyclose __P((struct tty *tp));
-void	 ttyflush __P((struct tty *tp, int rw));
-void	 ttyinfo __P((struct tty *tp));
-int	 ttyinput __P((int c, struct tty *tp));
-int	 ttylclose __P((struct tty *tp, int flag));
-int	 ttymodem __P((struct tty *tp, int flag));
-int	 ttyopen __P((dev_t device, struct tty *tp));
-int	 ttyoutput __P((int c, struct tty *tp));
-void	 ttypend __P((struct tty *tp));
-void	 ttyretype __P((struct tty *tp));
-void	 ttyrub __P((int c, struct tty *tp));
-int	 ttysleep __P((struct tty *tp,
-	    void *chan, int pri, char *wmesg, int timeout));
-int	 ttywait __P((struct tty *tp));
-int	 ttywflush __P((struct tty *tp));
+int	 nullmodem (struct tty *tp, int flag);
+int	 tputchar (int c, struct tty *tp);
+int	 ttioctl (struct tty *tp, ioctl_cmd_t com, void *data, int flag);
+int	 ttread (struct tty *tp, struct uio *uio, int flag);
+void	 ttrstrt (void *tp);
+int	 ttselect (dev_t device, int rw, struct proc *p);
+void	 ttsetwater (struct tty *tp);
+int	 ttspeedtab (int speed, struct speedtab *table);
+int	 ttstart (struct tty *tp);
+void	 ttwakeup (struct tty *tp);
+int	 ttwrite (struct tty *tp, struct uio *uio, int flag);
+void	 ttychars (struct tty *tp);
+int	 ttycheckoutq (struct tty *tp, int wait);
+int	 ttyclose (struct tty *tp);
+void	 ttyflush (struct tty *tp, int rw);
+void	 ttyinfo (struct tty *tp);
+int	 ttyinput (int c, struct tty *tp);
+int	 ttylclose (struct tty *tp, int flag);
+int	 ttymodem (struct tty *tp, int flag);
+int	 ttyopen (dev_t device, struct tty *tp);
+int	 ttyoutput (int c, struct tty *tp);
+void	 ttypend (struct tty *tp);
+void	 ttyretype (struct tty *tp);
+void	 ttyrub (int c, struct tty *tp);
+int	 ttysleep (struct tty *tp,
+	    void *chan, int pri, char *wmesg, int timeout);
+int	 ttywait (struct tty *tp);
+int	 ttywflush (struct tty *tp);
 #endif
 
 #endif /* !_SYS_TTY_H_ */

--- a/lites-1.1.1/include/sys/types.h
+++ b/lites-1.1.1/include/sys/types.h
@@ -85,7 +85,7 @@ typedef	u_int32_t	uid_t;		/* user id */
 #ifndef KERNEL
 #include <sys/cdefs.h>
 __BEGIN_DECLS
-off_t	 lseek __P((int, off_t, int));
+off_t	 lseek (int, off_t, int);
 __END_DECLS
 #endif
 

--- a/lites-1.1.1/include/sys/uio.h
+++ b/lites-1.1.1/include/sys/uio.h
@@ -76,8 +76,8 @@ struct uio {
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS
-ssize_t	readv __P((int, const struct iovec *, int));
-ssize_t	writev __P((int, const struct iovec *, int));
+ssize_t	readv (int, const struct iovec *, int);
+ssize_t	writev (int, const struct iovec *, int);
 __END_DECLS
 #endif /* !KERNEL */
 #endif /* !_SYS_UIO_H_ */

--- a/lites-1.1.1/include/sys/vnode.h
+++ b/lites-1.1.1/include/sys/vnode.h
@@ -247,10 +247,10 @@ extern int		vttoif_tab[];
 #define	VHOLD(vp)	vhold(vp)
 #define	VREF(vp)	vref(vp)
 
-void	holdrele __P((struct vnode *));
-void	vattr_null __P((struct vattr *));
-void	vhold __P((struct vnode *));
-void	vref __P((struct vnode *));
+void	holdrele (struct vnode *);
+void	vattr_null (struct vattr *);
+void	vhold (struct vnode *);
+void	vref (struct vnode *);
 #else
 #define	HOLDRELE(vp)	(vp)->v_holdcnt--	/* decrease buf or page ref */
 #define	VATTR_NULL(vap)	(*(vap) = va_null)	/* initialize a vattr */
@@ -275,9 +275,9 @@ extern	struct vattr va_null;		/* predefined null vattr structure */
 
 #ifdef NFS
 #if NFS
-void	lease_check __P((struct vnode *vp, struct proc *p,
-	    struct ucred *ucred, int flag));
-void	lease_updatetime __P((int deltat));
+void	lease_check (struct vnode *vp, struct proc *p,
+	    struct ucred *ucred, int flag);
+void	lease_updatetime (int deltat);
 #define	LEASE_CHECK(vp, p, cred, flag)	lease_check((vp), (p), (cred), (flag))
 #define	LEASE_UPDATETIME(dt)		lease_updatetime(dt)
 #else
@@ -375,7 +375,7 @@ struct vnodeopv_desc {
 /*
  * A default routine which just returns an error.
  */
-int vn_default_error __P((void));
+int vn_default_error (void);
 
 /*
  * A generic structure.
@@ -419,35 +419,35 @@ struct vattr;
 struct vnode;
 struct vop_bwrite_args;
 
-int 	bdevvp __P((dev_t dev, struct vnode **vpp));
-int 	getnewvnode __P((enum vtagtype tag,
-	    struct mount *mp, int (**vops)(), struct vnode **vpp));
-int	vinvalbuf __P((struct vnode *vp, int save, struct ucred *cred,
-	    struct proc *p, int slpflag, int slptimeo));
-void 	vattr_null __P((struct vattr *vap));
-int 	vcount __P((struct vnode *vp));
-int 	vget __P((struct vnode *vp, int lockflag));
-void 	vgone __P((struct vnode *vp));
-void 	vgoneall __P((struct vnode *vp));
-int	vn_bwrite __P((struct vop_bwrite_args *ap));
-int 	vn_close __P((struct vnode *vp,
-	    int flags, struct ucred *cred, struct proc *p));
-int 	vn_closefile __P((struct file *fp, struct proc *p));
-int	vn_ioctl __P((struct file *fp, ioctl_cmd_t com, caddr_t data,
-		      struct proc *p));
-int 	vn_open __P((struct nameidata *ndp, int fmode, int cmode));
-int 	vn_rdwr __P((enum uio_rw rw, struct vnode *vp, caddr_t base,
+int 	bdevvp (dev_t dev, struct vnode **vpp);
+int 	getnewvnode (enum vtagtype tag,
+	    struct mount *mp, int (**vops)(), struct vnode **vpp);
+int	vinvalbuf (struct vnode *vp, int save, struct ucred *cred,
+	    struct proc *p, int slpflag, int slptimeo);
+void 	vattr_null (struct vattr *vap);
+int 	vcount (struct vnode *vp);
+int 	vget (struct vnode *vp, int lockflag);
+void 	vgone (struct vnode *vp);
+void 	vgoneall (struct vnode *vp);
+int	vn_bwrite (struct vop_bwrite_args *ap);
+int 	vn_close (struct vnode *vp,
+	    int flags, struct ucred *cred, struct proc *p);
+int 	vn_closefile (struct file *fp, struct proc *p);
+int	vn_ioctl (struct file *fp, ioctl_cmd_t com, caddr_t data,
+		      struct proc *p);
+int 	vn_open (struct nameidata *ndp, int fmode, int cmode);
+int 	vn_rdwr (enum uio_rw rw, struct vnode *vp, caddr_t base,
 	    int len, off_t offset, enum uio_seg segflg, int ioflg,
-	    struct ucred *cred, int *aresid, struct proc *p));
-int	vn_read __P((struct file *fp, struct uio *uio, struct ucred *cred));
-int	vn_select __P((struct file *fp, int which, struct proc *p));
-int	vn_stat __P((struct vnode *vp, struct stat *sb, struct proc *p));
-int	vn_write __P((struct file *fp, struct uio *uio, struct ucred *cred));
+	    struct ucred *cred, int *aresid, struct proc *p);
+int	vn_read (struct file *fp, struct uio *uio, struct ucred *cred);
+int	vn_select (struct file *fp, int which, struct proc *p);
+int	vn_stat (struct vnode *vp, struct stat *sb, struct proc *p);
+int	vn_write (struct file *fp, struct uio *uio, struct ucred *cred);
 struct vnode *
-	checkalias __P((struct vnode *vp, dev_t nvp_rdev, struct mount *mp));
-void 	vput __P((struct vnode *vp));
-void 	vref __P((struct vnode *vp));
-void 	vrele __P((struct vnode *vp));
+	checkalias (struct vnode *vp, dev_t nvp_rdev, struct mount *mp);
+void 	vput (struct vnode *vp);
+void 	vref (struct vnode *vp);
+void 	vrele (struct vnode *vp);
 #endif /* KERNEL */
 
 #endif /* !_SYS_VNODE_H_ */

--- a/lites-1.1.1/include/time.h
+++ b/lites-1.1.1/include/time.h
@@ -81,23 +81,23 @@ struct tm {
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS
-char *asctime __P((const struct tm *));
-clock_t clock __P((void));
-char *ctime __P((const time_t *));
-double difftime __P((time_t, time_t));
-struct tm *gmtime __P((const time_t *));
-struct tm *localtime __P((const time_t *));
-time_t mktime __P((struct tm *));
-size_t strftime __P((char *, size_t, const char *, const struct tm *));
-time_t time __P((time_t *));
+char *asctime (const struct tm *);
+clock_t clock (void);
+char *ctime (const time_t *);
+double difftime (time_t, time_t);
+struct tm *gmtime (const time_t *);
+struct tm *localtime (const time_t *);
+time_t mktime (struct tm *);
+size_t strftime (char *, size_t, const char *, const struct tm *);
+time_t time (time_t *);
 
 #ifndef _ANSI_SOURCE
-void tzset __P((void));
+void tzset (void);
 #endif /* not ANSI */
 
 #if !defined(_ANSI_SOURCE) && !defined(_POSIX_SOURCE)
-char *timezone __P((int, int));
-void tzsetwall __P((void));
+char *timezone (int, int);
+void tzsetwall (void);
 #endif /* neither ANSI nor POSIX */
 __END_DECLS
 

--- a/lites-1.1.1/server/netiso/iso.h
+++ b/lites-1.1.1/server/netiso/iso.h
@@ -182,8 +182,8 @@ extern	struct protosw isosw[];
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS
-struct iso_addr *iso_addr __P((const char *));
-char *iso_ntoa __P((const struct iso_addr *));
+struct iso_addr *iso_addr (const char *);
+char *iso_ntoa (const struct iso_addr *);
 
 /* THESE DON'T EXIST YET */
 struct hostent *iso_gethostbyname(), *iso_gethostbyaddr();


### PR DESCRIPTION
## Summary
- modernize prototypes in `lites-1.1.1` by removing the obsolete `__P` macro
- keep `<sys/cdefs.h>` where still required for `__BEGIN_DECLS`

## Testing
- `make -C lites-1.1.1/include` *(fails: missing separator)*