### PR TITLE
Install pre-commit via pip and ensure config

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,12 @@ cmake --build build
 
 The optional `setup.sh` script installs a wide range of cross-compilers
 and emulators along with standard build utilities such as build-essential,
-GCC, clang, llvm, m4, CMake, Ninja and Meson.  It also sets up debugging
-and profiling tools, installs the pre-commit hooks and generates a
+GCC, clang, llvm, m4, CMake, Ninja and Meson.  BSD make (`bmake`) and the optional `mk-configure` framework are installed as well.  The script also sets up debugging and profiling tools, installs the pre-commit hooks and generates a
 `compile_commands.json` database for clang tooling.  Run `pre-commit run -a`
-after editing sources to keep formatting consistent.  The script ensures
-that `pre-commit`, `yacc` (via `byacc` or `bison`) and the Swift toolchain
-are installed, falling back to pip or additional package installs if
-necessary.  Any package failures are recorded in `/tmp/setup_failures.log`
+after editing sources to keep formatting consistent.  The script installs `pre-commit` via pip when missing and ensures a `.pre-commit-config.yaml` file exists.  It also verifies
+that `yacc` (via `byacc` or `bison`) and the Swift toolchain
+are available, falling back to additional package installs if necessary.
+Any package failures are recorded in `/tmp/setup_failures.log`
 so the remainder of the setup can continue.  The script requires root
 privileges and network access.
 

--- a/setup.sh
+++ b/setup.sh
@@ -43,7 +43,7 @@ fi
 for pkg in \
   build-essential gcc g++ clang lld llvm \
   clang-format clang-tidy uncrustify astyle editorconfig \
-  make bmake ninja-build cmake meson \
+  make bmake mk-configure ninja-build cmake meson \
   autoconf automake libtool m4 gawk flex bison byacc \
   pkg-config file ca-certificates curl git unzip \
   libopenblas-dev liblapack-dev libeigen3-dev \
@@ -84,6 +84,18 @@ if ! command -v pre-commit >/dev/null 2>&1; then
 fi
 
 if command -v pre-commit >/dev/null 2>&1; then
+  # ensure configuration exists
+  if [ ! -f .pre-commit-config.yaml ]; then
+    cat > .pre-commit-config.yaml <<'EOF'
+minimum_pre_commit_version: '2.20.0'
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+EOF
+  fi
   pre-commit install --install-hooks >/dev/null 2>&1 || true
   pre-commit --version || true
 fi


### PR DESCRIPTION
## Summary
- ensure `pre-commit` is installed via pip in `setup.sh`
- create a default `.pre-commit-config.yaml` if none exists
- update README about `pre-commit` installation and config

## Testing
- `pre-commit run --files README.md setup.sh` *(fails: command not found)*