### PR TITLE
Remove old register keywords and tidy spacing

### DIFF
--- a/src-lites-1.1-2025/include/i386/param.h
+++ b/src-lites-1.1-2025/include/i386/param.h
@@ -102,7 +102,7 @@
 
 /*
  * Size of kernel malloc arena in CLBYTES-sized logical pages
- */ 
+ */
 #ifndef NKMEMCLUSTERS
 #define	NKMEMCLUSTERS	(2048*1024/CLBYTES)
 #endif
@@ -147,7 +147,7 @@
 
 #ifndef KERNEL
 /* DELAY is in locore.s for the kernel */
-#define	DELAY(n)	{ register int N = (n); while (--N > 0); }
+#define	DELAY(n)	do { volatile int N = (n); while (--N > 0); } while (0)
 #endif
 
 /* LITES stuff */

--- a/src-lites-1.1-2025/include/ns532/param.h
+++ b/src-lites-1.1-2025/include/ns532/param.h
@@ -97,7 +97,7 @@
 
 /*
  * Size of kernel malloc arena in CLBYTES-sized logical pages
- */ 
+ */
 #ifndef NKMEMCLUSTERS
 #define	NKMEMCLUSTERS	(2048*1024/CLBYTES)
 #endif
@@ -142,7 +142,7 @@
 
 #ifndef KERNEL
 /* DELAY is in locore.s for the kernel */
-#define	DELAY(n)	{ register int N = (n); while (--N > 0); }
+#define	DELAY(n)	do { volatile int N = (n); while (--N > 0); } while (0)
 #endif
 
 /* LITES stuff */

--- a/src-lites-1.1-2025/include/parisc/param.h
+++ b/src-lites-1.1-2025/include/parisc/param.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 1994, The University of Utah and
  * the Computer Systems Laboratory at the University of Utah (CSL).
  *
@@ -139,7 +139,7 @@
 #define	PC_PRIV_USER	3
 #define	USERMODE(pc)	(((pc) & PC_PRIV_MASK) != PC_PRIV_KERN)
 
-#define	DELAY(n)	{ register int N = (n); while (--N > 0); }
+#define	DELAY(n)	do { volatile int N = (n); while (--N > 0); } while (0)
 
 #ifdef HPUXCOMPAT
 /*

--- a/src-lites-1.1-2025/include/sys/cmu_queue.h
+++ b/src-lites-1.1-2025/include/sys/cmu_queue.h
@@ -1,15 +1,15 @@
-/* 
+/*
  * Mach Operating System
  * Copyright (c) 1994,1993,1991,1990,1989,1988,1987 Carnegie Mellon University
  * Copyright (c) 1994 Johannes Helander
  * All Rights Reserved.
- * 
+ *
  * Permission to use, copy, modify and distribute this software and its
  * documentation is hereby granted, provided that both the copyright
  * notice and this permission notice appear in all copies of the
  * software, derivative works or modified versions, and any portions
  * thereof, and that both notices appear in supporting documentation.
- * 
+ *
  * CARNEGIE MELLON AND JOHANNES HELANDER ALLOW FREE USE OF THIS
  * SOFTWARE IN ITS "AS IS" CONDITION.  CARNEGIE MELLON AND JOHANNES
  * HELANDER DISCLAIM ANY LIABILITY OF ANY KIND FOR ANY DAMAGES
@@ -90,7 +90,7 @@ typedef	struct queue_entry	*queue_entry_t;
  */
 #define	queue_init(q)	((q)->next = (q)->prev = q)
 
-/* 
+/*
  * Fill queue chain element with a value known to be invalid.
  */
 #define queue_chain_init(qc) ((qc)->next = (qc)->prev = (void *)(-1L))
