### PR TITLE
Implement capability primitives

### DIFF
--- a/src-lites-1.1-2025/include/cap.h
+++ b/src-lites-1.1-2025/include/cap.h
@@ -1,0 +1,17 @@
+#ifndef _CAP_H_
+#define _CAP_H_
+
+struct cap {
+    struct cap *parent;
+    struct cap *children; /* linked list of children */
+    struct cap *next_sibling;
+    unsigned long epoch;
+    unsigned long rights;
+    unsigned int flags;
+};
+
+struct cap *cap_refine(struct cap *parent, unsigned long rights, unsigned int flags);
+void revoke_capability(struct cap *cap);
+int cap_check(const struct cap *cap);
+
+#endif /* _CAP_H_ */

--- a/src-lites-1.1-2025/server/kern/cap.c
+++ b/src-lites-1.1-2025/server/kern/cap.c
@@ -1,0 +1,72 @@
+#include <stdlib.h>
+#include "../../include/cap.h"
+
+static int cap_check_node(const struct cap *c)
+{
+    const struct cap *child;
+    for (child = c->children; child; child = child->next_sibling) {
+        if (child->parent != c)
+            return 0;
+        if ((child->rights & c->rights) != child->rights)
+            return 0;
+        if (child->epoch != c->epoch)
+            return 0;
+        if (!cap_check_node(child))
+            return 0;
+    }
+    return 1;
+}
+
+int cap_check(const struct cap *cap)
+{
+    if (!cap)
+        return 0;
+    return cap_check_node(cap);
+}
+
+struct cap *
+cap_refine(struct cap *parent, unsigned long rights, unsigned int flags)
+{
+    struct cap *c;
+
+    if (!parent)
+        return NULL;
+    if ((rights & parent->rights) != rights)
+        return NULL;
+
+    c = malloc(sizeof(*c));
+    if (!c)
+        return NULL;
+
+    c->parent = parent;
+    c->children = NULL;
+    c->next_sibling = parent->children;
+    parent->children = c;
+
+    c->epoch = parent->epoch;
+    c->rights = rights;
+    c->flags = flags;
+
+    return c;
+}
+
+void
+delete_subtree(struct cap *cap)
+{
+    struct cap *child = cap->children;
+    while (child) {
+        struct cap *next = child->next_sibling;
+        delete_subtree(child);
+        child = next;
+    }
+    free(cap);
+}
+
+void
+revoke_capability(struct cap *cap)
+{
+    struct cap *child;
+    cap->epoch++;
+    for (child = cap->children; child; child = child->next_sibling)
+        revoke_capability(child);
+}

--- a/tests/cap/Makefile
+++ b/tests/cap/Makefile
@@ -1,0 +1,12 @@
+CC ?= gcc
+CFLAGS ?= -std=c2x -Wall -Wextra 
+
+all: test_cap
+
+.PHONY: all clean
+
+test_cap: test_cap.c ../../src-lites-1.1-2025/server/kern/cap.c
+	$(CC) $(CFLAGS) $^ -o $@
+
+clean:
+	rm -f test_cap

--- a/tests/cap/test_cap.c
+++ b/tests/cap/test_cap.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+#include <stdlib.h>
+#include "../../src-lites-1.1-2025/include/cap.h"
+
+int main(void)
+{
+    struct cap root = {0};
+    root.rights = 0xff;
+    root.epoch = 1;
+
+    struct cap *child = cap_refine(&root, 0x0f, 0);
+    assert(child);
+    assert(child->parent == &root);
+    assert(child->rights == 0x0f);
+    assert(cap_check(&root));
+
+    revoke_capability(&root);
+    assert(root.epoch == 2);
+    assert(child->epoch == 2);
+    assert(cap_check(&root));
+
+    free(child);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- introduce `struct cap` for tracking capability state
- implement `cap_refine` and `revoke_capability`
- add basic invariant checking helpers
- provide simple unit test for capabilities

## Testing
- `scripts/check-kr.sh`
- `make -C tests/cap`
- `tests/cap/test_cap`