### PR TITLE
Add Mach kernel headers instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ set(CMAKE_C_STANDARD 23)
 set(ARCH "$ENV{ARCH}" CACHE STRING "Target architecture (x86_64 or i686)")
 set(CFLAGS "$ENV{CFLAGS}" CACHE STRING "Additional compiler flags")
 set(LDFLAGS "$ENV{LDFLAGS}" CACHE STRING "Additional linker flags")
+set(LITES_MACH_DIR "$ENV{LITES_MACH_DIR}" CACHE PATH "Mach kernel source directory")
+if(NOT LITES_MACH_DIR AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/openmach")
+    set(LITES_MACH_DIR "${CMAKE_CURRENT_SOURCE_DIR}/openmach")
+endif()
+set(MACH_DIR "${LITES_MACH_DIR}")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CFLAGS}")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LDFLAGS}")
@@ -93,7 +98,8 @@ if(EXISTS "${LITES_SRC_DIR}")
     add_executable(lites_server ${SERVER_SRC})
     target_include_directories(lites_server PRIVATE
         "${LITES_SRC_DIR}/include"
-        "${LITES_SRC_DIR}/server")
+        "${LITES_SRC_DIR}/server"
+        $<$<BOOL:${MACH_DIR}>:${MACH_DIR}/include>)
     if(ARCH STREQUAL "x86_64")
         target_include_directories(lites_server PRIVATE
             "${LITES_SRC_DIR}/include/x86_64")
@@ -108,7 +114,8 @@ if(EXISTS "${LITES_SRC_DIR}")
         add_executable(lites_emulator ${EMULATOR_SRC})
         target_include_directories(lites_emulator PRIVATE
             "${LITES_SRC_DIR}/include"
-            "${LITES_SRC_DIR}/emulator")
+            "${LITES_SRC_DIR}/emulator"
+            $<$<BOOL:${MACH_DIR}>:${MACH_DIR}/include>)
         if(ARCH STREQUAL "x86_64")
             target_include_directories(lites_emulator PRIVATE
                 "${LITES_SRC_DIR}/include/x86_64")

--- a/Makefile.new
+++ b/Makefile.new
@@ -6,6 +6,17 @@ SRCDIR ?= build/lites-1.1.u3
 endif
 CC ?= gcc
 
+# Optional Mach kernel source tree for headers
+MACHDIR ?= $(LITES_MACH_DIR)
+ifeq ($(MACHDIR),)
+ifneq ($(wildcard openmach/include),)
+MACHDIR := openmach
+endif
+endif
+ifneq ($(MACHDIR),)
+MACH_INCDIR := -I$(MACHDIR)/include
+endif
+
 # Target architecture (x86_64 or i686). Determines -m32/-m64 flags.
 ARCH ?= x86_64
 
@@ -60,11 +71,11 @@ prepare:
 fi
 
 lites_server: $(SERVER_SRC)
-	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(SERVER_INCDIRS) $^ $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(SERVER_INCDIRS) $^ $(LDFLAGS) -o $@
 
 ifneq ($(EMULATOR_SRC),)
 lites_emulator: $(EMULATOR_SRC)
-	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(EMULATOR_INCDIRS) $^ $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(EMULATOR_INCDIRS) $^ $(LDFLAGS) -o $@
 endif
 	
 clean:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,29 @@ The file `johannes_helander-unix_under_mach-the_lites_server.pdf` in this
 repository contains a comprehensive thesis describing Lites' design in
 detail.
 
+## Mach kernel headers
+
+Lites relies on headers from a Mach kernel source tree such as the
+OpenMach/Mach4 distribution.  The modern build system looks for these
+headers in the directory specified by the `LITES_MACH_DIR` environment
+variable.  If that variable is unset and a directory named `openmach`
+exists at the repository root, it will be used automatically (a git
+submodule can conveniently provide it).
+
+Example using the makefile:
+
+```sh
+git submodule add <mach-repo-url> openmach  # once
+make -f Makefile.new LITES_MACH_DIR=openmach
+```
+
+Or with CMake:
+
+```sh
+cmake -B build -DLITES_MACH_DIR=openmach
+cmake --build build
+```
+
 ## Building
 
 Lites requires a Mach 3 or Mach 4 kernel and a 4.4BSD userland.  Each
@@ -81,7 +104,6 @@ after editing sources to keep formatting consistent.  The script ensures
 that `pre-commit`, `yacc` (via `byacc` or `bison`) and the Swift toolchain
 are installed, falling back to pip or additional package installs if
 necessary.  The script requires root privileges and network access.
-ster
 
 Additional notes are kept in [`docs/`](docs/).
 


### PR DESCRIPTION
## Summary
- document how to provide Mach kernel headers via `LITES_MACH_DIR`
- support `LITES_MACH_DIR` in the CMake and make build scripts

## Testing
- `make -f Makefile.new` *(fails: mach headers missing)*
- `cmake -B build -DLITES_MACH_DIR=openmach`
