### PR TITLE
Fix setup.sh environment issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ a.out
 /obj/
 /dist/
 /release/
+compile_commands.json
 
 # Ignore archived source tarballs
 *.tar.gz

--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ cmake --build build
 The optional `setup.sh` script installs a wide range of cross-compilers
 and emulators along with standard build utilities such as build-essential,
 GCC, clang, llvm, m4, CMake, Ninja and Meson.  It also sets up debugging
-and profiling tools and provides pre-commit support.  Run `pre-commit
-run -a` after editing sources to keep formatting consistent.  The script
-requires root privileges and network access.
+and profiling tools, installs the pre-commit hooks and generates a
+`compile_commands.json` database for clang tooling.  Run `pre-commit run -a`
+after editing sources to keep formatting consistent.  The script requires
+root privileges and network access.
 
 Additional notes are kept in [`docs/`](docs/).
 

--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,7 @@ apt-get update -y
 for pkg in \
   build-essential gcc g++ clang lld llvm \
   clang-format clang-tidy uncrustify astyle editorconfig pre-commit \
-  make bmake ninja-build cmake meson \
+  make bmake ninja-build cmake meson bear \
   autoconf automake libtool m4 gawk flex bison byacc \
   pkg-config file ca-certificates curl git unzip \
   libopenblas-dev liblapack-dev libeigen3-dev \
@@ -137,6 +137,17 @@ rm /tmp/protoc.zip
 
 #— gmake alias
 command -v gmake >/dev/null 2>&1 || ln -s "$(command -v make)" /usr/local/bin/gmake
+
+# Install git hooks and sanity check dev tools
+pre-commit install >/dev/null 2>&1 || true
+clang-format --version >/dev/null 2>&1 || true
+clang-tidy --version >/dev/null 2>&1 || true
+
+# Generate a compilation database for clang tooling
+cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON >/dev/null 2>&1 || true
+if [ -f build/compile_commands.json ]; then
+  ln -sf build/compile_commands.json compile_commands.json
+fi
 
 # verify links from the README
 if [ -f README.md ]; then


### PR DESCRIPTION
## Summary
- add `bear` and automatic compile database generation
- install pre-commit hooks automatically
- ignore compile_commands.json
- document the new behaviour in README

## Testing
- `cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
- `cmake --build build` *(fails: machine/ansi.h missing)*