### PR TITLE
Add x86_64 asm header and update build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,16 +39,20 @@ set(LITES_SRC_DIR "${_default_src}" CACHE PATH "Lites source directory")
 # Collect sources for server and emulator if the directory exists
 if(EXISTS "${LITES_SRC_DIR}")
     file(GLOB_RECURSE SERVER_SRC
-        "${LITES_SRC_DIR}/server/*.c")
+        "${LITES_SRC_DIR}/server/*.c" "${LITES_SRC_DIR}/server/*.s")
     if(EXISTS "${LITES_SRC_DIR}/emulator")
         file(GLOB_RECURSE EMULATOR_SRC
-            "${LITES_SRC_DIR}/emulator/*.c")
+            "${LITES_SRC_DIR}/emulator/*.c" "${LITES_SRC_DIR}/emulator/*.s")
     endif()
 
     add_executable(lites_server ${SERVER_SRC})
     target_include_directories(lites_server PRIVATE
         "${LITES_SRC_DIR}/include"
         "${LITES_SRC_DIR}/server")
+    if(ARCH STREQUAL "x86_64")
+        target_include_directories(lites_server PRIVATE
+            "${LITES_SRC_DIR}/include/x86_64")
+    endif()
     target_compile_options(lites_server PRIVATE ${C23_FLAG} ${CFLAGS})
     target_link_options(lites_server PRIVATE ${LDFLAGS})
 
@@ -57,6 +61,10 @@ if(EXISTS "${LITES_SRC_DIR}")
         target_include_directories(lites_emulator PRIVATE
             "${LITES_SRC_DIR}/include"
             "${LITES_SRC_DIR}/emulator")
+        if(ARCH STREQUAL "x86_64")
+            target_include_directories(lites_emulator PRIVATE
+                "${LITES_SRC_DIR}/include/x86_64")
+        endif()
         target_compile_options(lites_emulator PRIVATE ${C23_FLAG} ${CFLAGS})
         target_link_options(lites_emulator PRIVATE ${LDFLAGS})
     endif()

--- a/Makefile.new
+++ b/Makefile.new
@@ -21,12 +21,13 @@ LDFLAGS += -m32
 else ifeq ($(ARCH),x86_64)
 CFLAGS += -m64
 LDFLAGS += -m64
+ARCH_INCDIR := -I$(SRCDIR)/include/x86_64
 endif
 
-SERVER_SRC := $(shell find $(SRCDIR)/server -name '*.c')
+SERVER_SRC := $(shell find $(SRCDIR)/server -name '*.c' -o -name '*.s')
 SERVER_INCDIRS := $(shell find $(SRCDIR)/server -type d | sed 's/^/-I/')
 ifneq ($(wildcard $(SRCDIR)/emulator),)
-EMULATOR_SRC := $(shell find $(SRCDIR)/emulator -name '*.c')
+EMULATOR_SRC := $(shell find $(SRCDIR)/emulator -name '*.c' -o -name '*.s')
 EMULATOR_INCDIRS := $(shell find $(SRCDIR)/emulator -type d | sed 's/^/-I/')
 endif
 
@@ -45,13 +46,13 @@ prepare:
 fi
 
 lites_server: $(SERVER_SRC)
-	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(SERVER_INCDIRS) $^ $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(SERVER_INCDIRS) $^ $(LDFLAGS) -o $@
 
 ifneq ($(EMULATOR_SRC),)
 lites_emulator: $(EMULATOR_SRC)
-	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(EMULATOR_INCDIRS) $^ $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(EMULATOR_INCDIRS) $^ $(LDFLAGS) -o $@
 endif
-
+	
 clean:
 	rm -f lites_server lites_emulator
 

--- a/src-lites-1.1-2025/include/x86_64/asm.h
+++ b/src-lites-1.1-2025/include/x86_64/asm.h
@@ -1,0 +1,21 @@
+#ifndef _X86_64_ASM_H_
+#define _X86_64_ASM_H_
+
+/* Generic assembly macros modelled after the 4.4BSD i386 header. */
+
+#ifdef __ELF__
+#define _ENTRY(name)    .globl name; .type name,@function; name
+#define _LABEL(name)    name
+#else
+#define _ENTRY(name)    .globl _##name; .type _##name,@function; _##name
+#define _LABEL(name)    _##name
+#endif
+
+#define ENTRY(name)     _ENTRY(name):
+#define Entry(name)     ENTRY(name)
+#define END(name)       .size _LABEL(name), . - _LABEL(name)
+
+/* System call instruction */
+#define SVC             syscall
+
+#endif /* _X86_64_ASM_H_ */

