### PR TITLE
Add multicore scheduling framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(ARCH "$ENV{ARCH}" CACHE STRING "Target architecture (x86_64 or i686)")
 set(CFLAGS "$ENV{CFLAGS}" CACHE STRING "Additional compiler flags")
 set(LDFLAGS "$ENV{LDFLAGS}" CACHE STRING "Additional linker flags")
 set(SANITIZE "$ENV{SANITIZE}" CACHE STRING "Enable address sanitizer (1/0)")
+set(MULTICORE_SCHED "$ENV{MULTICORE_SCHED}" CACHE STRING "Enable multicore scheduler (1/0)")
 set(LITES_MACH_LIB_DIR "$ENV{LITES_MACH_LIB_DIR}" CACHE PATH "Directory containing Mach static libraries")
 set(LITES_MACH_DIR "$ENV{LITES_MACH_DIR}" CACHE PATH "Mach kernel source directory")
 if(NOT LITES_MACH_DIR AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/openmach")
@@ -36,6 +37,12 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LDFLAGS}")
 if(SANITIZE STREQUAL "1")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
+endif()
+
+if(MULTICORE_SCHED STREQUAL "1")
+    add_compile_definitions(CONFIG_SCHED_MULTICORE=1)
+else()
+    add_compile_definitions(CONFIG_SCHED_MULTICORE=0)
 endif()
 
 if(ARCH STREQUAL "i686")
@@ -98,6 +105,8 @@ if(EXISTS "${LITES_SRC_DIR}")
         file(GLOB_RECURSE _dir_src "${dir}/*.c" "${dir}/*.S")
         list(APPEND SERVER_SRC ${_dir_src})
     endforeach()
+    file(GLOB _kern_src "${CMAKE_CURRENT_SOURCE_DIR}/kern/*.c")
+    list(APPEND SERVER_SRC ${_kern_src})
 
     if(EXISTS "${LITES_SRC_DIR}/emulator")
         file(GLOB EMULATOR_SUBDIRS RELATIVE "${LITES_SRC_DIR}/emulator" "${LITES_SRC_DIR}/emulator/*")
@@ -116,13 +125,15 @@ if(EXISTS "${LITES_SRC_DIR}")
             file(GLOB_RECURSE _dir_src "${dir}/*.c" "${dir}/*.S")
             list(APPEND EMULATOR_SRC ${_dir_src})
         endforeach()
+        list(APPEND EMULATOR_SRC ${_kern_src})
     endif()
 
     add_executable(lites_server ${SERVER_SRC})
     target_include_directories(lites_server PRIVATE
         "${LITES_SRC_DIR}/include"
         "${LITES_SRC_DIR}/server"
-        "${MACH_INCLUDE_DIR}")
+        "${MACH_INCLUDE_DIR}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/kern")
     if(ARCH STREQUAL "x86_64")
         target_include_directories(lites_server PRIVATE
             "${LITES_SRC_DIR}/include/x86_64")
@@ -142,7 +153,8 @@ if(EXISTS "${LITES_SRC_DIR}")
         target_include_directories(lites_emulator PRIVATE
             "${LITES_SRC_DIR}/include"
             "${LITES_SRC_DIR}/emulator"
-            "${MACH_INCLUDE_DIR}")
+            "${MACH_INCLUDE_DIR}"
+            "${CMAKE_CURRENT_SOURCE_DIR}/kern")
         if(ARCH STREQUAL "x86_64")
             target_include_directories(lites_emulator PRIVATE
                 "${LITES_SRC_DIR}/include/x86_64")

--- a/Makefile.new
+++ b/Makefile.new
@@ -49,6 +49,14 @@ CFLAGS += -fsanitize=address
 LDFLAGS += -fsanitize=address
 endif
 
+# Multicore scheduler support
+MULTICORE_SCHED ?= 0
+ifeq ($(MULTICORE_SCHED),1)
+CFLAGS += -DCONFIG_SCHED_MULTICORE=1
+else
+CFLAGS += -DCONFIG_SCHED_MULTICORE=0
+endif
+
 
 # Translate ARCH into compiler options and cross-compilers
 ifeq ($(ARCH),i686)
@@ -85,6 +93,8 @@ SERVER_COMMON_DIRS := \
 SERVER_DIRS := $(SRCDIR)/server/$(ARCH_DIR) $(SERVER_COMMON_DIRS)
 SERVER_SRC := $(foreach d,$(SERVER_DIRS),$(shell find $(d) -name \*.c -o -name \*.S))
 SERVER_INCDIRS := $(addprefix -I,$(SERVER_DIRS))
