### PR TITLE
Add 64-bit bitops support

### DIFF
--- a/src-lites-1.1-2025/server/ufs/ext2fs/ext2_fs.h
+++ b/src-lites-1.1-2025/server/ufs/ext2fs/ext2_fs.h
@@ -23,8 +23,10 @@
 
 #include <sys/types.h>
 
-#ifdef i386
+#if defined(i386) || defined(__i386__)
 #include <i386/types.h>
+#elif defined(__x86_64__)
+#include <i386/types.h> /* TODO: add x86_64 types header */
 #else
 #error need processor specific types
 #endif

--- a/src-lites-1.1-2025/server/ufs/ext2fs/ext2_linux_balloc.c
+++ b/src-lites-1.1-2025/server/ufs/ext2fs/ext2_linux_balloc.c
@@ -41,8 +41,10 @@
 #include <ufs/ext2fs/fs.h>
 #include <sys/stat.h>
 
-#ifdef i386
+#if defined(i386) || defined(__i386__)
 #include <ufs/ext2fs/i386-bitops.h>
+#elif defined(__x86_64__)
+#include <ufs/ext2fs/x86_64-bitops.h>
 #else
 #error Provide an bitops.h file, please !
 #endif

--- a/src-lites-1.1-2025/server/ufs/ext2fs/ext2_linux_ialloc.c
+++ b/src-lites-1.1-2025/server/ufs/ext2fs/ext2_linux_ialloc.c
@@ -42,8 +42,10 @@
 #include <ufs/ext2fs/fs.h>
 #include <sys/stat.h>
 
-#if (i386)
+#if defined(i386) || defined(__i386__)
 #include <ufs/ext2fs/i386-bitops.h>
+#elif defined(__x86_64__)
+#include <ufs/ext2fs/x86_64-bitops.h>
 #else
 #error please provide bit operation functions
 #endif

--- a/src-lites-1.1-2025/server/ufs/ext2fs/x86_64-bitops.h
+++ b/src-lites-1.1-2025/server/ufs/ext2fs/x86_64-bitops.h
@@ -1,0 +1,92 @@
+#ifndef _X86_64_BITOPS_H
+#define _X86_64_BITOPS_H
+
+/* 64-bit bit operations implemented using GCC built-ins. */
+
+static inline int set_bit(int nr, void *addr)
+{
+    unsigned long *p = (unsigned long *)addr + (nr >> 6);
+    unsigned long mask = 1UL << (nr & 63);
+    unsigned long old = __atomic_fetch_or(p, mask, __ATOMIC_SEQ_CST);
+    return (old & mask) != 0;
+}
+
+static inline int clear_bit(int nr, void *addr)
+{
+    unsigned long *p = (unsigned long *)addr + (nr >> 6);
+    unsigned long mask = 1UL << (nr & 63);
+    unsigned long old = __atomic_fetch_and(p, ~mask, __ATOMIC_SEQ_CST);
+    return (old & mask) != 0;
+}
+
+static inline int change_bit(int nr, void *addr)
+{
+    unsigned long *p = (unsigned long *)addr + (nr >> 6);
+    unsigned long mask = 1UL << (nr & 63);
+    unsigned long old, new;
+    do {
+        old = __atomic_load_n(p, __ATOMIC_SEQ_CST);
+        new = old ^ mask;
+    } while (!__atomic_compare_exchange_n(p, &old, new, 0,
+                                          __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST));
+    return (old & mask) != 0;
+}
+
+static inline int test_bit(int nr, void *addr)
+{
+    unsigned long *p = (unsigned long *)addr + (nr >> 6);
+    unsigned long mask = 1UL << (nr & 63);
+    return (__atomic_load_n(p, __ATOMIC_SEQ_CST) & mask) != 0;
+}
+
+static inline unsigned long ffz(unsigned long word)
+{
+    return __builtin_ffsl(~word) - 1;
+}
+
+static inline int find_first_zero_bit(void *addr, unsigned size)
+{
+    unsigned long *p = addr;
+    unsigned long idx = 0;
+
+    while (size >= 64) {
+        if (*p != ~0UL)
+            return idx + ffz(*p);
+        p++;
+        idx += 64;
+        size -= 64;
+    }
+
+    if (size) {
+        unsigned long last = *p | (~0UL << size);
+        if (last != ~0UL)
+            return idx + ffz(last);
+        idx += size;
+    }
+
+    return idx;
+}
+
+static inline int find_next_zero_bit(void *addr, int size, int offset)
+{
+    int bit = offset;
+    while (bit < size) {
+        if (!test_bit(bit, addr))
+            return bit;
+        bit++;
+    }
+    return size;
+}
+
+static inline char *memscan(void *addr, unsigned char c, int size)
+{
+    unsigned char *p = addr;
+    while (size--) {
+        if (*p == c)
+            return (char *)p;
+        p++;
+    }
+    return (char *)p;
+}
+
+#endif /* _X86_64_BITOPS_H */


### PR DESCRIPTION
## Summary
- add `x86_64-bitops.h` providing 64-bit bit operations
- choose bitops header based on target architecture
- allow ext2fs headers to build on x86_64

## Testing
- `CC=i686-linux-gnu-gcc make -C src-lites-1.1-2025` *(fails: `/usr/src/lites/conf/configure: not found`)*
- `CC=x86_64-linux-gnu-gcc make -C src-lites-1.1-2025` *(fails: `/usr/src/lites/conf/configure: not found`)*