### PR TITLE
Add clang-tidy and pre-commit config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+Checks: '-*,clang-analyzer-*'
+WarningsAsErrors: ''
+ExtraArgs: ['-std=c2x']
+ExtraArgsCC: ['-std=c++17']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: local
+    hooks:
+      - id: clang-format
+        name: clang-format
+        entry: clang-format -i
+        language: system
+        files: \.(c|h|cpp|hpp|cc)$
+      - id: clang-tidy-c
+        name: clang-tidy C
+        entry: clang-tidy --extra-arg=-std=c2x
+        language: system
+        types: [c]
+      - id: clang-tidy-cpp
+        name: clang-tidy C++
+        entry: clang-tidy --extra-arg=-std=c++17
+        language: system
+        types: [c++,cpp]

--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ apt-get update -y
 #— core build tools, formatters, analysis, science libs
 for pkg in \
   build-essential gcc g++ clang lld llvm \
-  clang-format uncrustify astyle editorconfig pre-commit \
+  clang-format clang-tidy uncrustify astyle editorconfig pre-commit \
   make bmake ninja-build cmake meson \
   autoconf automake libtool m4 gawk flex bison byacc \
   pkg-config file ca-certificates curl git unzip \


### PR DESCRIPTION
## Summary
- install clang-tidy in the setup script
- add repository pre-commit configuration
- provide a default clang-tidy setup for C23 and C++17

## Testing
- `pre-commit run --files README.md` *(fails: command not found)*
- `meson --version` *(fails: command not found)*
- `clang-tidy --version`