### PR TITLE
Extend disklabel defs to x86_64

### DIFF
--- a/src-lites-1.1-2025/include/sys/disklabel.h
+++ b/src-lites-1.1-2025/include/sys/disklabel.h
@@ -50,7 +50,7 @@
  */
 
 /* XXX these should be defined per controller (or drive) elsewhere, not here! */
-#ifdef i386
+#if defined(i386) || defined(__x86_64__)
 #define LABELSECTOR	1			/* sector containing label */
 #define LABELOFFSET	0			/* offset of label in sector */
 #endif


### PR DESCRIPTION
## Summary
- adjust architecture guard in `disklabel.h` to include `__x86_64__`

## Testing
- `clang-format src-lites-1.1-2025/include/sys/disklabel.h | diff -u src-lites-1.1-2025/include/sys/disklabel.h -` *(fails: shows formatting differences)*
- `apt-get update -y` *(fails: Could not connect to proxy)*