### PR TITLE
Add C23 detection and architecture helpers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
 Checks: '-*,clang-analyzer-*'
 WarningsAsErrors: ''
-ExtraArgs: ['-std=c2x']
+ExtraArgs: ['-std=c23']
 ExtraArgsCC: ['-std=c++17']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         files: \.(c|h|cpp|hpp|cc)$
       - id: clang-tidy-c
         name: clang-tidy C
-        entry: clang-tidy --extra-arg=-std=c2x
+        entry: clang-tidy --extra-arg=-std=c23
         language: system
         types: [c]
       - id: clang-tidy-cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(lites LANGUAGES C)
-set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD 23)
 
-# Allow selecting the build architecture with -DARCH=i686, ARCH=ppc64 or ARCH=ppc
-set(ARCH "$ENV{ARCH}" CACHE STRING "Target architecture (x86_64, i686, ppc64 or ppc)")
+# Allow selecting the build architecture with -DARCH=i686 or ARCH=x86_64
+set(ARCH "$ENV{ARCH}" CACHE STRING "Target architecture (x86_64 or i686)")
 set(CFLAGS "$ENV{CFLAGS}" CACHE STRING "Additional compiler flags")
 set(LDFLAGS "$ENV{LDFLAGS}" CACHE STRING "Additional linker flags")
 
@@ -16,14 +16,14 @@ if(ARCH STREQUAL "i686")
 elseif(ARCH STREQUAL "x86_64")
     add_compile_options(-m64)
     add_link_options(-m64)
-elseif(ARCH STREQUAL "ppc")
-    set(CMAKE_SYSTEM_NAME Linux)
-    set(CMAKE_C_COMPILER powerpc-linux-gnu-gcc)
-    set(CMAKE_CXX_COMPILER powerpc-linux-gnu-g++)
-elseif(ARCH STREQUAL "ppc64")
-    set(CMAKE_SYSTEM_NAME Linux)
-    set(CMAKE_C_COMPILER powerpc64-linux-gnu-gcc)
-    set(CMAKE_CXX_COMPILER powerpc64-linux-gnu-g++)
+endif()
+
+include(CheckCCompilerFlag)
+check_c_compiler_flag(-std=c23 HAS_STD_C23)
+if(HAS_STD_C23)
+    set(C23_FLAG "-std=c23")
+else()
+    set(C23_FLAG "-std=c2x")
 endif()
 
 # Optionally allow building out-of-tree archives.
@@ -49,7 +49,7 @@ if(EXISTS "${LITES_SRC_DIR}")
     target_include_directories(lites_server PRIVATE
         "${LITES_SRC_DIR}/include"
         "${LITES_SRC_DIR}/server")
-    target_compile_options(lites_server PRIVATE -std=c2x ${CFLAGS})
+    target_compile_options(lites_server PRIVATE ${C23_FLAG} ${CFLAGS})
     target_link_options(lites_server PRIVATE ${LDFLAGS})
 
     if(EMULATOR_SRC)
@@ -57,7 +57,7 @@ if(EXISTS "${LITES_SRC_DIR}")
         target_include_directories(lites_emulator PRIVATE
             "${LITES_SRC_DIR}/include"
             "${LITES_SRC_DIR}/emulator")
-        target_compile_options(lites_emulator PRIVATE -std=c2x ${CFLAGS})
+        target_compile_options(lites_emulator PRIVATE ${C23_FLAG} ${CFLAGS})
         target_link_options(lites_emulator PRIVATE ${LDFLAGS})
     endif()
 endif()

--- a/Makefile.new
+++ b/Makefile.new
@@ -6,12 +6,12 @@ SRCDIR ?= build/lites-1.1.u3
 endif
 CC ?= gcc
 
-# Target architecture (x86_64, i686, ppc64 or ppc).  Determines -m32/-m64 flags
-# or cross-compilers where appropriate.
+# Target architecture (x86_64 or i686). Determines -m32/-m64 flags.
 ARCH ?= x86_64
 
 # Base optimisation flags
-CFLAGS ?= -O2 -std=c2x
+C23_FLAG := $(shell $(CC) -std=c23 -E -x c /dev/null >/dev/null 2>&1 && echo -std=c23 || echo -std=c2x)
+CFLAGS ?= -O2 $(C23_FLAG)
 
 
 # Translate ARCH into compiler options and cross-compilers
@@ -21,12 +21,6 @@ LDFLAGS += -m32
 else ifeq ($(ARCH),x86_64)
 CFLAGS += -m64
 LDFLAGS += -m64
-else ifeq ($(ARCH),ppc)
-CC = powerpc-linux-gnu-gcc
-CFLAGS += -m32
-else ifeq ($(ARCH),ppc64)
-CC = powerpc64-linux-gnu-gcc
-CFLAGS += -m64
 endif
 
 SERVER_SRC := $(shell find $(SRCDIR)/server -name '*.c')

--- a/src-lites-1.1-2025/include/c23_arch.h
+++ b/src-lites-1.1-2025/include/c23_arch.h
@@ -1,0 +1,15 @@
+#ifndef LITES_C23_ARCH_H
+#define LITES_C23_ARCH_H
+
+#if defined(__x86_64__) || defined(_M_X64)
+#  define LITES_ARCH_X86_64 1
+#elif defined(__i386__) || defined(_M_IX86)
+#  define LITES_ARCH_I386 1
+#else
+#  error "Unsupported architecture"
+#endif
+
+static_assert(sizeof(void*) == 8 || sizeof(void*) == 4,
+              "Pointer size must be 32 or 64 bits");
+
+#endif /* LITES_C23_ARCH_H */

--- a/src-lites-1.1-2025/server/i386/conf.c
+++ b/src-lites-1.1-2025/server/i386/conf.c
@@ -74,6 +74,7 @@
 
 #include <serv/import_mach.h>
 #include <sys/param.h>
+#include <c23_arch.h>
 #include <sys/systm.h>
 #include <sys/buf.h>	/* for B_TAPE */
 #include <sys/conf.h>

--- a/src-lites-1.1-2025/server/serv/server_init.c
+++ b/src-lites-1.1-2025/server/serv/server_init.c
@@ -50,6 +50,7 @@
 #include <sys/resource.h>
 #include <sys/msgbuf.h>
 #include <sys/user.h>
+#include <c23_arch.h>
 
 #include <serv/syscalltrace.h>
 


### PR DESCRIPTION
## Summary
- add portable `c23_arch.h` header
- include the header in startup code
- detect C23 support in buildsystem
- default Makefile and CMake to x86 targets only
- run clang-tidy in C23 mode

## Testing
- `cmake -S . -B build -DARCH=x86_64 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
- `cmake --build build -j$(nproc)` *(fails: missing headers)*