### PR TITLE
Clarify openmach directory requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ OpenMach/Mach4 distribution.  The modern build system looks for these
 headers in the directory specified by the `LITES_MACH_DIR` environment
 variable.  If that variable is unset and a directory named `openmach`
 exists at the repository root, it will be used automatically (a git
-submodule can conveniently provide it).
+submodule can conveniently provide it).  The Mach headers are not bundled
+with this repository, so if `openmach` is missing you must supply them
+manually or via git.
 Running `setup.sh` will automatically clone the OpenMach repository when
-network access is available.
+network access is available.  If the clone step fails due to a lack of
+network connectivity, create the directory yourself or set
+`LITES_MACH_DIR` to point at an existing Mach source tree.
 If prebuilt Mach libraries are present, set `LITES_MACH_LIB_DIR` to their
 location (for example `openmach/lib`).  When the variable is not set and
 `openmach/lib` exists, it will be used automatically.


### PR DESCRIPTION
## Summary
- clarify that Mach headers are not included with Lites
- explain how `setup.sh` handles cloning and what to do when offline

## Testing
- `scripts/run-precommit.sh -a` *(fails: Could not install pre-commit due to lack of network access)*