### PR TITLE
Fix header includes for builds

### DIFF
--- a/Makefile.new
+++ b/Makefile.new
@@ -30,8 +30,10 @@ CFLAGS += -m64
 endif
 
 SERVER_SRC := $(shell find $(SRCDIR)/server -name '*.c')
+SERVER_INCDIRS := $(shell find $(SRCDIR)/server -type d | sed 's/^/-I/')
 ifneq ($(wildcard $(SRCDIR)/emulator),)
 EMULATOR_SRC := $(shell find $(SRCDIR)/emulator -name '*.c')
+EMULATOR_INCDIRS := $(shell find $(SRCDIR)/emulator -type d | sed 's/^/-I/')
 endif
 
 TARGETS := lites_server
@@ -39,14 +41,21 @@ ifneq ($(EMULATOR_SRC),)
 TARGETS += lites_emulator
 endif
 
-all: $(TARGETS)
+all: prepare $(TARGETS)
+
+prepare:
+	@if [ ! -e $(SRCDIR)/include/machine ]; then \
+	arch_dir=$(ARCH); \
+	[ "$$arch_dir" = "i686" ] && arch_dir=i386; \
+	ln -s $$arch_dir $(SRCDIR)/include/machine; \
+fi
 
 lites_server: $(SERVER_SRC)
-	$(CC) $(CFLAGS) -I$(SRCDIR)/include -I$(SRCDIR)/server $^ $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(SERVER_INCDIRS) $^ $(LDFLAGS) -o $@
 
 ifneq ($(EMULATOR_SRC),)
 lites_emulator: $(EMULATOR_SRC)
-        $(CC) $(CFLAGS) -I$(SRCDIR)/include -I$(SRCDIR)/emulator $^ $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(EMULATOR_INCDIRS) $^ $(LDFLAGS) -o $@
 endif
 
 clean:

--- a/src-lites-1.1-2025/include/diagnostic.h
+++ b/src-lites-1.1-2025/include/diagnostic.h
@@ -1,0 +1,4 @@
+#ifndef _DIAGNOSTIC_H_
+#define _DIAGNOSTIC_H_
+#define DIAGNOSTIC 0
+#endif

--- a/src-lites-1.1-2025/include/eon.h
+++ b/src-lites-1.1-2025/include/eon.h
@@ -1,0 +1,4 @@
+#ifndef _EON_H_
+#define _EON_H_
+#include <netiso/eonvar.h>
+#endif

--- a/src-lites-1.1-2025/include/gateway.h
+++ b/src-lites-1.1-2025/include/gateway.h
@@ -1,0 +1,4 @@
+#ifndef _GATEWAY_H_
+#define _GATEWAY_H_
+/* Stub gateway header */
+#endif

--- a/src-lites-1.1-2025/include/inet.h
+++ b/src-lites-1.1-2025/include/inet.h
@@ -1,0 +1,4 @@
+#ifndef _INET_H_
+#define _INET_H_
+/* Basic network stubs */
+#endif

--- a/src-lites-1.1-2025/include/llc.h
+++ b/src-lites-1.1-2025/include/llc.h
@@ -1,0 +1,4 @@
+#ifndef _LLC_H_
+#define _LLC_H_
+/* Stub LLC header */
+#endif

--- a/src-lites-1.1-2025/include/mrouting.h
+++ b/src-lites-1.1-2025/include/mrouting.h
@@ -1,0 +1,4 @@
+#ifndef _MROUTING_H_
+#define _MROUTING_H_
+/* Stub multicast routing header */
+#endif


### PR DESCRIPTION
## Summary
- modernize Makefile.new to set up architecture header symlink
- recursively include subdirectories when compiling
- add placeholder headers for missing includes

## Testing
- `make -f Makefile.new` *(fails: mach/machine/vm_types.h: No such file or directory)*