### PR TITLE
Add x86_64 architecture framework

### DIFF
--- a/src-lites-1.1-2025/include/x86_64/Makefile
+++ b/src-lites-1.1-2025/include/x86_64/Makefile
@@ -1,0 +1,42 @@
+# 
+# Mach Operating System
+# Copyright (c) 1992 Carnegie Mellon University
+# Copyright (c) 1994 Johannes Helander
+# All Rights Reserved.
+# 
+# Permission to use, copy, modify and distribute this software and its
+# documentation is hereby granted, provided that both the copyright
+# notice and this permission notice appear in all copies of the
+# software, derivative works or modified versions, and any portions
+# thereof, and that both notices appear in supporting documentation.
+# 
+# CARNEGIE MELLON AND JOHANNES HELANDER ALLOW FREE USE OF THIS
+# SOFTWARE IN ITS "AS IS" CONDITION.  CARNEGIE MELLON AND JOHANNES
+# HELANDER DISCLAIM ANY LIABILITY OF ANY KIND FOR ANY DAMAGES
+# WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+#
+# HISTORY
+# $Log: Makefile,v $
+# Revision 1.1.1.1  1995/03/02  21:49:33  mike
+# Initial Lites release from hut.fi
+#
+# $EndLog$
+#
+#	File:	 include/x86_64/Makefile
+#	Authors: Mary Thompson, Johannes Helander
+#	Date:	 1992, 1994
+#
+# This Makefile copies the header files from the bsdss source
+# i386 directory to the export directory where they can be found
+# in the directory "machine". This eliminates the need for 
+# machine links in the sources.
+
+DATAFILES		= endian.h limits.h signal.h param.h stdarg.h \
+			  ansi.h types.h cpu.h ptrace.h vmparam.h exec.h \
+			  trap.h varargs.h
+
+INCLUDES		= ${DATAFILES}
+
+EXPDIR			= /include/x86_64/
+
+.include <${RULES_MK}>

--- a/src-lites-1.1-2025/include/x86_64/ansi.h
+++ b/src-lites-1.1-2025/include/x86_64/ansi.h
@@ -1,0 +1,72 @@
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)ansi.h	8.2 (Berkeley) 1/4/94
+ */
+
+#ifndef	_ANSI_H_
+#define	_ANSI_H_
+
+/*
+ * Types which are fundamental to the implementation and may appear in
+ * more than one standard header are defined here.  Standard headers
+ * then use:
+ *	#ifdef	_BSD_SIZE_T_
+ *	typedef	_BSD_SIZE_T_ size_t;
+ *	#undef	_BSD_SIZE_T_
+ *	#endif
+ */
+#define	_BSD_CLOCK_T_	unsigned long		/* clock() */
+#define	_BSD_PTRDIFF_T_	int			/* ptr1 - ptr2 */
+#define	_BSD_SIZE_T_	unsigned long		/* sizeof() */
+#define	_BSD_SSIZE_T_	int			/* byte count or error */
+#define	_BSD_TIME_T_	long			/* time() */
+#define	_BSD_VA_LIST_	char *			/* va_list */
+
+/*
+ * Runes (wchar_t) is declared to be an ``int'' instead of the more natural
+ * ``unsigned long'' or ``long''.  Two things are happening here.  It is not
+ * unsigned so that EOF (-1) can be naturally assigned to it and used.  Also,
+ * it looks like 10646 will be a 31 bit standard.  This means that if your
+ * ints cannot hold 32 bits, you will be in trouble.  The reason an int was
+ * chosen over a long is that the is*() and to*() routines take ints (says
+ * ANSI C), but they use _RUNE_T_ instead of int.  By changing it here, you
+ * lose a bit of ANSI conformance, but your programs will still work.
+ *    
+ * Note that _WCHAR_T_ and _RUNE_T_ must be of the same type.  When wchar_t
+ * and rune_t are typedef'd, _WCHAR_T_ will be undef'd, but _RUNE_T remains
+ * defined for ctype.h.
+ */
+#define	_BSD_WCHAR_T_	int			/* wchar_t */
+#define	_BSD_RUNE_T_	int			/* rune_t */
+
+#endif	/* _ANSI_H_ */

--- a/src-lites-1.1-2025/include/x86_64/cpu.h
+++ b/src-lites-1.1-2025/include/x86_64/cpu.h
@@ -1,0 +1,70 @@
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * William Jolitz.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)cpu.h	8.4 (Berkeley) 1/5/94
+ */
+
+/* Cleaned up for Lites -- jvh 5/94 */
+
+/*
+ * Definitions unique to i386 cpu support.
+ */
+/*
+ * definitions of cpu-dependent requirements
+ * referenced in generic code
+ */
+
+#undef	COPY_SIGCODE	/* don't copy sigcode above user stack in exec */
+
+/*
+ * Kinds of processor
+ */
+
+#define	CPU_386SX	0
+#define	CPU_386		1
+#define	CPU_486SX	2
+#define	CPU_486		3
+#define	CPU_586		4
+
+/*
+ * CTL_MACHDEP definitions.
+ */
+#define	CPU_CONSDEV		1	/* dev_t: console terminal device */
+#define	CPU_MAXID		2	/* number of valid machdep ids */
+
+#define CTL_MACHDEP_NAMES { \
+	{ 0, 0 }, \
+	{ "console_device", CTLTYPE_STRUCT }, \
+}

--- a/src-lites-1.1-2025/include/x86_64/endian.h
+++ b/src-lites-1.1-2025/include/x86_64/endian.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 1987, 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)endian.h	8.1 (Berkeley) 6/11/93
+ */
+
+#ifndef _ENDIAN_H_
+#define	_ENDIAN_H_
+
+/*
+ * Define _NOQUAD if the compiler does NOT support 64-bit integers.
+ */
+/* #define _NOQUAD */
+
+/*
+ * Define the order of 32-bit words in 64-bit words.
+ */
+#define _QUAD_HIGHWORD 1
+#define _QUAD_LOWWORD 0
+
+#ifndef _POSIX_SOURCE
+/*
+ * Definitions for byte order, according to byte significance from low
+ * address to high.
+ */
+#define	LITTLE_ENDIAN	1234	/* LSB first: i386, vax */
+#define	BIG_ENDIAN	4321	/* MSB first: 68000, ibm, net */
+#define	PDP_ENDIAN	3412	/* LSB first in word, MSW first in long */
+
+#define	BYTE_ORDER	LITTLE_ENDIAN
+
+#include <sys/cdefs.h>
+
+__BEGIN_DECLS
+unsigned long	htonl __P((unsigned long));
+unsigned short	htons __P((unsigned short));
+unsigned long	ntohl __P((unsigned long));
+unsigned short	ntohs __P((unsigned short));
+__END_DECLS
+
+/*
+ * Macros for network/external number representation conversion.
+ */
+#if BYTE_ORDER == BIG_ENDIAN && !defined(lint)
+#define	ntohl(x)	(x)
+#define	ntohs(x)	(x)
+#define	htonl(x)	(x)
+#define	htons(x)	(x)
+
+#define	NTOHL(x)	(x)
+#define	NTOHS(x)	(x)
+#define	HTONL(x)	(x)
+#define	HTONS(x)	(x)
+
+#else
+
+#define	NTOHL(x)	(x) = ntohl((u_long)x)
+#define	NTOHS(x)	(x) = ntohs((u_short)x)
+#define	HTONL(x)	(x) = htonl((u_long)x)
+#define	HTONS(x)	(x) = htons((u_short)x)
+#endif
+#endif /* ! _POSIX_SOURCE */
+#endif /* !_ENDIAN_H_ */

--- a/src-lites-1.1-2025/include/x86_64/exec.h
+++ b/src-lites-1.1-2025/include/x86_64/exec.h
@@ -1,0 +1,84 @@
+/*-
+ * Copyright (c) 1992, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)exec.h	8.1 (Berkeley) 6/11/93
+ */
+
+/* Size of a page in an object file. */
+#define	__LDPGSZ	4096
+
+/* Valid magic number check. */
+#define	N_BADMAG(ex) \
+	((ex).a_magic != NMAGIC && (ex).a_magic != OMAGIC && \
+	    (ex).a_magic != ZMAGIC)
+
+/* Address of the bottom of the text segment. */
+#define N_TXTADDR(X)	0
+
+/* Address of the bottom of the data segment. */
+#define N_DATADDR(ex) \
+	(N_TXTADDR(ex) + ((ex).a_magic == OMAGIC ? (ex).a_text \
+	: __LDPGSZ + ((ex).a_text - 1 & ~(__LDPGSZ - 1))))
+
+/* Text segment offset. */
+#define	N_TXTOFF(ex) \
+	((ex).a_magic == ZMAGIC ? __LDPGSZ : sizeof(struct exec))
+
+/* Data segment offset. */
+#define	N_DATOFF(ex) \
+	(N_TXTOFF(ex) + ((ex).a_magic != ZMAGIC ? (ex).a_text : \
+	__LDPGSZ + ((ex).a_text - 1 & ~(__LDPGSZ - 1))))
+
+/* Symbol table offset. */
+#define N_SYMOFF(ex) \
+	(N_TXTOFF(ex) + (ex).a_text + (ex).a_data + (ex).a_trsize + \
+	    (ex).a_drsize)
+
+/* String table offset. */
+#define	N_STROFF(ex) 	(N_SYMOFF(ex) + (ex).a_syms)
+
+/* Description of the object file header (a.out format). */
+struct exec {
+#define	OMAGIC	0407		/* old impure format */
+#define	NMAGIC	0410		/* read-only text */
+#define	ZMAGIC	0413		/* demand load format */
+#define QMAGIC	0314		/* demand load format. Header in text. */
+	unsigned int	a_magic;	/* magic number */
+
+	unsigned int	a_text;		/* text segment size */
+	unsigned int	a_data;		/* initialized data size */
+	unsigned int	a_bss;		/* uninitialized data size */
+	unsigned int	a_syms;		/* symbol table size */
+	unsigned int	a_entry;	/* entry point */
+	unsigned int	a_trsize;	/* text relocation size */
+	unsigned int	a_drsize;	/* data relocation size */
+};

