### PR TITLE
Add missing site and SAR headers; modernize sar test

### DIFF
--- a/src-lites-1.1-2025/xkernel/etc/site.h
+++ b/src-lites-1.1-2025/xkernel/etc/site.h
@@ -1,0 +1,5 @@
+#pragma once
+
+/* Default protocol table path used by compose */
+#define DEFAULT_PROTTBL "prottbl.std"
+

--- a/src-lites-1.1-2025/xkernel/include/prot/sarProt.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/sarProt.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#define SAR_GETSTATISTICS 0
+
+void sar_init(XObj);
+

--- a/src-lites-1.1-2025/xkernel/include/xtype.h
+++ b/src-lites-1.1-2025/xkernel/include/xtype.h
@@ -13,9 +13,8 @@
 #ifndef xtype_h
 #define xtype_h
 
+#include <stdbool.h>
 #include <sys/types.h>
-
-typedef unsigned int	bool;
 
 /*
  * upi internal error codes

--- a/src-lites-1.1-2025/xkernel/protocols/test/sartest.c
+++ b/src-lites-1.1-2025/xkernel/protocols/test/sartest.c
@@ -14,6 +14,7 @@
  * Ping-pong test of the SAR protocol
  */
 
+#include <stdbool.h>
 #include "site.h"
 #include "eth.h"
 #include "sarProt.h"
@@ -47,19 +48,19 @@ static int lens[] = {
 #include "common_test.c"
 
 static int
-sarIsServer()
+sarIsServer(void)
 {
   return 0;
 }
 
 static int
-sarIsClient()
+sarIsClient(void)
 {
   return 1;
 }
 
-void
-  showStatistics()
+static void
+showStatistics(void)
 {
   int stats[10];
   
@@ -81,13 +82,10 @@ void
 static int word;
 static int rcvdMsgs;
 
-static bool 
-show(ptr, len, arg)
-char *ptr;
-int len;
-char *arg;
+static bool
+show(char *ptr, int len, char *arg)
 {
-  int i, isav, j, *iptr = (int*)ptr;
+  int i, isav, *iptr = (int*)ptr;
   int start, *startp;
   int error = 0;
 
@@ -127,18 +125,16 @@ char *arg;
   }
 #endif TIME
 
-  return TRUE;
+  return true;
 }
 
 static int bufs;
 static int currentLen;
 
 static xkern_return_t
-sarDemux( self, lls, dg )
-    XObj self, lls;
-    Msg *dg;
+sarDemux(XObj self, XObj lls, Msg *dg)
 {
-  int i, len = msgLen(dg);
+  int len = msgLen(dg);
 
   if (len == currentLen) 
     rcvdMsgs++;
@@ -154,8 +150,7 @@ sarDemux( self, lls, dg )
 
 
 static int
-sarRunTest( len )
-    int len;
+sarRunTest(int len)
 {
     Msg		savedMsg, msg;
     int 	test, trips, i;
@@ -220,7 +215,7 @@ sarRunTest( len )
 
 
 static void
-testInit()
+testInit(void)
 {
   isClient = sarIsClient;
   isServer = sarIsServer;


### PR DESCRIPTION
## Summary
- define a default `site.h` for protocol table location
- add stub `sarProt.h` header
- modernize `sartest.c` to use C99/C23 style prototypes and `stdbool.h`
- switch boolean typedef to use `<stdbool.h>`

## Testing
- `pre-commit` *(fails: command not found)*