### PR TITLE
Improve failure handling in setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ and profiling tools, installs the pre-commit hooks and generates a
 after editing sources to keep formatting consistent.  The script ensures
 that `pre-commit`, `yacc` (via `byacc` or `bison`) and the Swift toolchain
 are installed, falling back to pip or additional package installs if
-necessary.  The script requires root privileges and network access.
+necessary.  Any package failures are recorded in `/tmp/setup_failures.log`
+so the remainder of the setup can continue.  The script requires root
+privileges and network access.
 
 Additional notes are kept in [`docs/`](docs/).
 


### PR DESCRIPTION
## Summary
- log installation failures in setup.sh
- attempt pip fallbacks for python packages
- warn when `apt update` fails
- record protoc/cmake/IA16 compiler failures
- clarify README about failure log

## Testing
- `bash -n setup.sh`
- `./scripts/run-precommit.sh` *(fails: pre-commit not installed)*