--- a/src-lites-1.1-2025/include/x86_64/limits.h
+++ b/src-lites-1.1-2025/include/x86_64/limits.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 1988, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)limits.h	8.3 (Berkeley) 1/4/94
+ */
+
+#define	CHAR_BIT	8		/* number of bits in a char */
+#define	MB_LEN_MAX	6		/* Allow 31 bit UTF2 */
+
+
+#define	CLK_TCK		60		/* ticks per second */
+
+/*
+ * According to ANSI (section 2.2.4.2), the values below must be usable by
+ * #if preprocessing directives.  Additionally, the expression must have the
+ * same type as would an expression that is an object of the corresponding
+ * type converted according to the integral promotions.  The subtraction for
+ * INT_MIN and LONG_MIN is so the value is not unsigned; 2147483648 is an
+ * unsigned int for 32-bit two's complement ANSI compilers (section 3.1.3.2).
+ * These numbers work for pcc as well.  The UINT_MAX and ULONG_MAX values
+ * are written as hex so that GCC will be quiet about large integer constants.
+ */
+#define	SCHAR_MAX	127		/* min value for a signed char */
+#define	SCHAR_MIN	(-128)		/* max value for a signed char */
+
+#define	UCHAR_MAX	255		/* max value for an unsigned char */
+#define	CHAR_MAX	127		/* max value for a char */
+#define	CHAR_MIN	(-128)		/* min value for a char */
+
+#define	USHRT_MAX	65535		/* max value for an unsigned short */
+#define	SHRT_MAX	32767		/* max value for a short */
+#define	SHRT_MIN	(-32768)	/* min value for a short */
+
+#define	UINT_MAX	0xffffffff	/* max value for an unsigned int */
+#define	INT_MAX		2147483647	/* max value for an int */
+#define	INT_MIN		(-2147483647-1)	/* min value for an int */
+
+#define	ULONG_MAX	0xffffffff	/* max value for an unsigned long */
+#define	LONG_MAX	2147483647	/* max value for a long */
+#define	LONG_MIN	(-2147483647-1)	/* min value for a long */
+
+#if !defined(_ANSI_SOURCE)
+#define	SSIZE_MAX	INT_MAX		/* max value for a ssize_t */
+
+#if !defined(_POSIX_SOURCE)
+#define	SIZE_T_MAX	UINT_MAX	/* max value for a size_t */
+
+/* GCC requires that quad constants be written as expressions. */
+#define	UQUAD_MAX	((u_quad_t)0-1)	/* max value for a uquad_t */
+					/* max value for a quad_t */
+#define	QUAD_MAX	((quad_t)(UQUAD_MAX >> 1))
+#define	QUAD_MIN	(-QUAD_MAX-1)	/* min value for a quad_t */
+
+#endif /* !_POSIX_SOURCE */
+#endif /* !_ANSI_SOURCE */

--- a/src-lites-1.1-2025/include/x86_64/param.h
+++ b/src-lites-1.1-2025/include/x86_64/param.h
@@ -1,0 +1,180 @@
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * William Jolitz.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)param.h	8.1 (Berkeley) 6/11/93
+ */
+
+/*
+ * Machine dependent constants for Intel 386.
+ */
+
+#ifndef _X86_64_PARAM_H_
+#define _X86_64_PARAM_H_
+
+#define MACHINE "x86_64"
+
+/*
+ * Round p (pointer or byte index) up to a correctly-aligned value for all
+ * data types (int, long, ...).   The result is u_int and must be cast to
+ * any desired pointer type.
+ */
+#define	ALIGNBYTES	3
+#define	ALIGN(p)	(((u_int)(p) + ALIGNBYTES) &~ ALIGNBYTES)
+
+#define	NBPG		4096		/* bytes/page */
+#define	PGOFSET		(NBPG-1)	/* byte offset into page */
+#define	PGSHIFT		12		/* LOG2(NBPG) */
+#define	NPTEPG		(NBPG/(sizeof (struct pte)))
+
+#define NBPDR		(1024*NBPG)	/* bytes/page dir */
+#define	PDROFSET	(NBPDR-1)	/* byte offset into page dir */
+#define	PDRSHIFT	22		/* LOG2(NBPDR) */
+
+#define	KERNBASE	0xFE000000	/* start of kernel virtual */
+#define	BTOPKERNBASE	((u_long)KERNBASE >> PGSHIFT)
+
+#define	DEV_BSIZE	512
+#define	DEV_BSHIFT	9		/* log2(DEV_BSIZE) */
+#define BLKDEV_IOSIZE	2048
+#define	MAXPHYS		(64 * 1024)	/* max raw I/O transfer size */
+
+#define	STACK_GROWS_UP	0		/* stack grows to lower addresses */
+
+#define	CLSIZE		1
+#define	CLSIZELOG2	0
+
+/* NOTE: SSIZE, SINCR and UPAGES must be multiples of CLSIZE */
+#define	SSIZE	1		/* initial stack size/NBPG */
+#define	SINCR	1		/* increment of stack/NBPG */
+
+#define	UPAGES	2		/* pages of u-area */
+
+/*
+ * Constants related to network buffer management.
+ * MCLBYTES must be no larger than CLBYTES (the software page size), and,
+ * on machines that exchange pages of input or output buffers with mbuf
+ * clusters (MAPPED_MBUFS), MCLBYTES must also be an integral multiple
+ * of the hardware page size.
+ */
+#define	MSIZE		128		/* size of an mbuf */
+#define	MCLBYTES	1024
+#define	MCLSHIFT	10
+#define	MCLOFSET	(MCLBYTES - 1)
+#ifndef NMBCLUSTERS
+#ifdef GATEWAY
+#define	NMBCLUSTERS	512		/* map size, max cluster allocation */
+#else
+#define	NMBCLUSTERS	256		/* map size, max cluster allocation */
+#endif
+#endif
+
+/*
+ * Size of kernel malloc arena in CLBYTES-sized logical pages
+ */ 
+#ifndef NKMEMCLUSTERS
+#define	NKMEMCLUSTERS	(2048*1024/CLBYTES)
+#endif
+/*
+ * Some macros for units conversion
+ */
+/* Core clicks (4096 bytes) to segments and vice versa */
+#define	ctos(x)	(x)
+#define	stoc(x)	(x)
+
+/* Core clicks (4096 bytes) to disk blocks */
+#define	ctod(x)	((x)<<(PGSHIFT-DEV_BSHIFT))
+#define	dtoc(x)	((x)>>(PGSHIFT-DEV_BSHIFT))
+#define	dtob(x)	((x)<<DEV_BSHIFT)
+
+/* clicks to bytes */
+#define	ctob(x)	((x)<<PGSHIFT)
+
+/* bytes to clicks */
+#define	btoc(x)	(((unsigned)(x)+(NBPG-1))>>PGSHIFT)
+
+#define	btodb(bytes)	 		/* calculates (bytes / DEV_BSIZE) */ \
+	((unsigned)(bytes) >> DEV_BSHIFT)
+#define	dbtob(db)			/* calculates (db * DEV_BSIZE) */ \
+	((unsigned)(db) << DEV_BSHIFT)
+
+/*
+ * Map a ``block device block'' to a file system block.
+ * This should be device dependent, and will be if we
+ * add an entry to cdevsw/bdevsw for that purpose.
+ * For now though just use DEV_BSIZE.
+ */
+#define	bdbtofsb(bn)	((bn) / (BLKDEV_IOSIZE/DEV_BSIZE))
+
+/*
+ * Mach derived conversion macros
+ */
+#define x86_64_round_pdr(x)	((((unsigned)(x)) + NBPDR - 1) & ~(NBPDR-1))
+#define x86_64_trunc_pdr(x)	((unsigned)(x) & ~(NBPDR-1))
+#define x86_64_btod(x)		((unsigned)(x) >> PDRSHIFT)
+#define x86_64_dtob(x)		((unsigned)(x) << PDRSHIFT)
+
+#ifndef KERNEL
+/* DELAY is in locore.s for the kernel */
+#define	DELAY(n)	{ register int N = (n); while (--N > 0); }
+#endif
+
+/* LITES stuff */
+/*
+ * Base address for U*X system call emulator.
+ */
+#define	EMULATOR_BASE	0xa0000000
+#define	EMULATOR_END	0xa0040000
+				/* 256 Kbytes */
+
+/*
+ * Define base for user mapped files
+ */
+
+#define MAP_FILE_BASE	0x90000000
+
+/*
+ * i386 stack sits above emulator.
+ */
+#define	EMULATOR_ABOVE_STACK	0
+
+#define TRAMPOLINE_MAX_SIZE	0x100
+
+#ifdef I386_PGBYTES		/* osfmach3 compat */
+#define PAGE_SIZE I386_PGBYTES
+#else
+#define PAGE_SIZE 4096
+#endif
+
+#endif /* _X86_64_PARAM_H_ */

--- a/src-lites-1.1-2025/include/x86_64/ptrace.h
+++ b/src-lites-1.1-2025/include/x86_64/ptrace.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 1992, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)ptrace.h	8.1 (Berkeley) 6/11/93
+ */
+
+/*
+ * Machine dependent trace commands.
+ *
+ * None for the i386 at this time.
+ */

--- a/src-lites-1.1-2025/include/x86_64/signal.h
+++ b/src-lites-1.1-2025/include/x86_64/signal.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 1986, 1989, 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)signal.h	8.1 (Berkeley) 6/11/93
+ */
+
+/*
+ * Machine-dependent signal definitions
+ */
+
+typedef int sig_atomic_t;
+
+#ifndef _POSIX_SOURCE
+#include <machine/trap.h>	/* codes for SIGILL, SIGFPE */
+#endif
+
+/*
+ * Information pushed on stack when a signal is delivered.
+ * This is used by the kernel to restore state following
+ * execution of the signal handler.  It is also made available
+ * to the handler to allow it to restore state properly if
+ * a non-standard exit is performed.
+ */
+struct	sigcontext {
+	int	sc_onstack;	/* sigstack state to restore */
+	int	sc_mask;	/* signal mask to restore */
+	int	sc_sp;		/* sp to restore */
+	int	sc_fp;		/* fp to restore */
+	int	sc_ap;		/* ap to restore */
+	int	sc_pc;		/* pc to restore */
+	int	sc_ps;		/* psl to restore */
+};

