### PR TITLE
Fix x86_64 docs and resilient setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,10 +7,12 @@ apt_pin_install(){
   pkg="$1"
   ver=$(apt-cache show "$pkg" 2>/dev/null \
         | awk '/^Version:/{print $2; exit}')
+  # Attempt to install the exact version if available. Failures are logged but
+  # do not abort the overall setup so subsequent installation methods may run.
   if [ -n "$ver" ]; then
-    apt-get install -y "${pkg}=${ver}"
+    apt-get install -y "${pkg}=${ver}" || apt-get install -y "$pkg" || true
   else
-    apt-get install -y "$pkg"
+    apt-get install -y "$pkg" || true
   fi
 }
 

--- a/src-lites-1.1-2025/include/x86_64/Makefile
+++ b/src-lites-1.1-2025/include/x86_64/Makefile
@@ -27,7 +27,7 @@
 #	Date:	 1992, 1994
 #
 # This Makefile copies the header files from the bsdss source
-# i386 directory to the export directory where they can be found
+# x86_64 directory to the export directory where they can be found
 # in the directory "machine". This eliminates the need for 
 # machine links in the sources.
 

--- a/src-lites-1.1-2025/include/x86_64/ptrace.h
+++ b/src-lites-1.1-2025/include/x86_64/ptrace.h
@@ -36,5 +36,5 @@
 /*
  * Machine dependent trace commands.
  *
- * None for the i386 at this time.
- */
+ * None for x86_64 at this time.
+*/

--- a/src-lites-1.1-2025/server/x86_64/second_syscalls.s
+++ b/src-lites-1.1-2025/server/x86_64/second_syscalls.s
@@ -21,7 +21,7 @@
 #
  */
 /* 
- *	File:	i386/second_syscalls.s
+ *	File:	x86_64/second_syscalls.s
  *	Author:	Johannes Helander, Helsinki University of Technology, 1994.
  *	Date:	June 1994
  *


### PR DESCRIPTION
## Summary
- clarify no ptrace commands for x86_64
- fix Makefile comment about header directory
- correct file header in second_syscalls.s
- allow setup.sh to continue if apt fails installing packages

## Testing
- `./scripts/run-precommit.sh` *(fails: pre-commit not installed)*
- `make -n` *(fails: No targets specified and no makefile found)*