### PR TITLE
Edit comment about in_cksum origin

### DIFF
--- a/src-lites-1.1-2025/liblites/x86_64/in_cksum.c
+++ b/src-lites-1.1-2025/liblites/x86_64/in_cksum.c
@@ -46,7 +46,7 @@
  * This routine is very heavily used in the network
  * code and should be modified for each CPU to be as fast as possible.
  * 
- * This implementation originated on the i386 but is generic.
+ * This algorithm was first written for 32-bit x86 but is portable.
 */
 
 #undef	ADDCARRY


### PR DESCRIPTION
## Summary
- note 32-bit x86 origin in `in_cksum.c`

## Testing
- `pre-commit run --files src-lites-1.1-2025/liblites/x86_64/in_cksum.c` *(fails: command not found)*