--- a/src-lites-1.1-2025/include/x86_64/stdarg.h
+++ b/src-lites-1.1-2025/include/x86_64/stdarg.h
@@ -1,0 +1,58 @@
+/*-
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)stdarg.h	8.1 (Berkeley) 6/10/93
+ */
+
+#ifndef _STDARG_H_
+#define	_STDARG_H_
+
+typedef char *va_list;
+
+#define	__va_promote(type) \
+	(((sizeof(type) + sizeof(int) - 1) / sizeof(int)) * sizeof(int))
+
+#define	va_start(ap, last) \
+	(ap = ((char *)&(last) + __va_promote(last)))
+
+#ifdef KERNEL
+#define	va_arg(ap, type) \
+	((type *)(ap += sizeof(type)))[-1]
+#else
+#define	va_arg(ap, type) \
+	((type *)(ap += sizeof(type) < sizeof(int) ? \
+		(abort(), 0) : sizeof(type)))[-1]
+#endif
+
+#define	va_end(ap)
+
+#endif /* !_STDARG_H_ */

--- a/src-lites-1.1-2025/include/x86_64/trap.h
+++ b/src-lites-1.1-2025/include/x86_64/trap.h
@@ -1,0 +1,97 @@
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * William Jolitz.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)trap.h	8.1 (Berkeley) 6/11/93
+ */
+
+/*
+ * Trap type values
+ * also known in trap.c for name strings
+ */
+
+#define	T_RESADFLT	0	/* reserved addressing */
+#define	T_PRIVINFLT	1	/* privileged instruction */
+#define	T_RESOPFLT	2	/* reserved operand */
+#define	T_BPTFLT	3	/* breakpoint instruction */
+#define	T_SYSCALL	5	/* system call (kcall) */
+#define	T_ARITHTRAP	6	/* arithmetic trap */
+#define	T_ASTFLT	7	/* system forced exception */
+#define	T_SEGFLT	8	/* segmentation (limit) fault */
+#define	T_PROTFLT	9	/* protection fault */
+#define	T_TRCTRAP	10	/* trace trap */
+#define	T_PAGEFLT	12	/* page fault */
+#define	T_TABLEFLT	13	/* page table fault */
+#define	T_ALIGNFLT	14	/* alignment fault */
+#define	T_KSPNOTVAL	15	/* kernel stack pointer not valid */
+#define	T_BUSERR	16	/* bus error */
+#define	T_KDBTRAP	17	/* kernel debugger trap */
+
+#define	T_DIVIDE	18	/* integer divide fault */
+#define	T_NMI		19	/* non-maskable trap */
+#define	T_OFLOW		20	/* overflow trap */
+#define	T_BOUND		21	/* bound instruction fault */
+#define	T_DNA		22	/* device not available fault */
+#define	T_DOUBLEFLT	23	/* double fault */
+#define	T_FPOPFLT	24	/* fp coprocessor operand fetch fault */
+#define	T_TSSFLT	25	/* invalid tss fault */
+#define	T_SEGNPFLT	26	/* segment not present fault */
+#define	T_STKFLT	27	/* stack fault */
+#define	T_RESERVED	28	/* reserved fault base */
+
+/* definitions for <sys/signal.h> */
+#define	    ILL_RESAD_FAULT	T_RESADFLT
+#define	    ILL_PRIVIN_FAULT	T_PRIVINFLT
+#define	    ILL_RESOP_FAULT	T_RESOPFLT
+#define	    ILL_ALIGN_FAULT	T_ALIGNFLT
+#define	    ILL_FPOP_FAULT	T_FPOPFLT	/* coprocessor operand fault */
+
+/* codes for SIGFPE/ARITHTRAP */
+#define	    FPE_INTOVF_TRAP	0x1	/* integer overflow */
+#define	    FPE_INTDIV_TRAP	0x2	/* integer divide by zero */
+#define	    FPE_FLTDIV_TRAP	0x3	/* floating/decimal divide by zero */
+#define	    FPE_FLTOVF_TRAP	0x4	/* floating overflow */
+#define	    FPE_FLTUND_TRAP	0x5	/* floating underflow */
+#define	    FPE_FPU_NP_TRAP	0x6	/* floating point unit not present */
+#define	    FPE_SUBRNG_TRAP	0x7	/* subrange out of bounds */
+
+/* codes for SIGBUS */
+#define	    BUS_PAGE_FAULT	T_PAGEFLT	/* page fault protection base */
+#define	    BUS_SEGNP_FAULT	T_SEGNPFLT	/* segment not present */
+#define	    BUS_STK_FAULT	T_STKFLT	/* stack segment */
+#define	    BUS_SEGM_FAULT	T_RESERVED	/* segment protection base */
+
+/* Trap's coming from user mode */
+#define	T_USER	0x100
+

--- a/src-lites-1.1-2025/include/x86_64/types.h
+++ b/src-lites-1.1-2025/include/x86_64/types.h
@@ -1,0 +1,64 @@
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)types.h	8.3 (Berkeley) 1/5/94
+ */
+
+#ifndef	_MACHTYPES_H_
+#define	_MACHTYPES_H_
+
+#include <mach/machine/vm_types.h>
+
+#if !defined(_ANSI_SOURCE) && !defined(_POSIX_SOURCE)
+typedef struct _physadr {
+	int r[1];
+} *physadr;
+
+typedef struct label_t {
+	int val[6];
+} label_t;
+#endif
+
+/*
+ * Basic integral types.  Omit the typedef if
+ * not possible for a machine/compiler combination.
+ */
+typedef	__signed char		   int8_t;
+typedef	unsigned char		 u_int8_t;
+typedef	short			  int16_t;
+typedef	unsigned short		u_int16_t;
+typedef	int			  int32_t;
+typedef	unsigned int		u_int32_t;
+typedef	long long		  int64_t;
+typedef	unsigned long long	u_int64_t;
+
+#endif	/* _MACHTYPES_H_ */

--- a/src-lites-1.1-2025/include/x86_64/varargs.h
+++ b/src-lites-1.1-2025/include/x86_64/varargs.h
@@ -1,0 +1,62 @@
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)varargs.h	8.2 (Berkeley) 3/22/94
+ */
+
+#ifndef _VARARGS_H_
+#define	_VARARGS_H_
+
+typedef char *va_list;
+
+#define	va_dcl	int va_alist;
+
+#define	va_start(ap) \
+	ap = (char *)&va_alist
+
+#ifdef KERNEL
+#define	va_arg(ap, type) \
+	((type *)(ap += sizeof(type)))[-1]
+#else
+#define	va_arg(ap, type) \
+	((type *)(ap += sizeof(type) < sizeof(int) ? \
+		(abort(), 0) : sizeof(type)))[-1]
+#endif
+
+#define	va_end(ap)
+
+#endif /* !_VARARGS_H_ */

