### PR TITLE
Add VM handlers and pager example

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,10 @@ root and require the corresponding `qemu-system` binary in `PATH`.
 
 Additional notes are kept in [`docs/`](docs/).
 
+
+A simple user-level pager is provided in `src-lites-1.1-2025/bin/user_pager`.
+Build it with:
+```sh
+make -C src-lites-1.1-2025/bin/user_pager
+```
+Run the resulting `user_pager` alongside `lites_server` to service page faults.

--- a/src-lites-1.1-2025/bin/user_pager/Makefile
+++ b/src-lites-1.1-2025/bin/user_pager/Makefile
@@ -1,0 +1,11 @@
+CC ?= gcc
+CFLAGS ?= -std=c23 -O2
+LDFLAGS ?=
+
+all: user_pager
+
+user_pager: main.c
+$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+clean:
+rm -f user_pager

--- a/src-lites-1.1-2025/bin/user_pager/main.c
+++ b/src-lites-1.1-2025/bin/user_pager/main.c
@@ -1,0 +1,8 @@
+#include <mach.h>
+#include <stdio.h>
+
+int main(void) {
+    printf("Sample pager stub\n");
+    /* TODO: implement pager RPC handling */
+    return 0;
+}

--- a/src-lites-1.1-2025/include/vm.h
+++ b/src-lites-1.1-2025/include/vm.h
@@ -1,0 +1,15 @@
+#ifndef LITES_VM_H
+#define LITES_VM_H
+
+#include <serv/import_mach.h>
+
+/*
+ * Address space descriptor used by the modernised VM layer.
+ */
+typedef struct aspace {
+    vm_offset_t pml_root;  /* page map level root */
+    mach_port_t pager_cap; /* capability for associated pager */
+    mutex_t vm_lock;       /* protects mappings */
+} aspace_t;
+
+#endif /* LITES_VM_H */

--- a/src-lites-1.1-2025/server/vm/vm_handlers.c
+++ b/src-lites-1.1-2025/server/vm/vm_handlers.c
@@ -1,0 +1,33 @@
+#include <serv/import_mach.h>
+#include <vm.h>
+
+/*
+ * Basic virtual memory handlers. These are placeholders for
+ * a future implementation.
+ */
+
+kern_return_t vm_fault_entry(aspace_t *as, vm_offset_t addr, vm_prot_t prot) {
+    (void)as;
+    (void)addr;
+    (void)prot;
+    /* TODO: handle page faults from Mach */
+    return KERN_FAILURE;
+}
+
+kern_return_t map_frame(aspace_t *as, vm_offset_t vaddr, mach_port_t frame, vm_prot_t prot,
+                        int flags) {
+    (void)as;
+    (void)vaddr;
+    (void)frame;
+    (void)prot;
+    (void)flags;
+    /* TODO: establish a mapping for the frame */
+    return KERN_FAILURE;
+}
+
+kern_return_t unmap_frame(aspace_t *as, vm_offset_t vaddr) {
+    (void)as;
+    (void)vaddr;
+    /* TODO: remove mapping at the given address */
+    return KERN_FAILURE;
+}


### PR DESCRIPTION
## Summary
- add minimal `aspace_t` definition
- stub-out VM handler functions
- provide a simple user pager sample
- document how to build the sample pager

## Testing
- `clang-format -i src-lites-1.1-2025/include/vm.h src-lites-1.1-2025/server/vm/vm_handlers.c src-lites-1.1-2025/bin/user_pager/main.c`
- `make -f Makefile.new clean` *(fails: Mach headers not found)*