### PR TITLE
Add i386 asm macros

### DIFF
--- a/src-lites-1.1-2025/include/i386/Makefile
+++ b/src-lites-1.1-2025/include/i386/Makefile
@@ -31,7 +31,7 @@
 # in the directory "machine". This eliminates the need for 
 # machine links in the sources.
 
-DATAFILES		= endian.h limits.h signal.h param.h stdarg.h \
+DATAFILES               = asm.h endian.h limits.h signal.h param.h stdarg.h \
 			  ansi.h types.h cpu.h ptrace.h vmparam.h exec.h \
 			  trap.h varargs.h
 

--- a/src-lites-1.1-2025/include/i386/asm.h
+++ b/src-lites-1.1-2025/include/i386/asm.h
@@ -1,0 +1,21 @@
+#ifndef _I386_ASM_H_
+#define _I386_ASM_H_
+
+/* Generic assembly macros modelled after the 4.4BSD i386 header. */
+
+#ifdef __ELF__
+#define _ENTRY(name)    .globl name; .type name,@function; name
+#define _LABEL(name)    name
+#else
+#define _ENTRY(name)    .globl _##name; .type _##name,@function; _##name
+#define _LABEL(name)    _##name
+#endif
+
+#define ENTRY(name)     _ENTRY(name):
+#define Entry(name)     ENTRY(name)
+#define END(name)       .size _LABEL(name), . - _LABEL(name)
+
+/* System call instruction */
+#define SVC             int $0x80
+
+#endif /* _I386_ASM_H_ */


### PR DESCRIPTION
## Summary
- add i386/asm.h modeled after x86_64 header
- install asm.h via include/i386/Makefile

## Testing
- `pre-commit` *(fails: command not found)*