--- a/src-lites-1.1-2025/include/x86_64/vmparam.h
+++ b/src-lites-1.1-2025/include/x86_64/vmparam.h
@@ -1,0 +1,205 @@
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * William Jolitz.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)vmparam.h	8.2 (Berkeley) 4/22/94
+ */
+
+#ifndef _X86_64_BSD_VMPARAM_H_
+#define _X86_64_BSD_VMPARAM_H_
+/*
+ * Machine dependent constants for 386.
+ */
+
+/*
+ * Virtual address space arrangement. On 386, both user and kernel
+ * share the address space, not unlike the vax.
+ * USRTEXT is the start of the user text/data space, while USRSTACK
+ * is the top (end) of the user stack. Immediately above the user stack
+ * resides the user structure, which is UPAGES long and contains the
+ * kernel stack.
+ *
+ * Immediately after the user structure is the page table map, and then
+ * kernal address space.
+ */
+#define	USRTEXT		0
+#ifdef LITES
+#define	USRSTACK	VM_MAX_ADDRESS
+#define	BTOPUSRSTACK	x86_64_btop(USRSTACK)
+#else /* LITES */
+#define	USRSTACK	0xFDBFE000
+#define	BTOPUSRSTACK	(0xFDC00-(UPAGES))	/* btop(USRSTACK) */
+#endif /* LITES */
+#define	LOWPAGES	0
+#define HIGHPAGES	UPAGES
+
+/*
+ * Virtual memory related constants, all in bytes
+ */
+#define	MAXTSIZ		(6*1024*1024)		/* max text size */
+#ifndef DFLDSIZ
+#define	DFLDSIZ		(6*1024*1024)		/* initial data size limit */
+#endif
+#ifndef MAXDSIZ
+#define	MAXDSIZ		(32*1024*1024)		/* max data size */
+#endif
+#ifndef	DFLSSIZ
+#define	DFLSSIZ		(512*1024)		/* initial stack size limit */
+#endif
+#ifndef	MAXSSIZ
+#define	MAXSSIZ		MAXDSIZ			/* max stack size */
+#endif
+
+/*
+ * Default sizes of swap allocation chunks (see dmap.h).
+ * The actual values may be changed in vminit() based on MAXDSIZ.
+ * With MAXDSIZ of 16Mb and NDMAP of 38, dmmax will be 1024.
+ */
+#define	DMMIN	32			/* smallest swap allocation */
+#define	DMMAX	4096			/* largest potential swap allocation */
+#define	DMTEXT	1024			/* swap allocation for text */
+
+/*
+ * Sizes of the system and user portions of the system page table.
+ */
+#define	SYSPTSIZE 	(2*NPTEPG)
+#define	USRPTSIZE 	(2*NPTEPG)
+
+/*
+ * Size of User Raw I/O map
+ */
+#define	USRIOSIZE 	300
+
+/*
+ * The size of the clock loop.
+ */
+#define	LOOPPAGES	(maxfree - firstfree)
+
+/*
+ * The time for a process to be blocked before being very swappable.
+ * This is a number of seconds which the system takes as being a non-trivial
+ * amount of real time.  You probably shouldn't change this;
+ * it is used in subtle ways (fractions and multiples of it are, that is, like
+ * half of a ``long time'', almost a long time, etc.)
+ * It is related to human patience and other factors which don't really
+ * change over time.
+ */
+#define	MAXSLP 		20
+
+/*
+ * A swapped in process is given a small amount of core without being bothered
+ * by the page replacement algorithm.  Basically this says that if you are
+ * swapped in you deserve some resources.  We protect the last SAFERSS
+ * pages against paging and will just swap you out rather than paging you.
+ * Note that each process has at least UPAGES+CLSIZE pages which are not
+ * paged anyways (this is currently 8+2=10 pages or 5k bytes), so this
+ * number just means a swapped in process is given around 25k bytes.
+ * Just for fun: current memory prices are 4600$ a megabyte on VAX (4/22/81),
+ * so we loan each swapped in process memory worth 100$, or just admit
+ * that we don't consider it worthwhile and swap it out to disk which costs
+ * $30/mb or about $0.75.
+ * { wfj 6/16/89: Retail AT memory expansion $800/megabyte, loan of $17
+ *   on disk costing $7/mb or $0.18 (in memory still 100:1 in cost!) }
+ */
+#define	SAFERSS		8		/* nominal ``small'' resident set size
+					   protected against replacement */
+
+/*
+ * DISKRPM is used to estimate the number of paging i/o operations
+ * which one can expect from a single disk controller.
+ */
+#define	DISKRPM		60
+
+/*
+ * Klustering constants.  Klustering is the gathering
+ * of pages together for pagein/pageout, while clustering
+ * is the treatment of hardware page size as though it were
+ * larger than it really is.
+ *
+ * KLMAX gives maximum cluster size in CLSIZE page (cluster-page)
+ * units.  Note that KLMAX*CLSIZE must be <= DMMIN in dmap.h.
+ */
+
+#define	KLMAX	(4/CLSIZE)
+#define	KLSEQL	(2/CLSIZE)		/* in klust if vadvise(VA_SEQL) */
+#define	KLIN	(4/CLSIZE)		/* default data/stack in klust */
+#define	KLTXT	(4/CLSIZE)		/* default text in klust */
+#define	KLOUT	(4/CLSIZE)
+
+/*
+ * KLSDIST is the advance or retard of the fifo reclaim for sequential
+ * processes data space.
+ */
+#define	KLSDIST	3		/* klusters advance/retard for seq. fifo */
+
+/*
+ * Paging thresholds (see vm_sched.c).
+ * Strategy of 1/19/85:
+ *	lotsfree is 512k bytes, but at most 1/4 of memory
+ *	desfree is 200k bytes, but at most 1/8 of memory
+ */
+#define	LOTSFREE	(512 * 1024)
+#define	LOTSFREEFRACT	4
+#define	DESFREE		(200 * 1024)
+#define	DESFREEFRACT	8
+
+/*
+ * There are two clock hands, initially separated by HANDSPREAD bytes
+ * (but at most all of user memory).  The amount of time to reclaim
+ * a page once the pageout process examines it increases with this
+ * distance and decreases as the scan rate rises.
+ */
+#define	HANDSPREAD	(2 * 1024 * 1024)
+
+/*
+ * The number of times per second to recompute the desired paging rate
+ * and poke the pagedaemon.
+ */
+#define	RATETOSCHEDPAGING	4
+
+/*
+ * Believed threshold (in megabytes) for which interleaved
+ * swapping area is desirable.
+ */
+#define	LOTSOFMEM	2
+
+#define	mapin(pte, v, pfnum, prot) \
+	{(*(int *)(pte) = ((pfnum)<<PGSHIFT) | (prot)) ; }
+
+/* virtual sizes (bytes) for various kernel submaps */
+#define VM_MBUF_SIZE		(NMBCLUSTERS*MCLBYTES)
+#define VM_KMEM_SIZE		(NKMEMCLUSTERS*CLBYTES)
+#define VM_PHYS_SIZE		(USRIOSIZE*CLBYTES)
+
+#endif /* _X86_64_BSD_VMPARAM_H_ */

--- a/src-lites-1.1-2025/liblites/Makefile
+++ b/src-lites-1.1-2025/liblites/Makefile
@@ -58,6 +58,7 @@ MIGFLAGS 	= ${DEFINES}
 ASFLAGS		= ${${TARGET_MACHINE}ASFLAGS}
 
 i386_OFILES = ntoh.o memcmp.o in_cksum.o
+x86_64_OFILES = ntoh.o memcmp.o in_cksum.o
 parisc_OFILES =
 ns532_OFILES = misc_asm.s memcmp.o in_cksum.o bcmp.o
 mips_OFILES = ntoh.o memcmp.o

--- a/src-lites-1.1-2025/liblites/x86_64/in_cksum.c
+++ b/src-lites-1.1-2025/liblites/x86_64/in_cksum.c
@@ -1,0 +1,131 @@
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * from tahoe:	in_cksum.c	1.2	86/01/05
+ *	@(#)in_cksum.c	8.1 (Berkeley) 6/11/93
+ */
+
+#include <sys/param.h>
+#include <sys/mbuf.h>
+
+#include <netinet/in.h>
+#include <netinet/in_systm.h>
+
+/*
+ * Checksum routine for Internet Protocol family headers.
+ *
+ * This routine is very heavily used in the network
+ * code and should be modified for each CPU to be as fast as possible.
+ * 
+ * This implementation is 386 version.
+ */
+
+#undef	ADDCARRY
+#define ADDCARRY(sum)  {				\
+			if (sum & 0xffff0000) {		\
+				sum &= 0xffff;		\
+				sum++;			\
+			}				\
+		}
+in_cksum(m, len)
+	register struct mbuf *m;
+	register int len;
+{
+	union word {
+		char	c[2];
+		u_short	s;
+	} u;
+	register u_short *w;
+	register int sum = 0;
+	register int mlen = 0;
+
+	for (;m && len; m = m->m_next) {
+		if (m->m_len == 0)
+			continue;
+		w = mtod(m, u_short *);
+		if (mlen == -1) {
+			/*
+			 * The first byte of this mbuf is the continuation
+			 * of a word spanning between this mbuf and the
+			 * last mbuf.
+			 */
+
+			/* u.c[0] is already saved when scanning previous 
+			 * mbuf.
+			 */
+			u.c[1] = *(u_char *)w;
+			sum += u.s;
+			ADDCARRY(sum);
+			w = (u_short *)((char *)w + 1);
+			mlen = m->m_len - 1;
+			len--;
+		} else
+			mlen = m->m_len;
+
+		if (len < mlen)
+			mlen = len;
+		len -= mlen;
+
+		/*
+		 * add by words.
+		 */
+		while ((mlen -= 2) >= 0) {
+			if ((int)w & 0x1) {
+				/* word is not aligned */
+				u.c[0] = *(char *)w;
+				u.c[1] = *((char *)w+1);
+				sum += u.s;
+				w++;
+			} else
+				sum += *w++;
+			ADDCARRY(sum);
+		}
+		if (mlen == -1)
+			/*
+			 * This mbuf has odd number of bytes. 
+			 * There could be a word split betwen
+			 * this mbuf and the next mbuf.
+			 * Save the last byte (to prepend to next mbuf).
+			 */
+			u.c[0] = *(u_char *)w;
+	}
+	if (len)
+		printf("cksum: out of data\n");
+	if (mlen == -1) {
+		/* The last mbuf has odd # of bytes. Follow the
+		   standard (the odd byte is shifted left by 8 bits) */
+		u.c[1] = 0;
+		sum += u.s;
+		ADDCARRY(sum);
+	}
+	return (~sum & 0xffff);
+}

--- a/src-lites-1.1-2025/liblites/x86_64/ntoh.s
+++ b/src-lites-1.1-2025/liblites/x86_64/ntoh.s
@@ -1,0 +1,56 @@
+/* 
+ * Mach Operating System
+ * Copyright (c) 1992 Carnegie Mellon University
+ * All Rights Reserved.
+ * 
+ * Permission to use, copy, modify and distribute this software and its
+ * documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ * 
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
+ * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ * 
+ * Carnegie Mellon requests users of this software to return to
+ * 
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ * 
+ * any improvements or extensions that they make and grant Carnegie Mellon 
+ * the rights to redistribute these changes.
+ */
+/*
+ * HISTORY
+ * $Log: ntoh.s,v $
+# Revision 1.1.1.1  1995/03/02  21:49:39  mike
+# Initial Lites release from hut.fi
+#
+ * Revision 2.2  93/05/11  11:59:59  rvb
+ * 	Fix comment leader.
+ * 	[93/05/03  13:06:10  rvb]
+ * 
+ * Revision 2.1  92/04/21  17:19:04  rwd
+ * BSDSS
+ *
+ */
+
+#include <i386/asm.h>
+
+Entry(ntohl)
+ENTRY(htonl)
+	movl	4(%esp), %eax
+	rorw	$8, %ax
+	ror	$16,%eax
+	rorw	$8, %ax
+	ret
+
+
+Entry(ntohs)
+ENTRY(htons)
+	movzwl	4(%esp), %eax
+	rorw	$8, %ax
+	ret

