### PR TITLE
Update setup with pip installs for build tools

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -46,7 +46,7 @@ for pkg in \
 done
 
 pip3 install --no-cache-dir \
-  pre-commit \
+  pre-commit cmake ninja meson \
   tensorflow-cpu jax jaxlib \
   tensorflow-model-optimization mlflow onnxruntime-tools
 


### PR DESCRIPTION
## Summary
- ensure ninja, meson, and cmake are also installed via `pip` in the dev environment

## Testing
- `bash -n setup.sh`