### PR TITLE
Clean up inline keyword redefinitions

### DIFF
--- a/src-lites-1.1-2025/include/sys/cdefs.h
+++ b/src-lites-1.1-2025/include/sys/cdefs.h
@@ -66,7 +66,6 @@
 #define	__inline	inline		/* convert to C++ keyword */
 #else
 #ifndef __GNUC__
-#define	__inline			/* delete GCC keyword */
 #endif /* !__GNUC__ */
 #endif /* !__cplusplus */
 
@@ -77,7 +76,6 @@
 
 #ifndef __GNUC__
 #define	__const				/* delete pseudo-ANSI C keywords */
-#define	__inline
 #define	__signed
 #define	__volatile
 /*
@@ -90,7 +88,6 @@
  */
 #ifndef	NO_ANSI_KEYWORDS
 #define	const				/* delete ANSI C keywords */
-#define	inline
 #define	signed
 #define	volatile
 #endif

--- a/src-lites-1.1-2025/server/net/bpf.c
+++ b/src-lites-1.1-2025/server/net/bpf.c
@@ -45,11 +45,6 @@
 
 #if NBPFILTER > 0
 
-#ifndef __GNUC__
-#define inline
-#else
-#define inline __inline
-#endif
 
 #include <sys/param.h>
 #include <sys/systm.h>


### PR DESCRIPTION
## Summary
- remove inline redefinition from `bpf.c`
- drop obsolete inline macros in `sys/cdefs.h`

## Testing
- `gcc -std=c11 -Isrc-lites-1.1-2025/include /tmp/test_inline.c -o /tmp/test_inline`