--- a/src-lites-1.1-2025/server/ufs/ext2fs/x86_64-bitops.h
+++ b/src-lites-1.1-2025/server/ufs/ext2fs/x86_64-bitops.h
@@ -1,0 +1,159 @@
+/*
+ * this is mixture of i386/bitops.h and asm/string.h
+ * taken from the Linux source tree 
+ *
+ * XXX replace with Mach routines or reprogram in C
+ */
+#ifndef _X86_64_BITOPS_H
+#define _X86_64_BITOPS_H
+
+/*
+ * Copyright 1992, Linus Torvalds.
+ */
+
+/*
+ * These have to be done with inline assembly: that way the bit-setting
+ * is guaranteed to be atomic. All bit operations return 0 if the bit
+ * was cleared before the operation and != 0 if it was not.
+ *
+ * bit 0 is the LSB of addr; bit 64 is the LSB of (addr+1).
+ */
+
+/*
+ * Some hacks to defeat gcc over-optimizations..
+ */
+struct __dummy { unsigned long a[100]; };
+#define ADDR (*(struct __dummy *) addr)
+
+extern __inline__ int set_bit(int nr, void * addr)
+{
+	int oldbit;
+
+	__asm__ __volatile__("btsq %2,%1\n\tsbbl %0,%0"
+		:"=r" (oldbit),"=m" (ADDR)
+		:"ir" (nr));
+	return oldbit;
+}
+
+extern __inline__ int clear_bit(int nr, void * addr)
+{
+	int oldbit;
+
+	__asm__ __volatile__("btrq %2,%1\n\tsbbl %0,%0"
+		:"=r" (oldbit),"=m" (ADDR)
+		:"ir" (nr));
+	return oldbit;
+}
+
+extern __inline__ int change_bit(int nr, void * addr)
+{
+	int oldbit;
+
+	__asm__ __volatile__("btcq %2,%1\n\tsbbl %0,%0"
+		:"=r" (oldbit),"=m" (ADDR)
+		:"ir" (nr));
+	return oldbit;
+}
+
+/*
+ * This routine doesn't need to be atomic, but it's faster to code it
+ * this way.
+ */
+extern __inline__ int test_bit(int nr, void * addr)
+{
+	int oldbit;
+
+	__asm__ __volatile__("btq %2,%1\n\tsbbl %0,%0"
+		:"=r" (oldbit)
+		:"m" (ADDR),"ir" (nr));
+	return oldbit;
+}
+
+/*
+ * Find-bit routines..
+ */
+extern inline int find_first_zero_bit(void * addr, unsigned size)
+{
+	int res;
+
+	if (!size)
+		return 0;
+	__asm__("
+		cld
+		movq $-1,%%eax
+		xorq %%rdx,%%rdx
+		repe; scasq
+		je 1f
+		xorq -8(%%edi),%%eax
+		subq $8,%%edi
+		bsfq %%eax,%%edx
+1:		subq %%rbx,%%edi
+		shlq $3,%%edi
+		addq %%edi,%%edx"
+		:"=d" (res)
+		:"c" ((size + 63) >> 6), "D" (addr), "b" (addr)
+		:"ax", "cx", "di");
+	return res;
+}
+
+extern inline int find_next_zero_bit (void * addr, int size, int offset)
+{
+	unsigned long * p = ((unsigned long *) addr) + (offset >> 6);
+	int set = 0, bit = offset & 63, res;
+	
+	if (bit) {
+		/*
+		 * Look for zero in first byte
+		 */
+		__asm__("
+			bsfq %1,%0
+			jne 1f
+			movq $64, %0
+1:			"
+			: "=r" (set)
+			: "r" (~(*p >> bit)));
+		if (set < (64 - bit))
+			return set + offset;
+		set = 64 - bit;
+		p++;
+	}
+	/*
+	 * No zero yet, search remaining full bytes for a zero
+	 */
+	res = find_first_zero_bit (p, size - 64 * (p - (unsigned long *) addr));
+	return (offset + set + res);
+}
+
+/*
+ * ffz = Find First Zero in word. Undefined if no zero exists,
+ * so code should check against ~0UL first..
+ */
+extern inline unsigned long ffz(unsigned long word)
+{
+	__asm__("bsfq %1,%0"
+		:"=r" (word)
+		:"r" (~word));
+	return word;
+}
+
+/* 
+ * memscan() taken from linux asm/string.h
+ */
+/*
+ * find the first occurrence of byte 'c', or 1 past the area if none
+ */
+extern inline char * memscan(void * addr, unsigned char c, int size)
+{
+        if (!size)
+                return addr;
+        __asm__("cld
+                repnz; scasb
+                jnz 1f
+                dec %%edi
+1:              "
+                : "=D" (addr), "=c" (size)
+                : "0" (addr), "1" (size), "a" (c));
+        return addr;
+}
+
+#endif /* _X86_64_BITOPS_H */

