### PR TITLE
Fix x86_64 comment

### DIFF
--- a/src-lites-1.1-2025/include/x86_64/param.h
+++ b/src-lites-1.1-2025/include/x86_64/param.h
@@ -165,7 +165,7 @@
 #define MAP_FILE_BASE	0x90000000
 
 /*
- * i386 stack sits above emulator.
+ * x86_64 stack sits above emulator.
  */
 #define	EMULATOR_ABOVE_STACK	0
 


### PR DESCRIPTION
## Summary
- clarify stack comment in `param.h`

## Testing
- `make -f Makefile.new -n` *(fails: Syntax error: Unterminated quoted string)*