### PR TITLE
Improve tool setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ and emulators along with standard build utilities such as build-essential,
 GCC, clang, llvm, m4, CMake, Ninja and Meson.  It also sets up debugging
 and profiling tools, installs the pre-commit hooks and generates a
 `compile_commands.json` database for clang tooling.  Run `pre-commit run -a`
-after editing sources to keep formatting consistent.  The script requires
-root privileges and network access.
+after editing sources to keep formatting consistent.  The script ensures
+that `pre-commit`, `yacc` (via `byacc` or `bison`) and the Swift toolchain
+are installed, falling back to pip or additional package installs if
+necessary.  The script requires root privileges and network access.
 
 Additional notes are kept in [`docs/`](docs/).
 

--- a/setup.sh
+++ b/setup.sh
@@ -50,8 +50,22 @@ pip3 install --no-cache-dir \
   tensorflow-cpu jax jaxlib \
   tensorflow-model-optimization mlflow onnxruntime-tools
 
+# Ensure pre-commit is available even if the distribution package failed
+if ! command -v pre-commit >/dev/null 2>&1; then
+  pip3 install --no-cache-dir pre-commit
+fi
+
 if command -v pre-commit >/dev/null 2>&1; then
   pre-commit install-hooks || true
+fi
+
+# Provide a yacc alias when only bison or byacc are installed
+if ! command -v yacc >/dev/null 2>&1; then
+  if command -v byacc >/dev/null 2>&1; then
+    ln -sf "$(command -v byacc)" /usr/local/bin/yacc
+  elif command -v bison >/dev/null 2>&1; then
+    ln -sf "$(command -v bison)" /usr/local/bin/yacc
+  fi
 fi
 
 #— QEMU emulation for foreign binaries
@@ -102,6 +116,14 @@ for pkg in \
   fpc lazarus zig nim nimble crystal shards gforth; do
   apt_pin_install "$pkg"
 done
+
+# Verify swift installation and provide guidance if missing
+if ! command -v swift >/dev/null 2>&1; then
+  echo "Swift not found after installation. Attempting to install via apt..."
+  apt_pin_install swift || true
+  apt_pin_install swift-lldb || true
+  apt_pin_install swiftpm || true
+fi
 
 #— GUI & desktop-dev frameworks
 for pkg in \


### PR DESCRIPTION
## Summary
- document that setup.sh installs pre-commit, yacc and Swift
- ensure setup.sh installs pre-commit reliably
- provide a fallback `yacc` alias
- verify Swift installation and attempt reinstallation if missing

## Testing
- `pre-commit run --files setup.sh README.md` *(fails: command not found)*