--- a/src-lites-1.1-2025/server/x86_64/conf.c
+++ b/src-lites-1.1-2025/server/x86_64/conf.c
@@ -1,0 +1,577 @@
+/* 
+ * Mach Operating System
+ * Copyright (c) 1992 Carnegie Mellon University
+ * Copyright (c) 1994 Johannes Helander
+ * Copyright (c) 1994 Timo Rinne
+ * All Rights Reserved.
+ * 
+ * Permission to use, copy, modify and distribute this software and its
+ * documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ * 
+ * CARNEGIE MELLON AND JOHANNES HELANDER AND TIMO RINNE ALLOW FREE USE
+ * OF THIS SOFTWARE IN ITS "AS IS" CONDITION.  CARNEGIE MELLON AND
+ * JOHANNES HELANDER AND TIMO RINNE DISCLAIM ANY LIABILITY OF ANY KIND
+ * FOR ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ */
+/*
+ * HISTORY
+ * $Log: conf.c,v $
+ * Revision 1.1.1.2  1995/03/23  01:16:28  law
+ * lites-950323 from jvh.
+ *
+ */
+/* 
+ *	File:	 x86_64/server/conf.c
+ *	Authors:
+ *	Randall Dean, Carnegie Mellon University, 1992.
+ *	Johannes Helander, Helsinki University of Technology, 1994.
+ *	Timo Rinne, Helsinki University of Technology, 1994.
+ *
+ *	Simplified configuration.
+ */
+/*-
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)conf.c	8.3 (Berkeley) 1/21/94
+ */
+
+#include <serv/import_mach.h>
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/buf.h>	/* for B_TAPE */
+#include <sys/conf.h>
+#include <sys/errno.h>
+#include <sys/vnode.h>
+
+#include <serv/device.h>
+#include <serv/device_utils.h>
+
+#include <sys/ioctl.h>	/* for tty */
+#include <sys/tty.h>
+#include <sys/proc.h>
+
+#include <serv/tape_io.h>	/* tape_io prototypes */
+/*
+ * Block devices all use the same open/close/strategy routines.
+ */
+int bdev_open(dev_t, int, int, struct proc *);
+int bdev_close(dev_t, int, int, struct proc *);
+int bio_strategy(struct buf *);
+int bdev_ioctl(dev_t, ioctl_cmd_t, caddr_t, int, struct proc *);
+int bdev_dump(dev_t);
+int bdev_size(dev_t);
+#define	bdev_ops	bdev_open, bdev_close, bio_strategy, bdev_ioctl,\
+			bdev_dump, bdev_size
+
+struct bdevsw	bdevsw[] =
+{
+/*0*/	{ "hd",		C_BLOCK(8),	bdev_ops },	/* isa */
+/*1*/   { "",           0,              bdev_ops },
+/*2*/	{ "fd",		C_BLOCK(8),	bdev_ops },	/* isa */
+/*3*/	{ "wt",		B_TAPE,		bdev_ops },	/* isa */
+/*4*/	{ "sd",		C_BLOCK(8),	bdev_ops },	/* ipsc, isa */
+/*5*/	{ "st",		C_BLOCK(16),	bdev_ops },	/* ipsc, isa */
+/*6*/	{ "cd",		C_BLOCK(8),	bdev_ops },	/* ipsc, isa */
+
+};
+int	nblkdev = sizeof(bdevsw)/sizeof(bdevsw[0]);
+
+int char_open(dev_t, int, int, struct proc *);
+int char_close(dev_t, int, int, struct proc *);
+int char_read(dev_t, struct uio *, int);
+int char_write(dev_t, struct uio *, int);
+int char_ioctl(dev_t, ioctl_cmd_t, caddr_t, int, struct proc *);
+int char_select(dev_t, int, struct proc *);
+mach_port_t char_port(dev_t);
+#define	char_ops \
+	char_open, char_close, char_read, char_write, char_ioctl, \
+	null_stop, null_reset, null_tty, char_select, device_map, \
+	null_strategy, char_port
+
+int disk_open(dev_t, int, int, struct proc *);
+int disk_close(dev_t, int, int, struct proc *);
+int disk_read(dev_t, struct uio *, int);
+int disk_write(dev_t, struct uio *, int);
+int disk_ioctl(dev_t, ioctl_cmd_t, caddr_t, int, struct proc *);
+int isa_disk_ioctl(dev_t, ioctl_cmd_t, caddr_t, int, struct proc *);
+extern mach_port_t disk_port(dev_t);
+#define	disk_ops \
+	disk_open, disk_close, disk_read, disk_write, disk_ioctl, \
+	null_stop, null_reset, null_tty, seltrue, null_mmap, \
+	null_strategy, disk_port
+
+#define	isa_disk_ops \
+	disk_open, disk_close, disk_read, disk_write, isa_disk_ioctl, \
+	null_stop, null_reset, null_tty, seltrue, null_mmap, \
+	null_strategy, disk_port
+
+#define	tape_ops \
+	tape_open, tape_close, tape_read, tape_write, tape_ioctl, \
+	null_stop, null_reset, null_tty, seltrue, null_mmap, \
+	null_strategy, tape_port
+
+int tty_open(dev_t, int, int, struct proc *);
+int tty_close(dev_t, int, int, struct proc *);
+int tty_read(dev_t, struct uio *, int);
+int tty_write(dev_t, struct uio *, int);
+int tty_ioctl(dev_t, ioctl_cmd_t, caddr_t, int, struct proc *);
+int ttselect(dev_t, int, struct proc *);
+int tty_stop(struct tty *, int);
+struct tty *tty_find_tty(dev_t);
+#define	tty_ops	\
+	tty_open, tty_close, tty_read, tty_write, tty_ioctl,\
+	tty_stop, null_reset, tty_find_tty, ttselect, null_mmap, \
+	null_strategy, null_port
+
+int cons_open(dev_t, int, int, struct proc *);
+int cons_write(dev_t, struct uio *, int);
+int cons_ioctl(dev_t, ioctl_cmd_t, caddr_t, int, struct proc *);
+extern mach_port_t cons_port(dev_t);
+#define	console_ops	\
+	cons_open, tty_close, tty_read, cons_write, cons_ioctl, \
+	tty_stop, null_reset, tty_find_tty, ttselect, device_map, \
+	null_strategy, cons_port
+
+int cttyopen(dev_t, int, int, struct proc *);
+int cttyread(dev_t, struct uio *, int);
+int cttywrite(dev_t, struct uio *, int);
+int cttyioctl(dev_t, ioctl_cmd_t, caddr_t, int, struct proc *);
+int cttyselect(dev_t, int, struct proc *);
+#define	ctty_ops \
+ 	cttyopen, null_close, cttyread, cttywrite, cttyioctl, \
+ 	null_stop, null_reset, null_tty, cttyselect, null_mmap, \
+	null_strategy, null_port
+
+int logopen(dev_t, int, int, struct proc *);
+int logclose(dev_t, int, int, struct proc *);
+int logread(dev_t, struct uio *, int);
+int logioctl(dev_t, ioctl_cmd_t, caddr_t, int, struct proc *);
+int logselect(dev_t, int, struct proc *);
+#define	log_ops \
+	logopen, logclose, logread, null_write, logioctl, \
+	null_stop, null_reset, null_tty, logselect, null_mmap, \
+	null_strategy, null_port
+
+int mmopen(dev_t, int, int, struct proc *);
+int mmread(dev_t, struct uio *, int);
+int mmwrite(dev_t, struct uio *, int);
+#define	mm_ops \
+	mmopen, null_close, mmread, mmwrite, nodev_ioctl, \
+	null_stop, null_reset, null_tty, seltrue, null_mmap, \
+	null_strategy, null_port
+
+int ptsopen(dev_t, int, int, struct proc *);
+int ptsclose(dev_t, int, int, struct proc *);
+int ptsread(dev_t, struct uio *, int);
+int ptswrite(dev_t, struct uio *, int);
+int ptyioctl(dev_t, ioctl_cmd_t, caddr_t, int, struct proc *);
+int ptsselect(dev_t, int, struct proc *);
+int ptsstop(struct tty *, int);
+struct tty *pty_find_tty(dev_t);
+#define	pts_ops \
+	ptsopen, ptsclose, ptsread, ptswrite, ptyioctl, \
+	ptsstop, null_reset, pty_find_tty, ttselect, null_mmap, \
+	null_strategy, null_port
+
+int ptcopen(dev_t, int, int, struct proc *);
+int ptcclose(dev_t, int, int, struct proc *);
+int ptcread(dev_t, struct uio *, int);
+int ptcwrite(dev_t, struct uio *, int);
+int ptcselect(dev_t, int, struct proc *);
+#define	ptc_ops \
+	ptcopen, ptcclose, ptcread, ptcwrite, ptyioctl, \
+	null_stop, null_reset, null_tty, ptcselect, null_mmap, \
+	null_strategy, null_port
+
+int iopl_open(dev_t, int, int, struct proc *);
+mach_port_t iopl_port(dev_t);
+#define	iopl_ops \
+	iopl_open, char_close, null_read, null_write, null_ioctl, \
+	null_stop, null_reset, null_tty, seltrue, device_map, \
+	null_strategy, char_port
+
+/* Keyboard has it's own IOCTL */
+int kbd_ioctl(dev_t, ioctl_cmd_t, caddr_t, int, struct proc *);
+#define	kbd_ops \
+	char_open, char_close, char_read, char_write, kbd_ioctl, \
+	null_stop, null_reset, null_tty, char_select, null_mmap, \
+	null_strategy, null_port
+
+/* Like char_ops but less methods */
+#define	maptime_ops \
+	char_open, char_close, null_read, null_write, null_ioctl, \
+	null_stop, null_reset, null_tty, null_select, device_map, \
+	null_strategy, char_port
+
+/* Mapped timezone and time offset */
+int maptz_open(dev_t, int, int, struct proc *);
+int maptz_close(dev_t, int, int, struct proc *);
+mach_port_t maptz_port(dev_t);
+kern_return_t maptz_map(mach_port_t, vm_prot_t, vm_offset_t, vm_size_t,
+			mach_port_t *, int);
+#define	maptz_ops \
+	maptz_open, maptz_close, null_read, null_write, null_ioctl, \
+	null_stop, null_reset, null_tty, null_select, maptz_map, \
+	null_strategy, maptz_port
+
+#define	no_ops \
+	nodev_open, nodev_close, nodev_read, nodev_write, nodev_ioctl, \
+	null_stop, nodev_reset, null_tty, nodev_select, nodev_mmap, \
+	nodev_strategy, null_port
+
+struct cdevsw	cdevsw[] =
+{
+/*0*/	{ "console",	0,		console_ops,	},
+/*1*/	{ "",		0,		ctty_ops,	},	/* tty */
+/*2*/	{ "",		0,		mm_ops,		},	/* kmem,null */
+/*3*/	{ "hd",		C_BLOCK(8),	isa_disk_ops,	},	/* isa */
+/*4*/	{ "",		0,		no_ops,		},      /* drum */
+/*5*/	{ "",		0,		pts_ops,	},	/* pts */
+/*6*/	{ "",		0,		ptc_ops,	},	/* ptc */
+/*7*/	{ "",		0,		log_ops,	},      /* log */
+/*8*/	{ "com",	0,		tty_ops,	},	/* isa */
+/*9*/	{ "fd",		C_BLOCK(8),	isa_disk_ops,	},	/* isa */
+/*10*/	{ "wt",		0,		char_ops,	},	/* isa */
+/*11*/	{ "",		0,		no_ops,		},      /* xd */
+/*12*/	{ "",		0,		no_ops,		},      /* pc */
+/*13*/	{ "sd",		C_BLOCK(8),	isa_disk_ops,	},	/* isa */
+/*14*/	{ "st",		C_BLOCK(16),	tape_ops,	},	/* isa */
+/*15*/	{ "cd",		C_BLOCK(8),	isa_disk_ops,	},	/* isa */
+/*16*/	{ "",		0,		no_ops,		}, 	/* - */
+/*17*/	{ "",		0,		no_ops,		},      /* - */
+/*18*/	{ "",		0,		no_ops,		},      /* - */
+/*19*/	{ "",		0,		no_ops,		},      /* - */
+/*20*/	{ "",		0,		no_ops,		},      /* - */
+/*21*/	{ "",		0,		no_ops,		},      /* - */
+/*22*/	{ "iopl",	0,		iopl_ops,	},      /* iopl */
+/*23*/	{ "kbd",	0,		kbd_ops,	},      /* keyboard */
+/*24*/	{ "mouse",	0,		char_ops,	},      /* mouse */
+/*25*/	{ "time",	0,		maptime_ops,	},/* mapped time */
+/*26*/	{ "",		0,		maptz_ops,	},/* mapped timezone */
+/*27*/	{ "",		0,		no_ops,		},      /* - */
+/*28*/	{ "",		0,		no_ops,		},      /* - */
+/*29*/	{ "",		0,		no_ops,		},      /* - */
+};
+#define NCHRDEV sizeof(cdevsw)/sizeof(cdevsw[0])
+int	nchrdev = NCHRDEV;
+
+dev_t	cttydev = makedev(1, 0);
+int	mem_no = 2;
+
+/*
+ * Conjure up a name string for funny devices (not all minors have
+ * the same name).
+ */
+int
+check_dev(dev_t	dev, char *str)
+{
+    return 0;
+}
+
+/*
+ * ISA disk IOCTL
+ */
+#undef	p_flag			/* conflict from sys/{proc,user}.h */
+
+#include "mach4_includes.h"
+#include "osfmach3.h"
+
+#if MACH4_INCLUDES || OSFMACH3
+#include <i386/disk.h>
+#else
+#include <i386at/disk.h>
+#endif
+
+int isa_disk_ioctl(
+	dev_t dev,
+	ioctl_cmd_t cmd,
+	caddr_t data,
+	int flag,
+	struct proc *p)
+{
+	mach_port_t		device_port = disk_port(dev);
+	mach_msg_type_number_t	count;
+	register int		error;
+
+	switch (cmd) {
+#if !OSFMACH3
+	    case V_RDABS:
+	    {
+		char buf[512];
+
+		error = device_set_status(device_port,
+					  V_ABS,
+			   (dev_status_t) &((struct absio *)data)->abs_sec,
+					  1);
+		if (error)
+		    return (dev_error_to_errno(error));
+		count = 512/sizeof(int);
+		error = device_get_status(device_port,
+					  cmd,
+					  (dev_status_t) buf,
+					  &count);
+
+		if (error)
+		    return (dev_error_to_errno(error));
+		if (copyout(buf, ((struct absio *)data)->abs_buf, 512))
+		    return (EFAULT);
+		break;
+	    }
+
+	    case V_VERIFY:
+	    {
+		union vfy_io *vfy_io = (union vfy_io *) data;
+		int vfy[2] = {	vfy_io->vfy_in.abs_sec,
+				vfy_io->vfy_in.num_sec};
+
+		error = device_set_status(device_port,
+					  V_ABS,
+					  vfy,
+					  2);
+		if (error)
+		    return (dev_error_to_errno(error));
+		count = sizeof (int)/sizeof(int);
+		error = device_get_status(device_port,
+					  cmd,
+					  vfy,
+					  &count);
+
+		vfy_io->vfy_out.err_code = vfy[0];
+		if (error)
+		    return (dev_error_to_errno(error));
+		break;
+	    }
+
+	    case V_WRABS:
+	    {
+		char buf[512];
+
+		error = device_set_status(device_port,
+			V_ABS,
+			(dev_status_t) &((struct absio *)data)->abs_sec,
+			1);
+		if (error)
+		    return (dev_error_to_errno(error));
+		if (copyin(((struct absio *)data)->abs_buf, buf, 512))
+		    return (EFAULT);
+		count = 512/sizeof(int);
+		error = device_set_status(device_port,
+					  cmd,
+					  (dev_status_t) buf,
+					  count);
+		if (error)
+		    return (dev_error_to_errno(error));
+		break;
+	    }
+#endif /* !OSFMACH3 */
+	    default:
+	    {
+		return (disk_ioctl(dev, cmd, data, flag, p));
+	    }
+	}
+	return (0);
+}
+
+/*
+ * IOPL device has to give send rights to port to task.
+ */
+
+int iopl_open(dev_t dev, int flag, int devtype, struct proc *p)
+{
+	kern_return_t	kr;
+	mach_port_t	name, iopl_port;
+
+	kr = char_open(dev, flag, devtype, p);
+	if (kr)
+	    return kr;
+
+	iopl_port = char_port(dev);
+	/*
+	 * Give send rights to task to let it access IO
+	 */
+	name = 0x10000;	/* XXX */
+	do {
+	    kr = mach_port_insert_right(p->p_task,
+					name++,
+					iopl_port,
+					MACH_MSG_TYPE_COPY_SEND);
+	} while ((kr == KERN_NAME_EXISTS || kr == KERN_RIGHT_EXISTS)
+		 && name < 0x10100); /* give up after 256 tries */
+	if (kr != KERN_SUCCESS) {
+		char_close(dev, flag, 0 /*mode*/, p);
+		return EACCES;
+	}
+	return 0;
+}
+
+/*
+ * Keyboard device uses char ops but has special ioctl of its own.
+ */
+int kbd_ioctl(
+	dev_t dev,
+	ioctl_cmd_t cmd,
+	caddr_t data,
+	int flag,
+	struct proc *p)
+{
+	/* 
+	 * XXX a newer version of this stuff is now in char_ioctl
+	 * XXX which is not the proper place
+	 */
+	return (char_ioctl(dev, cmd, data, flag, p));
+}
+
+/* XXX from Lite with fixes. Cleanup */
+
+/*
+ * Swapdev is a fake device implemented
+ * in sw.c used only internally to get to swstrategy.
+ * It cannot be provided to the users, because the
+ * swstrategy routine munches the b_dev and b_blkno entries
+ * before calling the appropriate driver.  This would horribly
+ * confuse, e.g. the hashing routines. Instead, /dev/drum is
+ * provided as a character (raw) device.
+ */
+dev_t	swapdev = makedev(3, 0);
+
+/*
+ * Routine that identifies /dev/mem and /dev/kmem.
+ *
+ * A minimal stub routine can always return 0.
+ */
+boolean_t iskmemdev(dev_t dev)
+{
+
+	return FALSE;
+}
+
+boolean_t iszerodev(dev_t dev)
+{
+	return FALSE;
+	return (major(dev) == 2 && minor(dev) == 12);
+}
+
+/*
+ * Routine to determine if a device is a disk.
+ *
+ * A minimal stub routine can always return 0.
+ */
+boolean_t isdisk(dev_t dev, int type)
+{
+
+	switch (major(dev)) {
+	case 0:
+	case 2:
+	case 4:
+	case 6:
+		if (type == VBLK)
+			return TRUE;
+		return FALSE;
+	case 3:
+	case 9:
+	case 13:
+	case 15:
+		if (type == VCHR)
+			return TRUE;
+		/* fall through */
+	default:
+		return FALSE;
+	}
+	/* NOTREACHED */
+}
+
+static int chrtoblktbl[NCHRDEV] =  {
+      /* VCHR */      /* VBLK */
+	/* 0 */		NODEV,
+	/* 1 */		NODEV,
+	/* 2 */		NODEV,
+	/* 3 */		0,	/* hd (esdi) */
+	/* 4 */		NODEV,
+	/* 5 */		NODEV,
+	/* 6 */		NODEV,
+	/* 7 */		NODEV,
+	/* 8 */		NODEV,
+	/* 9 */		2,	/* fd */
+	/* 10 */	NODEV,
+	/* 11 */	NODEV,
+	/* 12 */	NODEV,
+	/* 13 */	4,	/* sd */
+	/* 14 */	NODEV,
+	/* 15 */	6,	/* cd */
+	/* 16 */	NODEV,
+	/* 17 */	NODEV,
+	/* 18 */	NODEV,
+	/* 19 */	NODEV,
+	/* 20 */	NODEV,
+			NODEV,
+			NODEV,
+	/* 23 */	NODEV,
+			NODEV,
+	/* 25 */	NODEV,
+			NODEV,
+	/* 27 */	NODEV,
+			NODEV,
+	/* 29 */	NODEV
+
+};
+/*
+ * Routine to convert from character to block device number.
+ *
+ * A minimal stub routine can always return NODEV.
+ */
+dev_t chrtoblk(dev_t dev)
+{
+	int blkmaj;
+
+	if (major(dev) >= NCHRDEV || (blkmaj = chrtoblktbl[major(dev)]) == NODEV)
+		return (NODEV);
+	return (makedev(blkmaj, minor(dev)));
+}
+
+dev_t blktochr(dev_t bdev)
+{
+  int i;
+
+  for (i = 0; i < NCHRDEV; i++) {
+    if (major(bdev) == chrtoblktbl[i])
+      return makedev(i, minor(bdev));
+  }
+  return NODEV;
+}

