### PR TITLE
Refactor remaining K&R definitions

### DIFF
--- a/src-lites-1.1-2025/server/serv/device_utils.c
+++ b/src-lites-1.1-2025/server/serv/device_utils.c
@@ -165,8 +165,7 @@ dev_number_hash_lookup(xdev_t dev)
  * Map kernel device error codes to BSD error numbers.
  */
 int
-dev_error_to_errno(err)
-	int	err;
+dev_error_to_errno(int err)
 {
 	/* Unnecessary: the emulator does the mapping */
 	return err;

--- a/src-lites-1.1-2025/server/serv/disk_io.c
+++ b/src-lites-1.1-2025/server/serv/disk_io.c
@@ -263,8 +263,7 @@ mach_error_t disk_ioctl(
 }
 
 mach_port_t
-disk_port(dev)
-	dev_t	dev;
+disk_port(dev_t dev)
 {
 	return (disk_port_lookup(dev));
 }

--- a/src-lites-1.1-2025/server/serv/ether_io.c
+++ b/src-lites-1.1-2025/server/serv/ether_io.c
@@ -200,8 +200,7 @@ zone_t	net_msg_zone;
 #if 1
 /* Called by MFREE etc. */
 void
-net_input_dispose(msg)
-	char *	msg;
+net_input_dispose(char *msg)
 {
 	zfree(net_msg_zone, (vm_offset_t)msg);
 }
@@ -387,10 +386,7 @@ if(debug_netcode) {
 
 /*ARGSUSED*/
 kern_return_t
-ether_write_reply(ifp_p, return_code, count)
-	char *		ifp_p;
-	kern_return_t	return_code;
-	unsigned int	count;
+ether_write_reply(char *ifp_p, kern_return_t return_code, unsigned int count)
 {
 	panic("ether_write_reply called");
 	return EOPNOTSUPP;
@@ -471,8 +467,7 @@ void ether_error()
  * Name points to the full device name (including unit number).
  */
 struct ifnet *
-iface_find(name)
-	char		*name;
+iface_find(char *name)
 {
 	register struct ifnet	*ifp;
 	register struct ether_softc *es;

--- a/src-lites-1.1-2025/server/serv/gprof_support.c
+++ b/src-lites-1.1-2025/server/serv/gprof_support.c
@@ -99,8 +99,7 @@ sampled_pc_t gprof_pc_samples[512];
  * Memory allocator for callarcs.
  */
 void
-gprof_callarc_get(n)
-	int n;			/* this many callarcs */
+gprof_callarc_get(int n)			/* this many callarcs */
 {
     kern_return_t kr;
     vm_address_t page;
@@ -305,8 +304,7 @@ mcount_done:
  */
 /*ARGSUSED*/
 int
-gprof_take_samples(arg)
-	caddr_t arg;
+gprof_take_samples(caddr_t arg)
 {
     kern_return_t kr;
     int samplecnt, i;
@@ -417,10 +415,7 @@ gprof_stop_profiling()
  */
 
 kern_return_t
-bsd_mon_switch(proc_port, intr, onoff)
-	mach_port_t	proc_port;
-	boolean_t	*intr;
-	int		*onoff;
+bsd_mon_switch(mach_port_t proc_port, boolean_t *intr, int *onoff)
 {
 	int old_value;
 	kern_return_t kr;
@@ -453,11 +448,7 @@ bsd_mon_switch(proc_port, intr, onoff)
 }
 
 kern_return_t
-bsd_mon_dump(proc_port, intr, mon_data, mon_data_cnt)
-	mach_port_t	proc_port;
-	boolean_t	*intr;
-	char		**mon_data;
-	int		*mon_data_cnt;
+bsd_mon_dump(mach_port_t proc_port, boolean_t *intr, char **mon_data, int *mon_data_cnt)
 {
 	vm_address_t	mon_buffer;
 	vm_size_t	mon_size;

--- a/src-lites-1.1-2025/server/serv/serv_synch.c
+++ b/src-lites-1.1-2025/server/serv/serv_synch.c
@@ -676,8 +676,7 @@ int hzto(tv)
 }
 
 int
-time_to_hz(tv)
-	struct timeval *tv;
+time_to_hz(struct timeval *tv)
 {
 	register long	ticks, sec;
 

--- a/src-lites-1.1-2025/server/serv/synch_prim.c
+++ b/src-lites-1.1-2025/server/serv/synch_prim.c
@@ -446,8 +446,7 @@ int hzto(tv)
 }
 
 int
-time_to_hz(tv)
-	struct timeval *tv;
+time_to_hz(struct timeval *tv)
 {
 	register long	ticks, sec;
 

--- a/src-lites-1.1-2025/server/serv/syscall_subr.c
+++ b/src-lites-1.1-2025/server/serv/syscall_subr.c
@@ -192,10 +192,7 @@ start_server_op(
 }
 
 int
-end_server_op(p, error, interrupt)
-    register int	error;
-    boolean_t	*interrupt;
-    register struct proc *p;
+end_server_op(struct proc *p, int error, boolean_t *interrupt)
 {
 	proc_invocation_t pk;
 	if (p == 0) {

--- a/src-lites-1.1-2025/server/serv/ux_syscall.c
+++ b/src-lites-1.1-2025/server/serv/ux_syscall.c
@@ -58,8 +58,7 @@ extern char	*syscallnames[];
  * Generic system call.
  */
 boolean_t
-ux_generic_server(InHeadP, OutHeadP)
-	mach_msg_header_t *InHeadP, *OutHeadP;
+ux_generic_server(mach_msg_header_t *InHeadP, mach_msg_header_t *OutHeadP)
 {
 	register struct bsd_request	*req = (struct bsd_request *)InHeadP;
 	register struct bsd_reply	*rep = (struct bsd_reply *)OutHeadP;
@@ -309,12 +308,7 @@ ux_generic_server(InHeadP, OutHeadP)
  */
 
 boolean_t
-rpsleep(rsleep, arg1, arg2, mesg1, mesg2)
-int (*rsleep)();
-int arg1;
-int arg2;
-char *mesg1;
-char *mesg2;
+rpsleep(int (*rsleep)(), int arg1, int arg2, char *mesg1, char *mesg2)
 {
     label_t lsave;
     boolean_t ret = TRUE;

--- a/src-lites-1.1-2025/server/serv/vm_glue.c
+++ b/src-lites-1.1-2025/server/serv/vm_glue.c
@@ -195,13 +195,7 @@ int indent = 0;
 
 /*ARGSUSED2*/
 void
-#if __STDC__
 iprintf(const char *fmt, ...)
-#else
-iprintf(fmt /* , va_alist */)
-	char *fmt;
-	/* va_dcl */
-#endif
 {
 	register int i;
 	va_list ap;

--- a/src-lites-1.1-2025/server/serv/vm_syscalls.c
+++ b/src-lites-1.1-2025/server/serv/vm_syscalls.c
@@ -321,8 +321,7 @@ msync(p, uap, retval)
 }
 
 void
-munmapfd(fd)
-	int fd;
+munmapfd(int fd)
 {
 	struct proc *curproc = get_proc();
 #ifdef DEBUG


### PR DESCRIPTION
## Summary
- convert various remaining K&R style definitions in `server/serv` to ANSI style

## Testing
- `make -f Makefile.new -n` *(fails: missing build directories)*