### PR TITLE
Fix pre-commit installation and config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,12 @@
+minimum_pre_commit_version: '2.20.0'
+exclude: 'Historical Archives/.*'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+
   - repo: local
     hooks:
       - id: clang-format
@@ -21,3 +24,4 @@ repos:
         entry: clang-tidy --extra-arg=-std=c++17
         language: system
         types: [c++,cpp]
+

--- a/setup.sh
+++ b/setup.sh
@@ -33,6 +33,7 @@ for pkg in \
   libopenblas-dev liblapack-dev libeigen3-dev \
   strace ltrace linux-perf systemtap systemtap-sdt-dev crash \
   valgrind kcachegrind trace-cmd kernelshark \
+  pre-commit \
   libasan6 libubsan1 likwid hwloc; do
   apt_pin_install "$pkg"
 done
@@ -64,6 +65,7 @@ fi
 
 if command -v pre-commit >/dev/null 2>&1; then
   pre-commit install --install-hooks >/dev/null 2>&1 || true
+  pre-commit --version || true
 fi
 
 # Provide a yacc alias when only bison or byacc are installed


### PR DESCRIPTION
## Summary
- fix truncated `.pre-commit-config.yaml`
- exclude Historical Archives from pre-commit
- ensure `pre-commit` is installed from apt packages
- check `pre-commit` version when setup runs

## Testing
- `make --version`
- `pre-commit run --files README.md` *(fails: command not found)*