--- a/src-lites-1.1-2025/server/x86_64/i386_exception.c
+++ b/src-lites-1.1-2025/server/x86_64/i386_exception.c
@@ -1,0 +1,83 @@
+/* 
+ * Mach Operating System
+ * Copyright (c) 1992 Carnegie Mellon University
+ * All Rights Reserved.
+ * 
+ * Permission to use, copy, modify and distribute this software and its
+ * documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ * 
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
+ * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ * 
+ * Carnegie Mellon requests users of this software to return to
+ * 
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ * 
+ * any improvements or extensions that they make and grant Carnegie Mellon 
+ * the rights to redistribute these changes.
+ */
+
+#define EXPORT_BOOLEAN
+
+#include <mach/boolean.h>
+#include <mach/exception.h>
+#include <sys/types.h>
+#include <mach/kern_return.h>
+#include <sys/signal.h>
+
+boolean_t
+machine_exception(integer_t exception, integer_t code, integer_t subcode,
+		  int *unix_signal, int *unix_code)
+{
+	switch(exception) {
+
+	    case EXC_BAD_INSTRUCTION:
+	        *unix_signal = SIGILL;
+		switch (code) {
+		    case EXC_I386_INVOP:
+			*unix_code = ILL_RESOP_FAULT;
+			break;
+		    default:
+			return(FALSE);
+		}
+		break;
+
+	    case EXC_ARITHMETIC:
+	        *unix_signal = SIGFPE;
+		switch (code) {
+		    case EXC_I386_INTO:
+			*unix_code = FPE_INTOVF_TRAP;
+			break;
+		    case EXC_I386_DIV:
+			*unix_code = FPE_INTDIV_TRAP;
+			break;
+		    case EXC_I386_BOUND:
+			*unix_code = FPE_SUBRNG_TRAP;
+			break;
+		    case EXC_I386_NOEXT:
+		    case EXC_I386_EXTOVR:
+		    case EXC_I386_EXTERR:
+		    case EXC_I386_EMERR:
+			*unix_code = 0;
+			break;
+		    default:
+			return(FALSE);
+		}
+		break;
+
+	    case EXC_BREAKPOINT:
+		*unix_signal = SIGTRAP;
+		break;
+
+	    default:
+		return(FALSE);
+	}
+	return(TRUE);
+}

--- a/src-lites-1.1-2025/server/x86_64/misc_asm.s
+++ b/src-lites-1.1-2025/server/x86_64/misc_asm.s
@@ -1,0 +1,74 @@
+/* 
+ * Mach Operating System
+ * Copyright (c) 1992 Carnegie Mellon University
+ * All Rights Reserved.
+ * 
+ * Permission to use, copy, modify and distribute this software and its
+ * documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ * 
+ * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
+ * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
+ * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ * 
+ * Carnegie Mellon requests users of this software to return to
+ * 
+ *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+ *  School of Computer Science
+ *  Carnegie Mellon University
+ *  Pittsburgh PA 15213-3890
+ * 
+ * any improvements or extensions that they make and grant Carnegie Mellon 
+ * the rights to redistribute these changes.
+ */
+/*
+ * HISTORY
+ * $Log: misc_asm.s,v $
+# Revision 1.1.1.1  1995/03/02  21:49:43  mike
+# Initial Lites release from hut.fi
+#
+ * 
+ */
+
+#include <i386/asm.h>
+
+#ifdef	GPROF
+	.globl	_gprof_do_profiling
+	.globl	_mcountaux
+	.globl	mcount
+	.globl	_mcount
+mcount:
+_mcount:
+	cmpl	$0,_gprof_do_profiling
+	jz	1f
+	pushl	0(%esp)
+	pushl	4(%ebp)
+	call	_mcountaux
+	leal	8(%esp),%esp
+1:	ret
+#endif
+
+/*
+ * bcmp(s1, s2, len)
+ * char *s1, *s2;
+ * int len
+ */
+ENTRY(bcmp)
+	pushl	%esi
+	pushl	%edi
+
+	xorl	%eax, %eax
+	movl	12(%esp), %esi
+	movl	16(%esp), %edi
+	movl	20(%esp), %ecx
+
+	cld
+	 repe; cmpsb
+	je	0f
+	incl	%eax
+	
+0:	popl	%edi
+	popl	%esi
+	ret

--- a/src-lites-1.1-2025/server/x86_64/second_syscalls.s
+++ b/src-lites-1.1-2025/server/x86_64/second_syscalls.s
@@ -1,0 +1,72 @@
+/* 
+ * Mach Operating System
+ * Copyright (c) 1994 Johannes Helander
+ * All Rights Reserved.
+ * 
+ * Permission to use, copy, modify and distribute this software and its
+ * documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ * 
+ * JOHANNES HELANDER ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
+ * CONDITION.  JOHANNES HELANDER DISCLAIMS ANY LIABILITY OF ANY KIND
+ * FOR ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ */
+/*
+ * HISTORY
+ * $Log: second_syscalls.s,v $
+# Revision 1.1.1.2  1995/03/23  01:16:29  law
+# lites-950323 from jvh.
+#
+ */
+/* 
+ *	File:	i386/second_syscalls.s
+ *	Author:	Johannes Helander, Helsinki University of Technology, 1994.
+ *	Date:	June 1994
+ *
+ *	system calls needed by second server to access the
+ *	primary server via unix system calls.
+ *
+ *	errno is not used by the server so don't bother with it.
+ */
+
+#include <i386/asm.h>
+#include <sys/syscall.h>
+
+#ifdef __ELF__	/* affects underscores only */
+
+#define kernel_trap(trap_name,trap_number,number_args) \
+	.globl trap_name; \
+trap_name : \
+	movl	$ trap_number,%eax; \
+	SVC; \
+	jc 1f; \
+	ret; \
+1:	movl $-1,%eax; \
+	ret;
+
+#else /* __ELF__ */
+
+#define kernel_trap(trap_name,trap_number,number_args) \
+	.globl _ ## trap_name; \
+_ ## trap_name : \
+	movl	$ trap_number,%eax; \
+	SVC; \
+	jc 1f; \
+	ret; \
+1:	movl $-1,%eax; \
+	ret;
+
+#endif /* __ELF__ */
+
+kernel_trap(second_open, SYS_open, 3)
+kernel_trap(second_fstat, SYS_fstat, 3)
+kernel_trap(second_access, SYS_access, 3)
+kernel_trap(second_lseek, SYS_lseek, 2)
+kernel_trap(second_write, SYS_write, 3)
+kernel_trap(second_read, SYS_read, 3)
+kernel_trap(second_close, SYS_close, 1)
+kernel_trap(second_ioctl, SYS_ioctl, 3)
+kernel_trap(second_sigvec, SYS_sigvec, 3)
+kernel_trap(second__exit, SYS_exit, 1)

