### PR TITLE
Modernize in_cksum prototypes

### DIFF
--- a/docs/technical_notes.md
+++ b/docs/technical_notes.md
@@ -13,3 +13,6 @@ To experiment with cross compilation or multiple architectures, see the
 `setup.sh` script in the repository root. It installs a full toolchain and
 qemu-based emulation targets.
 
+The modernized sources in `src-lites-1.1-2025` require a compiler with full
+C23 support. GCC 13 or Clang 17 (or newer) are known to work.
+

--- a/src-lites-1.1-2025/liblites/i386/in_cksum.c
+++ b/src-lites-1.1-2025/liblites/i386/in_cksum.c
@@ -34,8 +34,8 @@
  *	@(#)in_cksum.c	8.1 (Berkeley) 6/11/93
  */
 
-#include <sys/param.h>
 #include <sys/mbuf.h>
+#include <sys/param.h>
 
 #include <netinet/in.h>
 #include <netinet/in_systm.h>
@@ -45,87 +45,85 @@
  *
  * This routine is very heavily used in the network
  * code and should be modified for each CPU to be as fast as possible.
- * 
+ *
  * This implementation is 386 version.
  */
 
-#undef	ADDCARRY
-#define ADDCARRY(sum)  {				\
-			if (sum & 0xffff0000) {		\
-				sum &= 0xffff;		\
-				sum++;			\
-			}				\
-		}
-in_cksum(m, len)
-	register struct mbuf *m;
-	register int len;
-{
-	union word {
-		char	c[2];
-		u_short	s;
-	} u;
-	register u_short *w;
-	register int sum = 0;
-	register int mlen = 0;
+#undef ADDCARRY
+#define ADDCARRY(sum)                                                                              \
+    {                                                                                              \
+        if (sum & 0xffff0000) {                                                                    \
+            sum &= 0xffff;                                                                         \
+            sum++;                                                                                 \
+        }                                                                                          \
+    }
+u_short in_cksum(struct mbuf *m, int len) {
+    union word {
+        char c[2];
+        u_short s;
+    } u;
+    register u_short *w;
+    register int sum = 0;
+    register int mlen = 0;
 
-	for (;m && len; m = m->m_next) {
-		if (m->m_len == 0)
-			continue;
-		w = mtod(m, u_short *);
-		if (mlen == -1) {
-			/*
-			 * The first byte of this mbuf is the continuation
-			 * of a word spanning between this mbuf and the
-			 * last mbuf.
-			 */
+    for (; m && len; m = m->m_next) {
+        if (m->m_len == 0)
+            continue;
+        w = mtod(m, u_short *);
+        if (mlen == -1) {
+            /*
+             * The first byte of this mbuf is the continuation
+             * of a word spanning between this mbuf and the
+             * last mbuf.
+             */
 
-			/* u.c[0] is already saved when scanning previous 
-			 * mbuf.
-			 */
-			u.c[1] = *(u_char *)w;
-			sum += u.s;
-			ADDCARRY(sum);
-			w = (u_short *)((char *)w + 1);
-			mlen = m->m_len - 1;
-			len--;
-		} else
-			mlen = m->m_len;
+            /* u.c[0] is already saved when scanning previous
+             * mbuf.
+             */
+            u.c[1] = *(u_char *)w;
+            sum += u.s;
+            ADDCARRY(sum);
+            w = (u_short *)((char *)w + 1);
+            mlen = m->m_len - 1;
+            len--;
+        } else
+            mlen = m->m_len;
 
-		if (len < mlen)
-			mlen = len;
-		len -= mlen;
+        if (len < mlen)
+            mlen = len;
+        len -= mlen;
 
-		/*
-		 * add by words.
-		 */
-		while ((mlen -= 2) >= 0) {
-			if ((int)w & 0x1) {
-				/* word is not aligned */
-				u.c[0] = *(char *)w;
-				u.c[1] = *((char *)w+1);
-				sum += u.s;
-				w++;
-			} else
-				sum += *w++;
-			ADDCARRY(sum);
-		}
-		if (mlen == -1)
-			/*
-			 * This mbuf has odd number of bytes. 
-			 * There could be a word split betwen
-			 * this mbuf and the next mbuf.
-			 * Save the last byte (to prepend to next mbuf).
-			 */
-			u.c[0] = *(u_char *)w;
-	}
-	if (len)
-		printf("cksum: out of data\n");
-	if (mlen == -1) {
-		/* The last mbuf has odd # of bytes. Follow the
-		   standard (the odd byte is shifted left by 8 bits) */
-		u.c[1] = 0;
-		sum += u.s;
-		ADDCARRY(sum);
-	}
-	return (~sum & 0xffff);
+        /*
+         * add by words.
+         */
+        while ((mlen -= 2) >= 0) {
+            if ((int)w & 0x1) {
+                /* word is not aligned */
+                u.c[0] = *(char *)w;
+                u.c[1] = *((char *)w + 1);
+                sum += u.s;
+                w++;
+            } else
+                sum += *w++;
+            ADDCARRY(sum);
+        }
+        if (mlen == -1)
+            /*
+             * This mbuf has odd number of bytes.
+             * There could be a word split betwen
+             * this mbuf and the next mbuf.
+             * Save the last byte (to prepend to next mbuf).
+             */
+            u.c[0] = *(u_char *)w;
+    }
+    if (len)
+        printf("cksum: out of data\n");
+    if (mlen == -1) {
+        /* The last mbuf has odd # of bytes. Follow the
+           standard (the odd byte is shifted left by 8 bits) */
+        u.c[1] = 0;
+        sum += u.s;
+        ADDCARRY(sum);
+    }
+    return (~sum & 0xffff);
 }

--- a/src-lites-1.1-2025/liblites/ns532/in_cksum.c
+++ b/src-lites-1.1-2025/liblites/ns532/in_cksum.c
@@ -34,8 +34,8 @@
  *	@(#)in_cksum.c	8.1 (Berkeley) 6/11/93
  */
 
-#include <sys/param.h>
 #include <sys/mbuf.h>
+#include <sys/param.h>
 
 #include <netinet/in.h>
 #include <netinet/in_systm.h>
@@ -45,87 +45,85 @@
  *
  * This routine is very heavily used in the network
  * code and should be modified for each CPU to be as fast as possible.
- * 
+ *
  * This implementation is ns532 version.
  */
 
-#undef	ADDCARRY
-#define ADDCARRY(sum)  {				\
-			if (sum & 0xffff0000) {		\
-				sum &= 0xffff;		\
-				sum++;			\
-			}				\
-		}
-in_cksum(m, len)
-	register struct mbuf *m;
-	register int len;
-{
-	union word {
-		char	c[2];
-		u_short	s;
-	} u;
-	register u_short *w;
-	register int sum = 0;
-	register int mlen = 0;
+#undef ADDCARRY
+#define ADDCARRY(sum)                                                                              \
+    {                                                                                              \
+        if (sum & 0xffff0000) {                                                                    \
+            sum &= 0xffff;                                                                         \
+            sum++;                                                                                 \
+        }                                                                                          \
+    }
+u_short in_cksum(struct mbuf *m, int len) {
+    union word {
+        char c[2];
+        u_short s;
+    } u;
+    register u_short *w;
+    register int sum = 0;
+    register int mlen = 0;
 
-	for (;m && len; m = m->m_next) {
-		if (m->m_len == 0)
-			continue;
-		w = mtod(m, u_short *);
-		if (mlen == -1) {
-			/*
-			 * The first byte of this mbuf is the continuation
-			 * of a word spanning between this mbuf and the
-			 * last mbuf.
-			 */
+    for (; m && len; m = m->m_next) {
+        if (m->m_len == 0)
+            continue;
+        w = mtod(m, u_short *);
+        if (mlen == -1) {
+            /*
+             * The first byte of this mbuf is the continuation
+             * of a word spanning between this mbuf and the
+             * last mbuf.
+             */
 
-			/* u.c[0] is already saved when scanning previous 
-			 * mbuf.
-			 */
-			u.c[1] = *(u_char *)w;
-			sum += u.s;
-			ADDCARRY(sum);
-			w = (u_short *)((char *)w + 1);
-			mlen = m->m_len - 1;
-			len--;
-		} else
-			mlen = m->m_len;
+            /* u.c[0] is already saved when scanning previous
+             * mbuf.
+             */
+            u.c[1] = *(u_char *)w;
+            sum += u.s;
+            ADDCARRY(sum);
+            w = (u_short *)((char *)w + 1);
+            mlen = m->m_len - 1;
+            len--;
+        } else
+            mlen = m->m_len;
 
-		if (len < mlen)
-			mlen = len;
-		len -= mlen;
+        if (len < mlen)
+            mlen = len;
+        len -= mlen;
 
-		/*
-		 * add by words.
-		 */
-		while ((mlen -= 2) >= 0) {
-			if ((int)w & 0x1) {
-				/* word is not aligned */
-				u.c[0] = *(char *)w;
-				u.c[1] = *((char *)w+1);
-				sum += u.s;
-				w++;
-			} else
-				sum += *w++;
-			ADDCARRY(sum);
-		}
-		if (mlen == -1)
-			/*
-			 * This mbuf has odd number of bytes. 
-			 * There could be a word split betwen
-			 * this mbuf and the next mbuf.
-			 * Save the last byte (to prepend to next mbuf).
-			 */
-			u.c[0] = *(u_char *)w;
-	}
-	if (len)
-		printf("cksum: out of data\n");
-	if (mlen == -1) {
-		/* The last mbuf has odd # of bytes. Follow the
-		   standard (the odd byte is shifted left by 8 bits) */
-		u.c[1] = 0;
-		sum += u.s;
-		ADDCARRY(sum);
-	}
-	return (~sum & 0xffff);
+        /*
+         * add by words.
+         */
+        while ((mlen -= 2) >= 0) {
+            if ((int)w & 0x1) {
+                /* word is not aligned */
+                u.c[0] = *(char *)w;
+                u.c[1] = *((char *)w + 1);
+                sum += u.s;
+                w++;
+            } else
+                sum += *w++;
+            ADDCARRY(sum);
+        }
+        if (mlen == -1)
+            /*
+             * This mbuf has odd number of bytes.
+             * There could be a word split betwen
+             * this mbuf and the next mbuf.
+             * Save the last byte (to prepend to next mbuf).
+             */
+            u.c[0] = *(u_char *)w;
+    }
+    if (len)
+        printf("cksum: out of data\n");
+    if (mlen == -1) {
+        /* The last mbuf has odd # of bytes. Follow the
+           standard (the odd byte is shifted left by 8 bits) */
+        u.c[1] = 0;
+        sum += u.s;
+        ADDCARRY(sum);
+    }
+    return (~sum & 0xffff);
 }

--- a/src-lites-1.1-2025/liblites/x86_64/in_cksum.c
+++ b/src-lites-1.1-2025/liblites/x86_64/in_cksum.c
@@ -34,8 +34,8 @@
  *	@(#)in_cksum.c	8.1 (Berkeley) 6/11/93
  */
 
-#include <sys/param.h>
 #include <sys/mbuf.h>
+#include <sys/param.h>
 
 #include <netinet/in.h>
 #include <netinet/in_systm.h>
@@ -45,87 +45,85 @@
  *
  * This routine is very heavily used in the network
  * code and should be modified for each CPU to be as fast as possible.
- * 
+ *
  * This algorithm was first written for 32-bit x86 but is portable.
-*/
+ */
 
-#undef	ADDCARRY
-#define ADDCARRY(sum)  {				\
-			if (sum & 0xffff0000) {		\
-				sum &= 0xffff;		\
-				sum++;			\
-			}				\
-		}
-in_cksum(m, len)
-	register struct mbuf *m;
-	register int len;
-{
-	union word {
-		char	c[2];
-		u_short	s;
-	} u;
-	register u_short *w;
-	register int sum = 0;
-	register int mlen = 0;
+#undef ADDCARRY
+#define ADDCARRY(sum)                                                                              \
+    {                                                                                              \
+        if (sum & 0xffff0000) {                                                                    \
+            sum &= 0xffff;                                                                         \
+            sum++;                                                                                 \
+        }                                                                                          \
+    }
+u_short in_cksum(struct mbuf *m, int len) {
+    union word {
+        char c[2];
+        u_short s;
+    } u;
+    register u_short *w;
+    register int sum = 0;
+    register int mlen = 0;
 
-	for (;m && len; m = m->m_next) {
-		if (m->m_len == 0)
-			continue;
-		w = mtod(m, u_short *);
-		if (mlen == -1) {
-			/*
-			 * The first byte of this mbuf is the continuation
-			 * of a word spanning between this mbuf and the
-			 * last mbuf.
-			 */
+    for (; m && len; m = m->m_next) {
+        if (m->m_len == 0)
+            continue;
+        w = mtod(m, u_short *);
+        if (mlen == -1) {
+            /*
+             * The first byte of this mbuf is the continuation
+             * of a word spanning between this mbuf and the
+             * last mbuf.
+             */
 
-			/* u.c[0] is already saved when scanning previous 
-			 * mbuf.
-			 */
-			u.c[1] = *(u_char *)w;
-			sum += u.s;
-			ADDCARRY(sum);
-			w = (u_short *)((char *)w + 1);
-			mlen = m->m_len - 1;
-			len--;
-		} else
-			mlen = m->m_len;
+            /* u.c[0] is already saved when scanning previous
+             * mbuf.
+             */
+            u.c[1] = *(u_char *)w;
+            sum += u.s;
+            ADDCARRY(sum);
+            w = (u_short *)((char *)w + 1);
+            mlen = m->m_len - 1;
+            len--;
+        } else
+            mlen = m->m_len;
 
-		if (len < mlen)
-			mlen = len;
-		len -= mlen;
+        if (len < mlen)
+            mlen = len;
+        len -= mlen;
 
-		/*
-		 * add by words.
-		 */
-		while ((mlen -= 2) >= 0) {
-			if ((int)w & 0x1) {
-				/* word is not aligned */
-				u.c[0] = *(char *)w;
-				u.c[1] = *((char *)w+1);
-				sum += u.s;
-				w++;
-			} else
-				sum += *w++;
-			ADDCARRY(sum);
-		}
-		if (mlen == -1)
-			/*
-			 * This mbuf has odd number of bytes. 
-			 * There could be a word split betwen
-			 * this mbuf and the next mbuf.
-			 * Save the last byte (to prepend to next mbuf).
-			 */
-			u.c[0] = *(u_char *)w;
-	}
-	if (len)
-		printf("cksum: out of data\n");
-	if (mlen == -1) {
-		/* The last mbuf has odd # of bytes. Follow the
-		   standard (the odd byte is shifted left by 8 bits) */
-		u.c[1] = 0;
-		sum += u.s;
-		ADDCARRY(sum);
-	}
-	return (~sum & 0xffff);
+        /*
+         * add by words.
+         */
+        while ((mlen -= 2) >= 0) {
+            if ((int)w & 0x1) {
+                /* word is not aligned */
+                u.c[0] = *(char *)w;
+                u.c[1] = *((char *)w + 1);
+                sum += u.s;
+                w++;
+            } else
+                sum += *w++;
+            ADDCARRY(sum);
+        }
+        if (mlen == -1)
+            /*
+             * This mbuf has odd number of bytes.
+             * There could be a word split betwen
+             * this mbuf and the next mbuf.
+             * Save the last byte (to prepend to next mbuf).
+             */
+            u.c[0] = *(u_char *)w;
+    }
+    if (len)
+        printf("cksum: out of data\n");
+    if (mlen == -1) {
+        /* The last mbuf has odd # of bytes. Follow the
+           standard (the odd byte is shifted left by 8 bits) */
+        u.c[1] = 0;
+        sum += u.s;
+        ADDCARRY(sum);
+    }
+    return (~sum & 0xffff);
 }

--- a/src-lites-1.1-2025/server/netinet/in_cksum.c
+++ b/src-lites-1.1-2025/server/netinet/in_cksum.c
@@ -33,8 +33,8 @@
  *	@(#)in_cksum.c	8.1 (Berkeley) 6/10/93
  */
 
-#include <sys/param.h>
 #include <sys/mbuf.h>
+#include <sys/param.h>
 
 /*
  * Checksum routine for Internet Protocol family headers (Portable Version).
@@ -43,107 +43,123 @@
  * code and should be modified for each CPU to be as fast as possible.
  */
 
-#define ADDCARRY(x)  (x > 65535 ? x -= 65535 : x)
-#define REDUCE {l_util.l = sum; sum = l_util.s[0] + l_util.s[1]; ADDCARRY(sum);}
+#define ADDCARRY(x) (x > 65535 ? x -= 65535 : x)
+#define REDUCE                                                                                     \
+    {                                                                                              \
+        l_util.l = sum;                                                                            \
+        sum = l_util.s[0] + l_util.s[1];                                                           \
+        ADDCARRY(sum);                                                                             \
+    }
 
-int
-in_cksum(m, len)
-	register struct mbuf *m;
-	register int len;
-{
-	register u_short *w;
-	register int sum = 0;
-	register int mlen = 0;
-	int byte_swapped = 0;
+int in_cksum(struct mbuf *m, int len) {
+    register u_short *w;
+    register int sum = 0;
+    register int mlen = 0;
+    int byte_swapped = 0;
 
-	union {
-		char	c[2];
-		u_short	s;
-	} s_util;
-	union {
-		u_short s[2];
-		long	l;
-	} l_util;
+    union {
+        char c[2];
+        u_short s;
+    } s_util;
+    union {
+        u_short s[2];
+        long l;
+    } l_util;
 
-	for (;m && len; m = m->m_next) {
-		if (m->m_len == 0)
-			continue;
-		w = mtod(m, u_short *);
-		if (mlen == -1) {
-			/*
-			 * The first byte of this mbuf is the continuation
-			 * of a word spanning between this mbuf and the
-			 * last mbuf.
-			 *
-			 * s_util.c[0] is already saved when scanning previous 
-			 * mbuf.
-			 */
-			s_util.c[1] = *(char *)w;
-			sum += s_util.s;
-			w = (u_short *)((char *)w + 1);
-			mlen = m->m_len - 1;
-			len--;
-		} else
-			mlen = m->m_len;
-		if (len < mlen)
-			mlen = len;
-		len -= mlen;
-		/*
-		 * Force to even boundary.
-		 */
-		if ((1 & (integer_t) w) && (mlen > 0)) {
-			REDUCE;
-			sum <<= 8;
-			s_util.c[0] = *(u_char *)w;
-			w = (u_short *)((char *)w + 1);
-			mlen--;
-			byte_swapped = 1;
-		}
-		/*
-		 * Unroll the loop to make overhead from
-		 * branches &c small.
-		 */
-		while ((mlen -= 32) >= 0) {
-			sum += w[0]; sum += w[1]; sum += w[2]; sum += w[3];
-			sum += w[4]; sum += w[5]; sum += w[6]; sum += w[7];
-			sum += w[8]; sum += w[9]; sum += w[10]; sum += w[11];
-			sum += w[12]; sum += w[13]; sum += w[14]; sum += w[15];
-			w += 16;
-		}
-		mlen += 32;
-		while ((mlen -= 8) >= 0) {
-			sum += w[0]; sum += w[1]; sum += w[2]; sum += w[3];
-			w += 4;
-		}
-		mlen += 8;
-		if (mlen == 0 && byte_swapped == 0)
-			continue;
-		REDUCE;
-		while ((mlen -= 2) >= 0) {
-			sum += *w++;
-		}
-		if (byte_swapped) {
-			REDUCE;
-			sum <<= 8;
-			byte_swapped = 0;
-			if (mlen == -1) {
-				s_util.c[1] = *(char *)w;
-				sum += s_util.s;
-				mlen = 0;
-			} else
-				mlen = -1;
-		} else if (mlen == -1)
-			s_util.c[0] = *(char *)w;
-	}
-	if (len)
-		printf("cksum: out of data\n");
-	if (mlen == -1) {
-		/* The last mbuf has odd # of bytes. Follow the
-		   standard (the odd byte may be shifted left by 8 bits
-		   or not as determined by endian-ness of the machine) */
-		s_util.c[1] = 0;
-		sum += s_util.s;
-	}
-	REDUCE;
-	return (~sum & 0xffff);
+    for (; m && len; m = m->m_next) {
+        if (m->m_len == 0)
+            continue;
+        w = mtod(m, u_short *);
+        if (mlen == -1) {
+            /*
+             * The first byte of this mbuf is the continuation
+             * of a word spanning between this mbuf and the
+             * last mbuf.
+             *
+             * s_util.c[0] is already saved when scanning previous
+             * mbuf.
+             */
+            s_util.c[1] = *(char *)w;
+            sum += s_util.s;
+            w = (u_short *)((char *)w + 1);
+            mlen = m->m_len - 1;
+            len--;
+        } else
+            mlen = m->m_len;
+        if (len < mlen)
+            mlen = len;
+        len -= mlen;
+        /*
+         * Force to even boundary.
+         */
+        if ((1 & (integer_t)w) && (mlen > 0)) {
+            REDUCE;
+            sum <<= 8;
+            s_util.c[0] = *(u_char *)w;
+            w = (u_short *)((char *)w + 1);
+            mlen--;
+            byte_swapped = 1;
+        }
+        /*
+         * Unroll the loop to make overhead from
+         * branches &c small.
+         */
+        while ((mlen -= 32) >= 0) {
+            sum += w[0];
+            sum += w[1];
+            sum += w[2];
+            sum += w[3];
+            sum += w[4];
+            sum += w[5];
+            sum += w[6];
+            sum += w[7];
+            sum += w[8];
+            sum += w[9];
+            sum += w[10];
+            sum += w[11];
+            sum += w[12];
+            sum += w[13];
+            sum += w[14];
+            sum += w[15];
+            w += 16;
+        }
+        mlen += 32;
+        while ((mlen -= 8) >= 0) {
+            sum += w[0];
+            sum += w[1];
+            sum += w[2];
+            sum += w[3];
+            w += 4;
+        }
+        mlen += 8;
+        if (mlen == 0 && byte_swapped == 0)
+            continue;
+        REDUCE;
+        while ((mlen -= 2) >= 0) {
+            sum += *w++;
+        }
+        if (byte_swapped) {
+            REDUCE;
+            sum <<= 8;
+            byte_swapped = 0;
+            if (mlen == -1) {
+                s_util.c[1] = *(char *)w;
+                sum += s_util.s;
+                mlen = 0;
+            } else
+                mlen = -1;
+        } else if (mlen == -1)
+            s_util.c[0] = *(char *)w;
+    }
+    if (len)
+        printf("cksum: out of data\n");
+    if (mlen == -1) {
+        /* The last mbuf has odd # of bytes. Follow the
+           standard (the odd byte may be shifted left by 8 bits
+           or not as determined by endian-ness of the machine) */
+        s_util.c[1] = 0;
+        sum += s_util.s;
+    }
+    REDUCE;
+    return (~sum & 0xffff);
 }


### PR DESCRIPTION
## Summary
- modernize the in_cksum implementations to C23 style
- run clang-format
- document C23 compiler requirements

## Testing
- `clang-format -i src-lites-1.1-2025/server/netinet/in_cksum.c src-lites-1.1-2025/liblites/x86_64/in_cksum.c src-lites-1.1-2025/liblites/i386/in_cksum.c src-lites-1.1-2025/liblites/ns532/in_cksum.c`
- `scripts/run-clang-tidy.sh --extra-arg=-std=c23 src-lites-1.1-2025/server/netinet/in_cksum.c src-lites-1.1-2025/liblites/x86_64/in_cksum.c src-lites-1.1-2025/liblites/i386/in_cksum.c src-lites-1.1-2025/liblites/ns532/in_cksum.c` *(fails: Could not auto-detect compilation database)*