### PR TITLE
Fix clang-tidy integration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,12 @@ repos:
         files: \.(c|h|cpp|hpp|cc)$
       - id: clang-tidy-c
         name: clang-tidy C
-        entry: clang-tidy --extra-arg=-std=c23
+        entry: scripts/run-clang-tidy.sh --extra-arg=-std=c23
         language: system
         types: [c]
       - id: clang-tidy-cpp
         name: clang-tidy C++
-        entry: clang-tidy --extra-arg=-std=c++17
+        entry: scripts/run-clang-tidy.sh --extra-arg=-std=c++17
         language: system
         types: [c++,cpp]
 

--- a/README.md
+++ b/README.md
@@ -111,5 +111,9 @@ privileges and network access.
 You can also invoke `scripts/run-precommit.sh` which automatically installs
 `pre-commit` via pip when missing.
 
+The clang-tidy hooks rely on `scripts/run-clang-tidy.sh`.  This helper
+ensures a `compile_commands.json` database is generated on demand so
+clang-tidy can analyse the sources even before the project has been built.
+
 Additional notes are kept in [`docs/`](docs/).
 

--- a/scripts/run-clang-tidy.sh
+++ b/scripts/run-clang-tidy.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure a compile_commands.json exists
+compdb="compile_commands.json"
+if [ ! -f "$compdb" ]; then
+  echo "[run-clang-tidy] Generating $compdb via CMake" >&2
+  if cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON >/dev/null 2>&1; then
+    if [ -f build/compile_commands.json ]; then
+      ln -sf build/compile_commands.json "$compdb"
+    fi
+  else
+    echo "[run-clang-tidy] Warning: failed to generate compilation database" >&2
+  fi
+fi
+
+exec clang-tidy -p build "$@"


### PR DESCRIPTION
## Summary
- add helper script `run-clang-tidy.sh`
- wire pre-commit hooks to use the helper
- document how the helper works in the README

## Testing
- `scripts/run-clang-tidy.sh --version`
- `scripts/run-precommit.sh --files README.md .pre-commit-config.yaml scripts/run-clang-tidy.sh` *(fails: Could not install pre-commit)*