### PR TITLE
Fix x86_64 ext2fs header include

### DIFF
--- a/src-lites-1.1-2025/server/ufs/ext2fs/ext2_fs.h
+++ b/src-lites-1.1-2025/server/ufs/ext2fs/ext2_fs.h
@@ -26,7 +26,7 @@
 #if defined(i386) || defined(__i386__)
 #include <i386/types.h>
 #elif defined(__x86_64__)
-#include <i386/types.h> /* TODO: add x86_64 types header */
+#include <x86_64/types.h>
 #else
 #error need processor specific types
 #endif


### PR DESCRIPTION
## Summary
- fix x86_64 include path in ext2fs header

## Testing
- `pre-commit` *(fails: command not found)*
- `apt-get update` *(fails: unable to connect to proxy)*