+KERN_SRC := $(wildcard kern/*.c)
+KERN_INCDIRS := -Ikern
 
 ifneq ($(wildcard $(SRCDIR)/emulator),)
 EMULATOR_SRC := $(shell find $(SRCDIR)/emulator -name '*.c' -o -name '*.S')
@@ -105,12 +115,12 @@ prepare:
 	  ln -s $$arch_dir $(SRCDIR)/include/machine; \
 	fi
 
-lites_server: $(SERVER_SRC)
-        $(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(SERVER_INCDIRS) $^ $(MACH_LIBS) $(LDFLAGS) -o $@
+lites_server: $(SERVER_SRC) $(KERN_SRC)
+        $(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(SERVER_INCDIRS) $(KERN_INCDIRS) $^ $(MACH_LIBS) $(LDFLAGS) -o $@
 
 ifneq ($(EMULATOR_SRC),)
-lites_emulator: $(EMULATOR_SRC)
-        $(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(EMULATOR_INCDIRS) $^ $(MACH_LIBS) $(LDFLAGS) -o $@
+lites_emulator: $(EMULATOR_SRC) $(KERN_SRC)
+        $(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(EMULATOR_INCDIRS) $(KERN_INCDIRS) $^ $(MACH_LIBS) $(LDFLAGS) -o $@
 endif
 	
 clean:

--- a/kern/sched.c
+++ b/kern/sched.c
@@ -1,0 +1,124 @@
+#include "sched.h"
+#include <mach/cthreads.h>
+#include <mach/mach.h>
+#include <sys/queue.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#ifndef CONFIG_SCHED_MULTICORE
+#define CONFIG_SCHED_MULTICORE 0
+#endif
+
+#ifndef MAX_CPUS
+#define MAX_CPUS 8
+#endif
+
+struct thread_entry {
+    cthread_t thread;
+    TAILQ_ENTRY(thread_entry) link;
+};
+
+struct run_queue {
+    TAILQ_HEAD(, thread_entry) queue;
+    mutex_t lock;
+};
+
+static struct run_queue run_queues[MAX_CPUS];
+static int sched_num_cpus = 1;
+static int next_cpu = 0;
+
+static struct thread_entry *attempt_work_steal(int cpu);
+
+void scheduler_init(int num_cores) {
+    if (num_cores < 1)
+        num_cores = 1;
+    if (num_cores > MAX_CPUS)
+        num_cores = MAX_CPUS;
+    sched_num_cpus = num_cores;
+    for (int i = 0; i < sched_num_cpus; ++i) {
+        TAILQ_INIT(&run_queues[i].queue);
+        mutex_init(&run_queues[i].lock);
+    }
+#if CONFIG_SCHED_MULTICORE
+    for (int i = 0; i < sched_num_cpus; ++i) {
+        cthread_detach(cthread_fork((cthread_fn_t)scheduler_loop, (void *)(long)i));
+    }
+#endif
+}
+
+void schedule_enqueue(cthread_t thread) {
+    struct thread_entry *te = malloc(sizeof(*te));
+    if (!te)
+        return;
+    te->thread = thread;
+    int cpu = 0;
+#if CONFIG_SCHED_MULTICORE
+    cpu = __sync_fetch_and_add(&next_cpu, 1) % sched_num_cpus;
+#endif
+    mutex_lock(&run_queues[cpu].lock);
+    TAILQ_INSERT_TAIL(&run_queues[cpu].queue, te, link);
+    mutex_unlock(&run_queues[cpu].lock);
+}
+
+void schedule_dequeue(cthread_t thread) {
+    for (int cpu = 0; cpu < sched_num_cpus; ++cpu) {
+        mutex_lock(&run_queues[cpu].lock);
+        struct thread_entry *it;
+        TAILQ_FOREACH(it, &run_queues[cpu].queue, link) {
+            if (it->thread == thread) {
+                TAILQ_REMOVE(&run_queues[cpu].queue, it, link);
+                mutex_unlock(&run_queues[cpu].lock);
+                free(it);
+                return;
+            }
+        }
+        mutex_unlock(&run_queues[cpu].lock);
+    }
+}
+
+static struct thread_entry *attempt_work_steal(int cpu) {
+    for (int i = 0; i < sched_num_cpus; ++i) {
+        if (i == cpu)
+            continue;
+        mutex_lock(&run_queues[i].lock);
+        struct thread_entry *it = TAILQ_FIRST(&run_queues[i].queue);
+        if (it) {
+            TAILQ_REMOVE(&run_queues[i].queue, it, link);
+            mutex_unlock(&run_queues[i].lock);
+            return it;
+        }
+        mutex_unlock(&run_queues[i].lock);
+    }
+    return NULL;
+}
+
+void *scheduler_loop(void *arg) {
+    int cpu = (int)(long)arg;
+    while (1) {
+        struct thread_entry *te = NULL;
+        mutex_lock(&run_queues[cpu].lock);
+        te = TAILQ_FIRST(&run_queues[cpu].queue);
+        if (te)
+            TAILQ_REMOVE(&run_queues[cpu].queue, te, link);
+        mutex_unlock(&run_queues[cpu].lock);
+
+        if (!te) {
+            te = attempt_work_steal(cpu);
+            if (!te) {
+                usleep(1000);
+                continue;
+            }
+        }
+
+        /*
+         * There is no direct user level context switch interface
+         * available here.  Simply yield in the hope that the newly
+         * queued thread will run.
+         */
+        free(te);
+        /* timer based preemption */
+        usleep(10000);
+        cthread_yield();
+    }
+    return NULL;
+}

--- a/kern/sched.h
+++ b/kern/sched.h
@@ -1,0 +1,11 @@
+#ifndef LITES_SCHED_H
+#define LITES_SCHED_H
+
+#include <cthreads.h>
+
+void schedule_enqueue(cthread_t thread);
+void schedule_dequeue(cthread_t thread);
+void *scheduler_loop(void *arg);
+void scheduler_init(int num_cores);
+
+#endif /* LITES_SCHED_H */


### PR DESCRIPTION
## Summary
- implement a basic multicore scheduler in `kern/sched.c`
- expose scheduler API in new `kern/sched.h`
- integrate scheduler with server thread bootstrap
- start scheduler from `ux_server_init`
- add build options and sources for the new scheduler

## Testing
- `pre-commit run --files CMakeLists.txt Makefile.new src-lites-1.1-2025/server/serv/ux_server_loop.c kern/sched.c kern/sched.h` *(fails: command not found)*