### PR TITLE
Fix pre-commit install logic

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -61,7 +61,7 @@ if ! command -v pre-commit >/dev/null 2>&1; then
 fi
 
 if command -v pre-commit >/dev/null 2>&1; then
-  pre-commit install-hooks || true
+  pre-commit install --install-hooks >/dev/null 2>&1 || true
 fi
 
 # Provide a yacc alias when only bison or byacc are installed
@@ -171,7 +171,6 @@ rm /tmp/protoc.zip
 command -v gmake >/dev/null 2>&1 || ln -s "$(command -v make)" /usr/local/bin/gmake
 
 # Install git hooks and sanity check dev tools
-pre-commit install >/dev/null 2>&1 || true
 clang-format --version >/dev/null 2>&1 || true
 clang-tidy --version >/dev/null 2>&1 || true
 


### PR DESCRIPTION
## Summary
- run `pre-commit install` once with `--install-hooks`

## Testing
- `pre-commit` *(fails: command not found)*