@@ -178,7 +178,7 @@ typedef	struct queue_entry	*queue_entry_t;
  */
 #define queue_enter(head, elt, type, field)			\
 { 								\
-	register queue_entry_t prev;				\
+	queue_entry_t prev;				\
 								\
 	prev = (head)->prev;					\
 	if ((head) == prev) {					\
@@ -205,7 +205,7 @@ typedef	struct queue_entry	*queue_entry_t;
  */
 #define queue_enter_first(head, elt, type, field)		\
 { 								\
-	register queue_entry_t next;				\
+	queue_entry_t next;				\
 								\
 	next = (head)->next;					\
 	if ((head) == next) {					\
@@ -242,7 +242,7 @@ typedef	struct queue_entry	*queue_entry_t;
  */
 #define	queue_enter_after(head, elt, newe, type, field)		\
 {								\
-	register queue_entry_t	next;				\
+	queue_entry_t	next;				\
 								\
 	next = (elt)->field.next;				\
 								\
@@ -267,7 +267,7 @@ typedef	struct queue_entry	*queue_entry_t;
  */
 #define	queue_enter_before(head, elt, newe, type, field)	\
 {								\
-	register queue_entry_t	prev;				\
+	queue_entry_t	prev;				\
 								\
 	prev = (elt)->field.prev;				\
 								\
@@ -292,7 +292,7 @@ typedef	struct queue_entry	*queue_entry_t;
  */
 #define	queue_remove(head, elt, type, field)			\
 {								\
-	register queue_entry_t	next, prev;			\
+	queue_entry_t	next, prev;			\
 								\
 	next = (elt)->field.next;				\
 	prev = (elt)->field.prev;				\
@@ -319,7 +319,7 @@ typedef	struct queue_entry	*queue_entry_t;
  */
 #define	queue_remove_first(head, entry, type, field)		\
 {								\
-	register queue_entry_t	next;				\
+	queue_entry_t	next;				\
 								\
 	(entry) = (type) ((head)->next);			\
 	next = (entry)->field.next;				\
@@ -342,7 +342,7 @@ typedef	struct queue_entry	*queue_entry_t;
  */
 #define	queue_remove_last(head, entry, type, field)		\
 {								\
-	register queue_entry_t	prev;				\
+	queue_entry_t	prev;				\
 								\
 	(entry) = (type) ((head)->prev);			\
 	prev = (entry)->field.prev;				\

--- a/src-lites-1.1-2025/include/sys/zalloc.h
+++ b/src-lites-1.1-2025/include/sys/zalloc.h
@@ -1,26 +1,26 @@
-/* 
+/*
  * Mach Operating System
  * Copyright (c) 1992 Carnegie Mellon University
  * All Rights Reserved.
- * 
+ *
  * Permission to use, copy, modify and distribute this software and its
  * documentation is hereby granted, provided that both the copyright
  * notice and this permission notice appear in all copies of the
  * software, derivative works or modified versions, and any portions
  * thereof, and that both notices appear in supporting documentation.
- * 
+ *
  * CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
  * CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
  * ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
- * 
+ *
  * Carnegie Mellon requests users of this software to return to
- * 
+ *
  *  Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
  *  School of Computer Science
  *  Carnegie Mellon University
  *  Pittsburgh PA 15213-3890
- * 
- * any improvements or extensions that they make and grant Carnegie Mellon 
+ *
+ * any improvements or extensions that they make and grant Carnegie Mellon
  * the rights to redistribute these changes.
  */
 /*
@@ -34,7 +34,7 @@
  *
  * Revision 2.1  92/04/21  17:15:27  rwd
  * BSDSS
- * 
+ *
  *
  */
 
@@ -75,7 +75,7 @@ typedef struct zone {
 
 vm_offset_t	zalloc(zone_t zone);
 vm_offset_t	zget(zone_t zone);
-zone_t		zinit(vm_size_t size, vm_size_t max, vm_size_t alloc, 
+zone_t		zinit(vm_size_t size, vm_size_t max, vm_size_t alloc,
 		      boolean_t pageable, char *name);
 void		zfree(zone_t zone, vm_offset_t elem);
 void		zchange(zone_t zone, boolean_t pageable, boolean_t sleepable,
@@ -99,7 +99,7 @@ void		zchange(zone_t zone, boolean_t pageable, boolean_t sleepable,
 
 #define ZFREE(zone, element)		\
 	MACRO_BEGIN			\
-	register zone_t	z = (zone);	\
+	zone_t	z = (zone);	\
 					\
 	mutex_lock(&z->lock);		\
 	ADD_TO_ZONE(z, element);	\
@@ -108,7 +108,7 @@ void		zchange(zone_t zone, boolean_t pageable, boolean_t sleepable,
 
 #define	ZALLOC(zone, ret, type)			\
 	MACRO_BEGIN				\
-	register zone_t	z = (zone);		\
+	zone_t	z = (zone);		\
 						\
 	mutex_lock(&z->lock);			\
 	REMOVE_FROM_ZONE(zone, ret, type);	\
@@ -119,7 +119,7 @@ void		zchange(zone_t zone, boolean_t pageable, boolean_t sleepable,
 
 #define	ZGET(zone, ret, type)			\
 	MACRO_BEGIN				\
-	register zone_t	z = (zone);		\
+	zone_t	z = (zone);		\
 						\
 	mutex_lock(&z->lock);			\
 	REMOVE_FROM_ZONE(zone, ret, type);	\

--- a/src-lites-1.1-2025/include/x86_64/param.h
+++ b/src-lites-1.1-2025/include/x86_64/param.h
@@ -102,7 +102,7 @@
 
 /*
  * Size of kernel malloc arena in CLBYTES-sized logical pages
- */ 
+ */
 #ifndef NKMEMCLUSTERS
 #define	NKMEMCLUSTERS	(2048*1024/CLBYTES)
 #endif
@@ -147,7 +147,7 @@
 
 #ifndef KERNEL
 /* DELAY is in locore.s for the kernel */
-#define	DELAY(n)	{ register int N = (n); while (--N > 0); }
+#define	DELAY(n)	do { volatile int N = (n); while (--N > 0); } while (0)
 #endif
 
 /* LITES stuff */

--- a/src-lites-1.1-2025/server/serv/zalloc.c
+++ b/src-lites-1.1-2025/server/serv/zalloc.c
@@ -1,15 +1,15 @@
-/* 
+/*
  * Mach Operating System
  * Copyright (c) 1992 Carnegie Mellon University
  * Copyright (c) 1994 Johannes Helander
  * All Rights Reserved.
- * 
+ *
  * Permission to use, copy, modify and distribute this software and its
  * documentation is hereby granted, provided that both the copyright
  * notice and this permission notice appear in all copies of the
  * software, derivative works or modified versions, and any portions
  * thereof, and that both notices appear in supporting documentation.
- * 
+ *
  * CARNEGIE MELLON AND JOHANNES HELANDER ALLOW FREE USE OF THIS
  * SOFTWARE IN ITS "AS IS" CONDITION.  CARNEGIE MELLON AND JOHANNES
  * HELANDER DISCLAIM ANY LIABILITY OF ANY KIND FOR ANY DAMAGES
@@ -22,7 +22,7 @@
  * Initial Lites release from hut.fi
  *
  */
-/* 
+/*
  *	File:	serv/zalloc.c
  *	Authors:
  *	Randall Dean, Carnegie Mellon University, 1992.
@@ -92,7 +92,7 @@ zone_t zinit(size, max, alloc, pageable, name)
 	boolean_t	pageable;	/* is this zone pageable? */
 	char		*name;		/* a name for the zone */
 {
-	register zone_t		z;
+	zone_t		z;
 
 	if (zone_zone == ZONE_NULL)
 		z = (zone_t) zdata;
@@ -136,11 +136,11 @@ zone_t zinit(size, max, alloc, pageable, name)
  *	Cram the given memory into the specified zone.
  */
 void zcram(zone, newmem, size)
-	register zone_t		zone;
+	zone_t		zone;
 	vm_offset_t		newmem;
 	vm_size_t		size;
 {
-	register vm_size_t	elem_size;
+	vm_size_t	elem_size;
 
 	elem_size = zone->elem_size;
 
@@ -159,9 +159,9 @@ void zcram(zone, newmem, size)
  *	zalloc returns an element from the specified zone.
  */
 vm_offset_t zalloc(zone)
-	register zone_t	zone;
+	zone_t	zone;
 {
-	register vm_offset_t	addr;
+	vm_offset_t	addr;
 
 	if (zone == ZONE_NULL)
 		panic ("zalloc: null zone");
@@ -221,9 +221,9 @@ vm_offset_t zalloc(zone)
  *	processing an interrupt).
  */
 vm_offset_t zget(zone)
-	register zone_t	zone;
+	zone_t	zone;
 {
-	register vm_offset_t	addr;
+	vm_offset_t	addr;
 
 	if (zone == ZONE_NULL)
 		panic ("zalloc: null zone");
@@ -236,7 +236,7 @@ vm_offset_t zget(zone)
 }
 
 void zfree(zone, elem)
-	register zone_t	zone;
+	zone_t	zone;
 	vm_offset_t	elem;
 {
 	lock_zone(zone);

--- a/src-lites-1.1-2025/server/x86_64/conf.c
+++ b/src-lites-1.1-2025/server/x86_64/conf.c
@@ -1,16 +1,16 @@
-/* 
+/*
  * Mach Operating System
  * Copyright (c) 1992 Carnegie Mellon University
  * Copyright (c) 1994 Johannes Helander
  * Copyright (c) 1994 Timo Rinne
  * All Rights Reserved.
- * 
+ *
  * Permission to use, copy, modify and distribute this software and its
  * documentation is hereby granted, provided that both the copyright
  * notice and this permission notice appear in all copies of the
  * software, derivative works or modified versions, and any portions
  * thereof, and that both notices appear in supporting documentation.
- * 
+ *
  * CARNEGIE MELLON AND JOHANNES HELANDER AND TIMO RINNE ALLOW FREE USE
  * OF THIS SOFTWARE IN ITS "AS IS" CONDITION.  CARNEGIE MELLON AND
  * JOHANNES HELANDER AND TIMO RINNE DISCLAIM ANY LIABILITY OF ANY KIND
@@ -23,7 +23,7 @@
  * lites-950323 from jvh.
  *
  */
-/* 
+/*
  *	File:	 x86_64/server/conf.c
  *	Authors:
  *	Randall Dean, Carnegie Mellon University, 1992.
@@ -328,7 +328,7 @@ int isa_disk_ioctl(
 {
 	mach_port_t		device_port = disk_port(dev);
 	mach_msg_type_number_t	count;
-	register int		error;
+	int		error;
 
 	switch (cmd) {
 #if !OSFMACH3
@@ -451,7 +451,7 @@ int kbd_ioctl(
 	int flag,
 	struct proc *p)
 {
-	/* 
+	/*
 	 * XXX a newer version of this stuff is now in char_ioctl
 	 * XXX which is not the proper place
 	 */


### PR DESCRIPTION
## Summary
- modernize DELAY macro across architectures
- drop `register` from queue and zone macros
- trim trailing whitespace in updated files
- remove register qualifiers in the server sources

## Testing
- `make -f Makefile.new ARCH=x86_64` *(fails: find: ‘build/lites-1.1.u3/server’: No such file or directory)*