### PR TITLE
Add C23 standard flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(lites LANGUAGES C)
+set(CMAKE_C_STANDARD 23)
 
 # Optionally allow building out-of-tree archives.
 set(LITES_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build/lites-1.1.u3" CACHE PATH "Extracted lites source")

--- a/Makefile.new
+++ b/Makefile.new
@@ -1,6 +1,6 @@
 SRCDIR := build/lites-1.1.u3
 CC ?= gcc
-CFLAGS ?= -O2
+CFLAGS ?= -O2 -std=c23
 LDFLAGS ?=
 
 SERVER_SRC := $(shell find $(SRCDIR)/server -name '*.c')

--- a/src-lites-1.1-2025/liblites/Makefile
+++ b/src-lites-1.1-2025/liblites/Makefile
@@ -51,7 +51,7 @@ INCDIRS		:= -I${EXPORTBASE} ${INCDIRS}
 .endif
 
 DEFINES		= -DTypeCheck=0 -DMACH_IPC_COMPAT=0 -DLITES
-CFLAGS		= ${DEFINES} -g -nostdinc -I-
+CFLAGS		= ${DEFINES} -std=c23 -g -nostdinc -I-
 PC532_CFLAGS	= -mhimem -DGNU_LD2 -Dns532
 
 MIGFLAGS 	= ${DEFINES}


### PR DESCRIPTION
## Summary
- default to C23 in Makefile.new
- build liblites with C23 standard
- require C23 in CMake

## Testing
- `./setup.sh` *(fails: Could not connect to proxy)*
- `make -f Makefile.new` *(fails: missing separator)*