### PR TITLE
Add generic bitops for non-x86 architectures

### DIFF
--- a/src-lites-1.1-2025/server/ufs/ext2fs/ext2_linux_balloc.c
+++ b/src-lites-1.1-2025/server/ufs/ext2fs/ext2_linux_balloc.c
@@ -46,7 +46,7 @@
 #elif defined(__x86_64__)
 #include <ufs/ext2fs/x86_64-bitops.h>
 #else
-#error Provide an bitops.h file, please !
+#include <ufs/ext2fs/generic-bitops.h>
 #endif
 
 unsigned long ext2_count_free (struct buffer_head *, unsigned int);

--- a/src-lites-1.1-2025/server/ufs/ext2fs/ext2_linux_ialloc.c
+++ b/src-lites-1.1-2025/server/ufs/ext2fs/ext2_linux_ialloc.c
@@ -47,7 +47,7 @@
 #elif defined(__x86_64__)
 #include <ufs/ext2fs/x86_64-bitops.h>
 #else
-#error please provide bit operation functions
+#include <ufs/ext2fs/generic-bitops.h>
 #endif
 
 /* this is supposed to mark a buffer dirty on ready for delayed writing

--- a/src-lites-1.1-2025/server/ufs/ext2fs/generic-bitops.h
+++ b/src-lites-1.1-2025/server/ufs/ext2fs/generic-bitops.h
@@ -1,0 +1,71 @@
+#ifndef _GENERIC_BITOPS_H
+#define _GENERIC_BITOPS_H
+
+/* Portable C implementations of basic bit operations. */
+
+static inline int set_bit(int nr, void *addr) {
+    unsigned char *p = (unsigned char *)addr + (nr >> 3);
+    unsigned char mask = (unsigned char)1U << (nr & 7);
+    unsigned char old = *p;
+    *p = old | mask;
+    return (old & mask) != 0;
+}
+
+static inline int clear_bit(int nr, void *addr) {
+    unsigned char *p = (unsigned char *)addr + (nr >> 3);
+    unsigned char mask = (unsigned char)1U << (nr & 7);
+    unsigned char old = *p;
+    *p = old & ~mask;
+    return (old & mask) != 0;
+}
+
+static inline int change_bit(int nr, void *addr) {
+    unsigned char *p = (unsigned char *)addr + (nr >> 3);
+    unsigned char mask = (unsigned char)1U << (nr & 7);
+    unsigned char old = *p;
+    *p = old ^ mask;
+    return (old & mask) != 0;
+}
+
+static inline int test_bit(int nr, void *addr) {
+    unsigned char *p = (unsigned char *)addr + (nr >> 3);
+    return ((*p >> (nr & 7)) & 1U) != 0;
+}
+
+static inline unsigned long ffz(unsigned long word) {
+    for (unsigned long i = 0; i < sizeof(unsigned long) * 8; i++) {
+        if (!(word & (1UL << i)))
+            return i;
+    }
+    return sizeof(unsigned long) * 8;
+}
+
+static inline int find_first_zero_bit(void *addr, unsigned size) {
+    unsigned long *p = (unsigned long *)addr;
+    unsigned bits = size;
+    unsigned index = 0;
+    while (bits >= sizeof(unsigned long) * 8) {
+        if (~(*p))
+            return index + ffz(*p);
+        p++;
+        index += sizeof(unsigned long) * 8;
+        bits -= sizeof(unsigned long) * 8;
+    }
+    if (bits) {
+        unsigned long last = *p | (~0UL << bits);
+        if (~last)
+            return index + ffz(last);
+        index += bits;
+    }
+    return index;
+}
+
+static inline int find_next_zero_bit(void *addr, int size, int offset) {
+    for (int bit = offset; bit < size; bit++) {
+        if (!test_bit(bit, addr))
+            return bit;
+    }
+    return size;
+}
+
+#endif /* _GENERIC_BITOPS_H */


### PR DESCRIPTION
## Summary
- implement portable bit operations in `generic-bitops.h`
- include the generic header in `ext2_linux_balloc.c` and `ext2_linux_ialloc.c` when not compiling for x86

## Testing
- `scripts/run-precommit.sh` *(fails: pre-commit not installed)*