--- a/src-lites-1.1-2025/liblites/x86_64/ntoh.s
+++ b/src-lites-1.1-2025/liblites/x86_64/ntoh.s
@@ -38,11 +38,11 @@
  *
  */
 
-#include <i386/asm.h>
+#include <x86_64/asm.h>
 
 Entry(ntohl)
 ENTRY(htonl)
-	movl	4(%esp), %eax
+	movl    8(%rsp), %eax
 	rorw	$8, %ax
 	ror	$16,%eax
 	rorw	$8, %ax
@@ -51,6 +51,6 @@ ENTRY(htonl)
 
 Entry(ntohs)
 ENTRY(htons)
-	movzwl	4(%esp), %eax
+	movzwl  8(%rsp), %eax
 	rorw	$8, %ax
 	ret

--- a/src-lites-1.1-2025/server/x86_64/misc_asm.s
+++ b/src-lites-1.1-2025/server/x86_64/misc_asm.s
@@ -32,7 +32,7 @@
  * 
  */
 
-#include <i386/asm.h>
+#include <x86_64/asm.h>
 
 #ifdef	GPROF
 	.globl	_gprof_do_profiling
@@ -41,12 +41,12 @@
 	.globl	_mcount
 mcount:
 _mcount:
-	cmpl	$0,_gprof_do_profiling
+	cmpq    $0,_gprof_do_profiling
 	jz	1f
-	pushl	0(%esp)
-	pushl	4(%ebp)
+	pushq   (%rsp)
+	pushq   8(%rbp)
 	call	_mcountaux
-	leal	8(%esp),%esp
+	leaq    16(%rsp),%rsp
 1:	ret
 #endif
 
@@ -56,19 +56,19 @@ _mcount:
  * int len
  */
 ENTRY(bcmp)
-	pushl	%esi
-	pushl	%edi
+	pushq   %rsi
+	pushq   %rdi
 
-	xorl	%eax, %eax
-	movl	12(%esp), %esi
-	movl	16(%esp), %edi
-	movl	20(%esp), %ecx
+	xorq    %rax, %rax
+	movq    24(%rsp), %rsi
+	movq    32(%rsp), %rdi
+	movq    40(%rsp), %rcx
 
 	cld
 	 repe; cmpsb
 	je	0f
-	incl	%eax
+	incq    %rax
 	
-0:	popl	%edi
-	popl	%esi
+0:	popq    %rdi
+	popq    %rsi
 	ret

--- a/src-lites-1.1-2025/server/x86_64/second_syscalls.s
+++ b/src-lites-1.1-2025/server/x86_64/second_syscalls.s
@@ -31,7 +31,7 @@
  *	errno is not used by the server so don't bother with it.
  */
 
-#include <i386/asm.h>
+#include <x86_64/asm.h>
 #include <sys/syscall.h>
 
 #ifdef __ELF__	/* affects underscores only */
@@ -39,11 +39,11 @@
 #define kernel_trap(trap_name,trap_number,number_args) \
 	.globl trap_name; \
 trap_name : \
-	movl	$ trap_number,%eax; \
+	movq    $ trap_number,%rax; \
 	SVC; \
 	jc 1f; \
 	ret; \
-1:	movl $-1,%eax; \
+1:	movq $-1,%rax; \
 	ret;
 
 #else /* __ELF__ */
@@ -51,11 +51,11 @@ trap_name : \
 #define kernel_trap(trap_name,trap_number,number_args) \
 	.globl _ ## trap_name; \
 _ ## trap_name : \
-	movl	$ trap_number,%eax; \
+	movq    $ trap_number,%rax; \
 	SVC; \
 	jc 1f; \
 	ret; \
-1:	movl $-1,%eax; \
+1:	movq $-1,%rax; \
 	ret;
 
 #endif /* __ELF__ */


### PR DESCRIPTION
## Summary
- provide new x86_64/asm.h with 64‑bit macros
- port x86_64 assembly to 64‑bit instructions
- include new dir for x86_64 in build scripts and compile .s files

## Testing
- `make -f Makefile.new ARCH=x86_64` *(fails: unknown type errors)*