### PR TITLE
Fix pre-commit setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,5 +107,8 @@ necessary.  Any package failures are recorded in `/tmp/setup_failures.log`
 so the remainder of the setup can continue.  The script requires root
 privileges and network access.
 
+You can also invoke `scripts/run-precommit.sh` which automatically installs
+`pre-commit` via pip when missing.
+
 Additional notes are kept in [`docs/`](docs/).
 

--- a/scripts/run-precommit.sh
+++ b/scripts/run-precommit.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v pre-commit >/dev/null 2>&1; then
-  exec pre-commit "$@"
-else
-  echo "pre-commit is not installed." >&2
-  echo "Install it with 'pip install pre-commit' and re-run this script." >&2
-  exit 1
+if ! command -v pre-commit >/dev/null 2>&1; then
+  echo "pre-commit not found; attempting installation via pip..." >&2
+  if command -v pip >/dev/null 2>&1; then
+    if ! pip install --user --quiet pre-commit; then
+      echo "Failed to install pre-commit via pip." >&2
+      exit 1
+    fi
+  else
+    echo "pip is not available to install pre-commit." >&2
+    exit 1
+  fi
 fi
+
+exec pre-commit "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -75,11 +75,11 @@ done
 
 # Ensure pre-commit is installed regardless of package source
 if ! command -v pre-commit >/dev/null 2>&1; then
-  if apt-cache show pre-commit >/dev/null 2>&1; then
+  echo "pre-commit not found, installing via pip..." >&2
+  if ! pip3 install --no-cache-dir pre-commit; then
+    echo "pip:pre-commit" >> "$FAIL_LOG"
+    # Fallback to apt if available
     apt_pin_install pre-commit || true
-  else
-    echo "Attempting to install pre-commit via pip" >&2
-    pip3 install --no-cache-dir pre-commit || true
   fi
 fi
 


### PR DESCRIPTION
## Summary
- attempt installing pre-commit automatically in run-precommit.sh
- update README with instructions about the helper script
- ensure setup.sh installs pre-commit via pip when missing

## Testing
- `scripts/run-precommit.sh --version` *(fails: Could not install pre-commit due to no network)*