### PR TITLE
Fix build path detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,14 +27,23 @@ elseif(ARCH STREQUAL "ppc64")
 endif()
 
 # Optionally allow building out-of-tree archives.
-set(LITES_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build/lites-1.1.u3" CACHE PATH "Extracted lites source")
+# Prefer the modernised tree if present.  Otherwise fall back to an
+# extracted historical archive under build/.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src-lites-1.1-2025")
+    set(_default_src "${CMAKE_CURRENT_SOURCE_DIR}/src-lites-1.1-2025")
+else()
+    set(_default_src "${CMAKE_CURRENT_SOURCE_DIR}/build/lites-1.1.u3")
+endif()
+set(LITES_SRC_DIR "${_default_src}" CACHE PATH "Lites source directory")
 
 # Collect sources for server and emulator if the directory exists
 if(EXISTS "${LITES_SRC_DIR}")
     file(GLOB_RECURSE SERVER_SRC
         "${LITES_SRC_DIR}/server/*.c")
-    file(GLOB_RECURSE EMULATOR_SRC
-        "${LITES_SRC_DIR}/emulator/*.c")
+    if(EXISTS "${LITES_SRC_DIR}/emulator")
+        file(GLOB_RECURSE EMULATOR_SRC
+            "${LITES_SRC_DIR}/emulator/*.c")
+    endif()
 
     add_executable(lites_server ${SERVER_SRC})
     target_include_directories(lites_server PRIVATE
@@ -43,11 +52,13 @@ if(EXISTS "${LITES_SRC_DIR}")
     target_compile_options(lites_server PRIVATE -std=c2x ${CFLAGS})
     target_link_options(lites_server PRIVATE ${LDFLAGS})
 
-    add_executable(lites_emulator ${EMULATOR_SRC})
-    target_include_directories(lites_emulator PRIVATE
-        "${LITES_SRC_DIR}/include"
-        "${LITES_SRC_DIR}/emulator")
-    target_compile_options(lites_emulator PRIVATE -std=c2x ${CFLAGS})
-    target_link_options(lites_emulator PRIVATE ${LDFLAGS})
+    if(EMULATOR_SRC)
+        add_executable(lites_emulator ${EMULATOR_SRC})
+        target_include_directories(lites_emulator PRIVATE
+            "${LITES_SRC_DIR}/include"
+            "${LITES_SRC_DIR}/emulator")
+        target_compile_options(lites_emulator PRIVATE -std=c2x ${CFLAGS})
+        target_link_options(lites_emulator PRIVATE ${LDFLAGS})
+    endif()
 endif()
 

--- a/Makefile.new
+++ b/Makefile.new
@@ -1,4 +1,9 @@
-SRCDIR := build/lites-1.1.u3
+# Prefer the modernised source tree if present
+ifeq ($(wildcard src-lites-1.1-2025),src-lites-1.1-2025)
+SRCDIR ?= src-lites-1.1-2025
+else
+SRCDIR ?= build/lites-1.1.u3
+endif
 CC ?= gcc
 
 # Target architecture (x86_64, i686, ppc64 or ppc).  Determines -m32/-m64 flags
@@ -25,15 +30,24 @@ CFLAGS += -m64
 endif
 
 SERVER_SRC := $(shell find $(SRCDIR)/server -name '*.c')
+ifneq ($(wildcard $(SRCDIR)/emulator),)
 EMULATOR_SRC := $(shell find $(SRCDIR)/emulator -name '*.c')
+endif
 
-all: lites_server lites_emulator
+TARGETS := lites_server
+ifneq ($(EMULATOR_SRC),)
+TARGETS += lites_emulator
+endif
+
+all: $(TARGETS)
 
 lites_server: $(SERVER_SRC)
 	$(CC) $(CFLAGS) -I$(SRCDIR)/include -I$(SRCDIR)/server $^ $(LDFLAGS) -o $@
 
+ifneq ($(EMULATOR_SRC),)
 lites_emulator: $(EMULATOR_SRC)
-	$(CC) $(CFLAGS) -I$(SRCDIR)/include -I$(SRCDIR)/emulator $^ $(LDFLAGS) -o $@
+        $(CC) $(CFLAGS) -I$(SRCDIR)/include -I$(SRCDIR)/emulator $^ $(LDFLAGS) -o $@
+endif
 
 clean:
 	rm -f lites_server lites_emulator

--- a/README.md
+++ b/README.md
@@ -53,18 +53,21 @@ make
 ```
 
 For the modernized build system in this repository you can also use
-`Makefile.new` or the provided CMake files.  Both recognise an optional
-`ARCH` variable, selecting between 64‑bit (`ARCH=x86_64`, default), 32‑bit
-(`ARCH=i686`) and PowerPC (`ARCH=ppc64` or `ARCH=ppc`) builds.  Examples:
+`Makefile.new` or the provided CMake files.  Both automatically build from
+the `src-lites-1.1-2025` directory when it is present.  Set the `SRCDIR` or
+`LITES_SRC_DIR` variables to override this behaviour.  The tools recognise an
+optional `ARCH` variable, selecting between 64‑bit (`ARCH=x86_64`, default),
+32‑bit (`ARCH=i686`) and PowerPC (`ARCH=ppc64` or `ARCH=ppc`) builds.
+Examples:
 
 ```sh
 # Using the makefile
 make -f Makefile.new ARCH=i686
 make -f Makefile.new ARCH=ppc64
 
-# Using CMake
+# Using CMake (optionally override the source directory)
 cmake -B build -DARCH=i686
-cmake -B build -DARCH=ppc64
+cmake -B build -DARCH=ppc64 -DLITES_SRC_DIR=src-lites-1.1-2025
 cmake --build build
 ```
 


### PR DESCRIPTION
## Summary
- detect modern `src-lites-1.1-2025` tree in CMake and Makefile
- make emulator build optional
- document new behavior in README

## Testing
- `make -f Makefile.new` *(fails: `fatal error: compat_43.h: No such file or directory`)*
- `cmake -B build`
- `cmake --build build` *(fails: `fatal error: machine/ansi.h: No such file or directory`)*