--- a/src-lites-1.1-2025/server/x86_64/serv_machdep.c
+++ b/src-lites-1.1-2025/server/x86_64/serv_machdep.c
@@ -1,0 +1,299 @@
+/* 
+ * Mach Operating System
+ * Copyright (c) 1992 Carnegie Mellon University
+ * Copyright (c) 1994 Johannes Helander
+ * All Rights Reserved.
+ * 
+ * Permission to use, copy, modify and distribute this software and its
+ * documentation is hereby granted, provided that both the copyright
+ * notice and this permission notice appear in all copies of the
+ * software, derivative works or modified versions, and any portions
+ * thereof, and that both notices appear in supporting documentation.
+ * 
+ * CARNEGIE MELLON AND JOHANNES HELANDER ALLOW FREE USE OF THIS
+ * SOFTWARE IN ITS "AS IS" CONDITION.  CARNEGIE MELLON AND JOHANNES
+ * HELANDER DISCLAIM ANY LIABILITY OF ANY KIND FOR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+ */
+/*
+ * HISTORY
+ * $Log: serv_machdep.c,v $
+ * Revision 1.4  1995/08/29  19:48:18  mike
+ * don't need include of x86_64/eflags.h anymore
+ *
+ * Revision 1.3  1995/08/29  19:36:49  mike
+ * Init ts.efl to 0 instead of EFL_USER_SET (those bits are always set by
+ * the kernel anyway)
+ *
+ * Revision 1.2  1995/08/10  23:31:28  gback
+ * fixed pagemove so it a) handles not page-aligned pages (!?) using bcopy
+ * and so that it b) panics on an error.
+ *
+ * Revision 1.1.1.1  1995/03/02  21:49:43  mike
+ * Initial Lites release from hut.fi
+ *
+ */
+/*
+ *	Machine-dependent routines evicted from other BSD
+ *	files.
+ */
+
+/*-
+ * Copyright (c) 1982, 1986, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * the Systems Programming Group of the University of Utah Computer
+ * Science Department, and William Jolitz.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+
+#include <serv/server_defs.h>
+#include <sys/exec_file.h>	/* for struct exec_load_info */
+#include <sys/param.h>
+#include <sys/proc.h>
+#include <sys/user.h>
+#include <sys/wait.h>
+#include <sys/uio.h>
+#include <sys/exec.h>
+#include <sys/systm.h>		/* boothowto */
+#include <sys/parallel.h>
+#include <sys/syscall.h>
+#include <sys/namei.h>
+#include <sys/vnode.h>
+
+void set_arg_addr(arg_size,
+	     arg_start_p,
+	     arg_size_p)
+	u_int		arg_size;
+	vm_offset_t	*arg_start_p;
+	vm_size_t	*arg_size_p;
+{
+	/*
+	 * Round arg size to fullwords
+	 */
+	arg_size = (arg_size + NBPW-1) & ~(NBPW - 1);
+
+	/*
+	 * Put argument list at top of stack.
+	 */
+	*arg_start_p = USRSTACK - arg_size;
+	*arg_size_p = arg_size;
+}
+
+/*
+ * Set up the process' registers to start the emulator - duplicate
+ * what execve() in the emulator would do.
+ */
+void set_emulator_state(
+	struct proc		*p,
+	struct exec_load_info	*li)
+{
+    struct x86_thread_state64	ts;
+    unsigned int		count;
+    kern_return_t ret;
+
+    /*
+     * Read the registers first, to get the correct
+     * segments.
+     */
+    count = X86_THREAD_STATE64_COUNT;
+    if ((ret=thread_get_state(p->p_thread,
+			      X86_THREAD_STATE64,
+			      (thread_state_t)&ts,
+			      &count)) != KERN_SUCCESS)
+	panic("set_emulator_state",ret);
+    ts.eip = li->pc;
+    ts.uesp = li->sp;
+    ts.efl = 0;
+    ts.ebx = li->zero_start;
+    ts.edi = li->zero_count;
+
+    if ((ret=thread_set_state(p->p_thread,
+			      X86_THREAD_STATE64,
+			      (thread_state_t)&ts,
+			      X86_THREAD_STATE64_COUNT)) != KERN_SUCCESS)
+	panic("set_emulator_state",ret);
+}
+
+/*
+ * Do weird things to the first process' address space before loading
+ * the emulator.
+ */
+void
+emul_init_process(p)
+	struct proc	*p;
+{
+	/*
+	 * Clear out the entire address space.
+	 */
+	(void) vm_deallocate(p->p_task,
+			VM_MIN_ADDRESS,
+			(vm_size_t)(VM_MAX_ADDRESS - VM_MIN_ADDRESS));
+
+}
+
+void sigreturn()
+{
+    panic("sigreturn - MiG interface");
+}
+void osigcleanup()
+{
+    panic("osigcleanup - MiG interface");
+}
+	
+/*
+ * Clone the parent's registers into the child thread for fork.
+ */
+boolean_t
+thread_dup(child_thread, new_state, new_state_count, parent_pid, rc)
+	thread_t	child_thread;
+	thread_state_t	new_state;
+	unsigned int	new_state_count;
+	int		parent_pid, rc;
+{
+	struct x86_thread_state64 *regs = (struct x86_thread_state64 *)new_state;
+
+	if (new_state_count != X86_THREAD_STATE64_COUNT)
+	    return (FALSE);
+
+	regs->eax = parent_pid;
+	regs->edx = rc;
+
+	(void) thread_set_state(child_thread, X86_THREAD_STATE64,
+				new_state, new_state_count);
+	return (TRUE);
+}
+
+/* 
+ * For sysctl and namei macros
+ */
+char machine[] = "x86_64";
+char atsys[] = "x86_64_lites";
+
+/*
+ * From lite x86_64/machdep.c
+ */
+boolean_t msgbufmapped = FALSE;		/* set when safe to use msgbuf */
+
+mach_error_t cpu_sysctl(
+	int *name,
+	u_int namelen,
+	void *oldp,
+	size_t *oldlenp,
+	void *newp,
+	size_t newlen,
+	struct proc *p)
+{
+
+	/* all sysctl names at this level are terminal */
+	if (namelen != 1)
+		return (ENOTDIR);		/* overloaded */
+
+	switch (name[0]) {
+#ifdef notyet
+	case CPU_CONSDEV:
+		return (sysctl_rdstruct(oldp, oldlenp, newp, &cn_tty->t_dev,
+		    sizeof cn_tty->t_dev));
+#endif
+	default:
+		return (EOPNOTSUPP);
+	}
+	/* NOTREACHED */
+}
+
+mach_error_t
+copystr(void *fromaddr, void *toaddr, u_int maxlength, u_int *lencopied)
+{
+	u_int tally;
+
+	tally = 0;
+	while (maxlength--) {
+		*(u_char *)toaddr = *(u_char *)fromaddr++;
+		tally++;
+		if (*(u_char *)toaddr++ == 0) {
+			if(lencopied) *lencopied = tally;
+			return(0);
+		}
+	}
+	if(lencopied) *lencopied = tally;
+	return(ENAMETOOLONG);
+}
+
+/* 
+ * From lite x86_64/vm_machdep.c
+ */
+/*
+ * Dump the machine specific header information at the start of a core dump.
+ */
+mach_error_t cpu_coredump(p, vp, cred)
+	struct proc *p;
+	struct vnode *vp;
+	struct ucred *cred;
+{
+
+	return vn_rdwr(UIO_WRITE, vp, (caddr_t) p->p_addr, ctob(UPAGES),
+		       (off_t)0, UIO_SYSSPACE, IO_NODELOCKED|IO_UNIT,
+		       cred, (int *)NULL, p);
+}
+
+/*
+ * Move pages from one kernel virtual address to another.
+ * Both addresses are assumed to reside in the Sysmap,
+ * and size must be a multiple of CLSIZE.
+ */
+void pagemove(
+	caddr_t from,
+	caddr_t to,
+	int size)
+{
+	kern_return_t kr = KERN_SUCCESS;
+
+	if(size % PAGE_SIZE || (int)from % PAGE_SIZE) 
+		bcopy(from, to, size);
+	else
+		kr = vm_write(mach_task_self(), (vm_offset_t) to,
+		      (vm_offset_t) from, size);
+
+	if(kr != KERN_SUCCESS) 
+		panic("pagemove(from: %x, to: %x, size %d failed !\n",
+			from, to, size);
+
+	assert(kr == KERN_SUCCESS);
+#if 0
+	/* The mapping should stay. So the old junk stays around ... */
+	/* There must be better ways to handle this whole thing on Mach... */
+	kr = vm_deallocate(mach_task_self(), from, size);
+	assert(kr == KERN_SUCCESS);
+#endif
+}
+


### PR DESCRIPTION
## Summary
- duplicate i386 headers and server code for a new `x86_64` platform
- implement 64-bit versions of ext2fs bit operations
- let `target_cpu` accept `x86_64` objects in liblites

## Testing
- `make -f Makefile.new` *(fails: `build/lites-1.1.u3/server`: No such file or directory)*