### PR TITLE
Document toolchain installed by setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,11 @@ cmake --build build
 ```
 
 The optional `setup.sh` script installs a wide range of cross-compilers
-and emulators.  It can be used to reproduce historical build setups, but
-it requires root privileges and network access.
+and emulators along with standard build utilities such as build-essential,
+GCC, clang, llvm, m4, CMake, Ninja and Meson.  It also sets up debugging
+and profiling tools and provides pre-commit support.  Run `pre-commit
+run -a` after editing sources to keep formatting consistent.  The script
+requires root privileges and network access.
 
 Additional notes are kept in [`docs/`](docs/).
 


### PR DESCRIPTION
## Summary
- clarify that setup.sh installs the full build toolchain and pre-commit

## Testing
- `pre-commit run -a` *(fails: command not found)*