### PR TITLE
Fix comment in in_cksum.c

### DIFF
--- a/src-lites-1.1-2025/liblites/x86_64/in_cksum.c
+++ b/src-lites-1.1-2025/liblites/x86_64/in_cksum.c
@@ -46,8 +46,8 @@
  * This routine is very heavily used in the network
  * code and should be modified for each CPU to be as fast as possible.
  * 
- * This implementation is 386 version.
- */
+ * This implementation originated on the i386 but is generic.
+*/
 
 #undef	ADDCARRY
 #define ADDCARRY(sum)  {				\


### PR DESCRIPTION
## Summary
- clarify that the x86_64 checksum implementation originated on i386 but is generic

## Testing
- `pre-commit run --files src-lites-1.1-2025/liblites/x86_64/in_cksum.c` *(fails: `pre-commit` not found)*