### PR TITLE
Add clang-format config and update pre-commit

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: LLVM
+ColumnLimit: 100
+IndentWidth: 4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: clang-format
         name: clang-format
-        entry: clang-format -i
+        entry: clang-format -i --style=file
         language: system
         files: \.(c|h|cpp|hpp|cc)$
       - id: clang-tidy-c


### PR DESCRIPTION
## Summary
- add repository-wide `.clang-format`
- update pre-commit clang-format hook to use `--style=file`

## Testing
- `clang-format --version`
- *(pre-commit not installed, so tests could not be run)*