### PR TITLE
Add keystore and enclave utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@ a.out
 
 # Ignore generated build directories
 /build/
-/bin/
+/bin/*
+!/bin/*.c
 /obj/
 /dist/
 /release/

--- a/bin/enclave-demo.c
+++ b/bin/enclave-demo.c
@@ -1,0 +1,7 @@
+#include "enclave.h"
+
+int main(void) {
+    int h = enclave_create("demo");
+    enclave_attest(h);
+    return 0;
+}

--- a/bin/keystore-demo.c
+++ b/bin/keystore-demo.c
@@ -1,0 +1,33 @@
+#include "keystore.h"
+
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, char *argv[]) {
+    if (argc != 3) {
+        fprintf(stderr, "Usage: %s <keyfile> <message>\n", argv[0]);
+        return 1;
+    }
+
+    if (ks_generate_key(argv[1], 16) != 0) {
+        perror("ks_generate_key");
+        return 1;
+    }
+
+    unsigned char enc[256];
+    size_t enc_len;
+    ks_encrypt(argv[1], (const unsigned char *)argv[2], strlen(argv[2]), enc, &enc_len);
+
+    printf("ciphertext: ");
+    for (size_t i = 0; i < enc_len; i++) {
+        printf("%02x", enc[i]);
+    }
+    printf("\n");
+
+    unsigned char dec[256];
+    size_t dec_len;
+    ks_decrypt(argv[1], enc, enc_len, dec, &dec_len);
+    dec[dec_len] = '\0';
+    printf("decrypted: %s\n", dec);
+    return 0;
+}

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,44 @@
+# Security APIs
+
+This document describes the keystore and enclave interfaces added to the modernised source tree.
+
+## Keystore
+
+The trivial keystore lives in `crypto/keystore.c`.
+
+```c
+int ks_generate_key(const char *path, size_t len);
+int ks_encrypt(const char *key_path, const unsigned char *in, size_t in_len,
+               unsigned char *out, size_t *out_len);
+int ks_decrypt(const char *key_path, const unsigned char *in, size_t in_len,
+               unsigned char *out, size_t *out_len);
+```
+
+`ks_generate_key` creates a random symmetric key and writes it to the specified file.
+`ks_encrypt` and `ks_decrypt` perform a simple XOR based transformation using the stored key.
+
+## Enclave
+
+`src-lites-1.1-2025/liblites/enclave.c` provides example enclave hooks.
+
+```c
+int enclave_create(const char *name);
+int enclave_attest(int handle);
+```
+
+The current implementation merely prints diagnostic messages but serves as a
+placeholder for a real secure enclave backend.
+
+## Command-line utilities
+
+Two small utilities under `bin/` demonstrate the APIs:
+
+- `keystore-demo` generates a key, encrypts a message and then decrypts it again.
+- `enclave-demo` creates a dummy enclave and performs an attestation step.
+
+They can be compiled manually, for example:
+
+```sh
+cc -I src-lites-1.1-2025/include crypto/keystore.c bin/keystore-demo.c -o keystore-demo
+cc -I src-lites-1.1-2025/include src-lites-1.1-2025/liblites/enclave.c bin/enclave-demo.c -o enclave-demo
+```

--- a/src-lites-1.1-2025/include/enclave.h
+++ b/src-lites-1.1-2025/include/enclave.h
@@ -1,0 +1,7 @@
+#ifndef ENCLAVE_H
+#define ENCLAVE_H
+
+int enclave_create(const char *name);
+int enclave_attest(int handle);
+
+#endif /* ENCLAVE_H */

--- a/src-lites-1.1-2025/include/keystore.h
+++ b/src-lites-1.1-2025/include/keystore.h
@@ -1,0 +1,12 @@
+#ifndef KEYSTORE_H
+#define KEYSTORE_H
+
+#include <stddef.h>
+
+int ks_generate_key(const char *path, size_t len);
+int ks_encrypt(const char *key_path, const unsigned char *in, size_t in_len, unsigned char *out,
+               size_t *out_len);
+int ks_decrypt(const char *key_path, const unsigned char *in, size_t in_len, unsigned char *out,
+               size_t *out_len);
+
+#endif /* KEYSTORE_H */

--- a/src-lites-1.1-2025/liblites/enclave.c
+++ b/src-lites-1.1-2025/liblites/enclave.c
@@ -1,0 +1,13 @@
+#include "enclave.h"
+
+#include <stdio.h>
+
+int enclave_create(const char *name) {
+    printf("enclave '%s' created\n", name);
+    return 1;
+}
+
+int enclave_attest(int handle) {
+    printf("enclave %d attested\n", handle);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `crypto/keystore.c` with simple XOR-based key handling
- introduce `enclave.c` with stub create/attest helpers
- provide sample command-line tools in `bin/`
- document new APIs
- tweak `.gitignore` so `bin/*.c` sources are tracked

## Testing
- `scripts/run-precommit.sh` *(fails: could not install pre-commit)*