### PR TITLE
Update endian comment

### DIFF
--- a/src-lites-1.1-2025/include/x86_64/endian.h
+++ b/src-lites-1.1-2025/include/x86_64/endian.h
@@ -52,7 +52,7 @@
  * Definitions for byte order, according to byte significance from low
  * address to high.
  */
-#define	LITTLE_ENDIAN	1234	/* LSB first: i386, vax */
+#define	LITTLE_ENDIAN	1234	/* LSB first: i386, x86_64, vax */
 #define	BIG_ENDIAN	4321	/* MSB first: 68000, ibm, net */
 #define	PDP_ENDIAN	3412	/* LSB first in word, MSW first in long */
 


### PR DESCRIPTION
## Summary
- clarify little-endian examples to mention x86_64

## Testing
- `pre-commit run --files src-lites-1.1-2025/include/x86_64/endian.h` *(fails: pre-commit not installed)*