### PR TITLE
Enable PowerPC cross-builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(lites LANGUAGES C)
-set(CMAKE_C_STANDARD 23)
+set(CMAKE_C_STANDARD 11)
 
-# Allow selecting the build architecture with -DARCH=i686 or ARCH
-set(ARCH "$ENV{ARCH}" CACHE STRING "Target architecture (x86_64 or i686)")
+# Allow selecting the build architecture with -DARCH=i686, ARCH=ppc64 or ARCH=ppc
+set(ARCH "$ENV{ARCH}" CACHE STRING "Target architecture (x86_64, i686, ppc64 or ppc)")
 set(CFLAGS "$ENV{CFLAGS}" CACHE STRING "Additional compiler flags")
 set(LDFLAGS "$ENV{LDFLAGS}" CACHE STRING "Additional linker flags")
 
@@ -16,6 +16,14 @@ if(ARCH STREQUAL "i686")
 elseif(ARCH STREQUAL "x86_64")
     add_compile_options(-m64)
     add_link_options(-m64)
+elseif(ARCH STREQUAL "ppc")
+    set(CMAKE_SYSTEM_NAME Linux)
+    set(CMAKE_C_COMPILER powerpc-linux-gnu-gcc)
+    set(CMAKE_CXX_COMPILER powerpc-linux-gnu-g++)
+elseif(ARCH STREQUAL "ppc64")
+    set(CMAKE_SYSTEM_NAME Linux)
+    set(CMAKE_C_COMPILER powerpc64-linux-gnu-gcc)
+    set(CMAKE_CXX_COMPILER powerpc64-linux-gnu-g++)
 endif()
 
 # Optionally allow building out-of-tree archives.
@@ -32,14 +40,14 @@ if(EXISTS "${LITES_SRC_DIR}")
     target_include_directories(lites_server PRIVATE
         "${LITES_SRC_DIR}/include"
         "${LITES_SRC_DIR}/server")
-    target_compile_options(lites_server PRIVATE ${CFLAGS})
+    target_compile_options(lites_server PRIVATE -std=c2x ${CFLAGS})
     target_link_options(lites_server PRIVATE ${LDFLAGS})
 
     add_executable(lites_emulator ${EMULATOR_SRC})
     target_include_directories(lites_emulator PRIVATE
         "${LITES_SRC_DIR}/include"
         "${LITES_SRC_DIR}/emulator")
-    target_compile_options(lites_emulator PRIVATE ${CFLAGS})
+    target_compile_options(lites_emulator PRIVATE -std=c2x ${CFLAGS})
     target_link_options(lites_emulator PRIVATE ${LDFLAGS})
 endif()
 

--- a/Makefile.new
+++ b/Makefile.new
@@ -1,20 +1,27 @@
 SRCDIR := build/lites-1.1.u3
 CC ?= gcc
 
-# Target architecture (x86_64 or i686).  Determines -m32/-m64 flags.
+# Target architecture (x86_64, i686, ppc64 or ppc).  Determines -m32/-m64 flags
+# or cross-compilers where appropriate.
 ARCH ?= x86_64
 
 # Base optimisation flags
-CFLAGS ?= -O2 -std=c23
+CFLAGS ?= -O2 -std=c2x
 
 
-# Translate ARCH into compiler options
+# Translate ARCH into compiler options and cross-compilers
 ifeq ($(ARCH),i686)
 CFLAGS += -m32
 LDFLAGS += -m32
 else ifeq ($(ARCH),x86_64)
 CFLAGS += -m64
 LDFLAGS += -m64
+else ifeq ($(ARCH),ppc)
+CC = powerpc-linux-gnu-gcc
+CFLAGS += -m32
+else ifeq ($(ARCH),ppc64)
+CC = powerpc64-linux-gnu-gcc
+CFLAGS += -m64
 endif
 
 SERVER_SRC := $(shell find $(SRCDIR)/server -name '*.c')
@@ -23,11 +30,11 @@ EMULATOR_SRC := $(shell find $(SRCDIR)/emulator -name '*.c')
 all: lites_server lites_emulator
 
 lites_server: $(SERVER_SRC)
-$(CC) $(CFLAGS) -I$(SRCDIR)/include -I$(SRCDIR)/server $^ $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) -I$(SRCDIR)/include -I$(SRCDIR)/server $^ $(LDFLAGS) -o $@
 
 lites_emulator: $(EMULATOR_SRC)
-$(CC) $(CFLAGS) -I$(SRCDIR)/include -I$(SRCDIR)/emulator $^ $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) -I$(SRCDIR)/include -I$(SRCDIR)/emulator $^ $(LDFLAGS) -o $@
 
 clean:
-rm -f lites_server lites_emulator
+	rm -f lites_server lites_emulator
 

--- a/README.md
+++ b/README.md
@@ -54,15 +54,17 @@ make
 
 For the modernized build system in this repository you can also use
 `Makefile.new` or the provided CMake files.  Both recognise an optional
-`ARCH` variable, selecting between 64‑bit (`ARCH=x86_64`, default) and
-32‑bit (`ARCH=i686`) builds.  Examples:
+`ARCH` variable, selecting between 64‑bit (`ARCH=x86_64`, default), 32‑bit
+(`ARCH=i686`) and PowerPC (`ARCH=ppc64` or `ARCH=ppc`) builds.  Examples:
 
 ```sh
 # Using the makefile
 make -f Makefile.new ARCH=i686
+make -f Makefile.new ARCH=ppc64
 
 # Using CMake
 cmake -B build -DARCH=i686
+cmake -B build -DARCH=ppc64
 cmake --build build
 ```
 

--- a/setup.sh
+++ b/setup.sh
@@ -62,6 +62,7 @@ for pkg in \
   bcc bin86 elks-libc \
   gcc-ia64-linux-gnu g++-ia64-linux-gnu \
   gcc-i686-linux-gnu g++-i686-linux-gnu \
+  libc6-dev-i386 \
   gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
   gcc-arm-linux-gnueabi g++-arm-linux-gnueabi \
   gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
@@ -69,6 +70,7 @@ for pkg in \
   gcc-powerpc-linux-gnu g++-powerpc-linux-gnu \
   gcc-powerpc64-linux-gnu g++-powerpc64-linux-gnu \
   gcc-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu \
+  libc6-dev-powerpc-cross libc6-dev-ppc64-cross \
   gcc-m68k-linux-gnu g++-m68k-linux-gnu \
   gcc-hppa-linux-gnu g++-hppa-linux-gnu \
   gcc-loongarch64-linux-gnu g++-loongarch64-linux-gnu \


### PR DESCRIPTION
## Summary
- add PowerPC cross-build support in CMake and Makefile
- fix missing tabs in Makefile
- mention PPC in README build instructions
- extend setup.sh with extra cross-compilers and libs

## Testing
- `make -f Makefile.new ARCH=x86_64` *(fails: missing headers)*