### PR TITLE
Add simple CMake build files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.5)
+project(lites LANGUAGES C)
+
+# Optionally allow building out-of-tree archives.
+set(LITES_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build/lites-1.1.u3" CACHE PATH "Extracted lites source")
+
+# Collect sources for server and emulator if the directory exists
+if(EXISTS "${LITES_SRC_DIR}")
+    file(GLOB_RECURSE SERVER_SRC
+        "${LITES_SRC_DIR}/server/*.c")
+    file(GLOB_RECURSE EMULATOR_SRC
+        "${LITES_SRC_DIR}/emulator/*.c")
+
+    add_executable(lites_server ${SERVER_SRC})
+    target_include_directories(lites_server PRIVATE
+        "${LITES_SRC_DIR}/include"
+        "${LITES_SRC_DIR}/server")
+    target_compile_options(lites_server PRIVATE ${CFLAGS})
+    target_link_options(lites_server PRIVATE ${LDFLAGS})
+
+    add_executable(lites_emulator ${EMULATOR_SRC})
+    target_include_directories(lites_emulator PRIVATE
+        "${LITES_SRC_DIR}/include"
+        "${LITES_SRC_DIR}/emulator")
+    target_compile_options(lites_emulator PRIVATE ${CFLAGS})
+    target_link_options(lites_emulator PRIVATE ${LDFLAGS})
+endif()
+

--- a/Makefile.new
+++ b/Makefile.new
@@ -1,0 +1,19 @@
+SRCDIR := build/lites-1.1.u3
+CC ?= gcc
+CFLAGS ?= -O2
+LDFLAGS ?=
+
+SERVER_SRC := $(shell find $(SRCDIR)/server -name '*.c')
+EMULATOR_SRC := $(shell find $(SRCDIR)/emulator -name '*.c')
+
+all: lites_server lites_emulator
+
+lites_server: $(SERVER_SRC)
+$(CC) $(CFLAGS) -I$(SRCDIR)/include -I$(SRCDIR)/server $^ $(LDFLAGS) -o $@
+
+lites_emulator: $(EMULATOR_SRC)
+$(CC) $(CFLAGS) -I$(SRCDIR)/include -I$(SRCDIR)/emulator $^ $(LDFLAGS) -o $@
+
+clean:
+rm -f lites_server lites_emulator
+


### PR DESCRIPTION
## Summary
- add a top-level `CMakeLists.txt` that collects server and emulator sources
- add a conventional `Makefile.new` with CC/CFLAGS/LDFLAGS

## Testing
- `cmake -S . -B build_dir`
- `cmake --build build_dir` *(fails: mach/boolean.h missing)*