### PR TITLE
Add x86_64 support for ext2fs types

### DIFF
--- a/src-lites-1.1-2025/server/ufs/ext2fs/ext2_fs.h
+++ b/src-lites-1.1-2025/server/ufs/ext2fs/ext2_fs.h
@@ -25,7 +25,7 @@
 
 #if defined(i386) || defined(__i386__)
 #include <i386/types.h>
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__amd64__)
 #include <x86_64/types.h>
 #else
 #error need processor specific types


### PR DESCRIPTION
## Summary
- ensure ext2fs pulls in x86_64 type definitions
- allow `ext2_fs.h` to use `__amd64__` synonym

## Testing
- `gcc -m32 -I src-lites-1.1-2025/include -I src-lites-1.1-2025/include/i386 -I src-lites-1.1-2025/server /tmp/test.c -c -o /tmp/test_i686.o`
- `gcc -m64 -I src-lites-1.1-2025/include -I src-lites-1.1-2025/include/x86_64 -I src-lites-1.1-2025/server /tmp/test.c -c -o /tmp/test_x86_64.o`
