### PR TITLE
Add architecture flag support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,22 @@
 cmake_minimum_required(VERSION 3.5)
 project(lites LANGUAGES C)
 
+# Allow selecting the build architecture with -DARCH=i686 or ARCH
+set(ARCH "$ENV{ARCH}" CACHE STRING "Target architecture (x86_64 or i686)")
+set(CFLAGS "$ENV{CFLAGS}" CACHE STRING "Additional compiler flags")
+set(LDFLAGS "$ENV{LDFLAGS}" CACHE STRING "Additional linker flags")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CFLAGS}")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LDFLAGS}")
+
+if(ARCH STREQUAL "i686")
+    add_compile_options(-m32)
+    add_link_options(-m32)
+elseif(ARCH STREQUAL "x86_64")
+    add_compile_options(-m64)
+    add_link_options(-m64)
+endif()
+
 # Optionally allow building out-of-tree archives.
 set(LITES_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build/lites-1.1.u3" CACHE PATH "Extracted lites source")
 

--- a/Makefile.new
+++ b/Makefile.new
@@ -1,7 +1,21 @@
 SRCDIR := build/lites-1.1.u3
 CC ?= gcc
+
+# Target architecture (x86_64 or i686).  Determines -m32/-m64 flags.
+ARCH ?= x86_64
+
+# Base optimisation flags
 CFLAGS ?= -O2
 LDFLAGS ?=
+
+# Translate ARCH into compiler options
+ifeq ($(ARCH),i686)
+CFLAGS += -m32
+LDFLAGS += -m32
+else ifeq ($(ARCH),x86_64)
+CFLAGS += -m64
+LDFLAGS += -m64
+endif
 
 SERVER_SRC := $(shell find $(SRCDIR)/server -name '*.c')
 EMULATOR_SRC := $(shell find $(SRCDIR)/emulator -name '*.c')

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ cd lites-1.1.u3
 make
 ```
 
+For the modernized build system in this repository you can also use
+`Makefile.new` or the provided CMake files.  Both recognise an optional
+`ARCH` variable, selecting between 64‑bit (`ARCH=x86_64`, default) and
+32‑bit (`ARCH=i686`) builds.  Examples:
+
+```sh
+# Using the makefile
+make -f Makefile.new ARCH=i686
+
+# Using CMake
+cmake -B build -DARCH=i686
+cmake --build build
+```
+
 The optional `setup.sh` script installs a wide range of cross-compilers
 and emulators.  It can be used to reproduce historical build setups, but
 it requires root privileges and network access.


### PR DESCRIPTION
## Summary
- make ARCH selectable for 32- vs 64-bit builds
- apply ARCH logic in CMake
- document ARCH usage

## Testing
- `make -f Makefile.new ARCH=i686` *(fails: missing source tree)*
- `cmake -B build -DARCH=i686`