### PR TITLE
Add basic IOMMU subsystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,8 @@ if(EXISTS "${LITES_SRC_DIR}")
         file(GLOB_RECURSE _dir_src "${dir}/*.c" "${dir}/*.S")
         list(APPEND SERVER_SRC ${_dir_src})
     endforeach()
+    file(GLOB _iommu_src "${LITES_SRC_DIR}/iommu/*.c")
+    list(APPEND SERVER_SRC ${_iommu_src})
 
     if(EXISTS "${LITES_SRC_DIR}/emulator")
         file(GLOB EMULATOR_SUBDIRS RELATIVE "${LITES_SRC_DIR}/emulator" "${LITES_SRC_DIR}/emulator/*")
@@ -121,6 +123,7 @@ if(EXISTS "${LITES_SRC_DIR}")
     add_executable(lites_server ${SERVER_SRC})
     target_include_directories(lites_server PRIVATE
         "${LITES_SRC_DIR}/include"
+        "${LITES_SRC_DIR}/iommu"
         "${LITES_SRC_DIR}/server"
         "${MACH_INCLUDE_DIR}")
     if(ARCH STREQUAL "x86_64")

--- a/Makefile.new
+++ b/Makefile.new
@@ -85,6 +85,7 @@ SERVER_COMMON_DIRS := \
 SERVER_DIRS := $(SRCDIR)/server/$(ARCH_DIR) $(SERVER_COMMON_DIRS)
 SERVER_SRC := $(foreach d,$(SERVER_DIRS),$(shell find $(d) -name \*.c -o -name \*.S))
 SERVER_INCDIRS := $(addprefix -I,$(SERVER_DIRS))
+IOMMU_SRC := $(wildcard $(SRCDIR)/iommu/*.c)
 
 ifneq ($(wildcard $(SRCDIR)/emulator),)
 EMULATOR_SRC := $(shell find $(SRCDIR)/emulator -name '*.c' -o -name '*.S')
@@ -105,8 +106,8 @@ prepare:
 	  ln -s $$arch_dir $(SRCDIR)/include/machine; \
 	fi
 
-lites_server: $(SERVER_SRC)
-        $(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(SERVER_INCDIRS) $^ $(MACH_LIBS) $(LDFLAGS) -o $@
+lites_server: $(SERVER_SRC) $(IOMMU_SRC)
+       $(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(SERVER_INCDIRS) $^ $(MACH_LIBS) $(LDFLAGS) -o $@
 
 ifneq ($(EMULATOR_SRC),)
 lites_emulator: $(EMULATOR_SRC)

--- a/docs/iommu.md
+++ b/docs/iommu.md
@@ -1,0 +1,25 @@
+# IOMMU Module
+
+This module provides a simple in-memory implementation of an IOMMU domain.
+It allows mapping I/O virtual addresses (IOVA) to physical addresses. The
+interface is defined in `include/iommu.h`.
+
+## Usage
+
+1. Initialize a domain:
+   ```c
+   iommu_dom_t dom;
+   iommu_dom_init(&dom);
+   ```
+
+2. Map or unmap regions:
+   ```c
+   iommu_map(&dom, iova, phys_addr, length);
+   iommu_unmap(&dom, iova, length);
+   ```
+
+3. Bulk mappings are possible with `iommu_bulk_map` which takes an array of
+   `iommu_map_entry` structures.
+
+Mappings are protected by an internal mutex. The current implementation stores
+entries in a linked list and checks for overlaps on each map operation.

--- a/src-lites-1.1-2025/include/iommu.h
+++ b/src-lites-1.1-2025/include/iommu.h
@@ -1,0 +1,38 @@
+#ifndef IOMMU_H
+#define IOMMU_H
+
+#include <pthread.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct iommu_map_entry {
+    uintptr_t iova;
+    uintptr_t pa;
+    size_t len;
+};
+
+struct iommu_mapping {
+    struct iommu_map_entry entry;
+    struct iommu_mapping *next;
+};
+
+typedef struct iommu_dom {
+    pthread_mutex_t lock;
+    struct iommu_mapping *mappings;
+} iommu_dom_t;
+
+static inline void iommu_dom_init(struct iommu_dom *dom) {
+    pthread_mutex_init(&dom->lock, NULL);
+    dom->mappings = NULL;
+}
+
+static inline void iommu_dom_lock(struct iommu_dom *dom) { pthread_mutex_lock(&dom->lock); }
+
+static inline void iommu_dom_unlock(struct iommu_dom *dom) { pthread_mutex_unlock(&dom->lock); }
+
+int iommu_map(struct iommu_dom *dom, uintptr_t iova, uintptr_t pa, size_t len);
+int iommu_unmap(struct iommu_dom *dom, uintptr_t iova, size_t len);
+int iommu_bulk_map(struct iommu_dom *dom, const struct iommu_map_entry *list, size_t count);
+
+#endif /* IOMMU_H */

--- a/src-lites-1.1-2025/iommu/iommu.c
+++ b/src-lites-1.1-2025/iommu/iommu.c
@@ -1,0 +1,81 @@
+#include <iommu.h>
+#include <stdlib.h>
+
+static struct iommu_mapping *find_mapping(struct iommu_dom *dom, uintptr_t iova, size_t len,
+                                          struct iommu_mapping ***prev) {
+    struct iommu_mapping **p = &dom->mappings;
+    while (*p) {
+        struct iommu_mapping *cur = *p;
+        if (cur->entry.iova == iova && cur->entry.len == len) {
+            if (prev)
+                *prev = p;
+            return cur;
+        }
+        p = &(*p)->next;
+    }
+    return NULL;
+}
+
+static bool overlap(const struct iommu_map_entry *a, const struct iommu_map_entry *b) {
+    uintptr_t a_end = a->iova + a->len;
+    uintptr_t b_end = b->iova + b->len;
+    return (a->iova < b_end) && (b->iova < a_end);
+}
+
+int iommu_map(struct iommu_dom *dom, uintptr_t iova, uintptr_t pa, size_t len) {
+    if (!dom || len == 0)
+        return -1;
+
+    struct iommu_map_entry ent = {.iova = iova, .pa = pa, .len = len};
+
+    iommu_dom_lock(dom);
+    for (struct iommu_mapping *cur = dom->mappings; cur; cur = cur->next) {
+        if (overlap(&ent, &cur->entry)) {
+            iommu_dom_unlock(dom);
+            return -1;
+        }
+    }
+
+    struct iommu_mapping *m = malloc(sizeof(*m));
+    if (!m) {
+        iommu_dom_unlock(dom);
+        return -1;
+    }
+    m->entry = ent;
+    m->next = dom->mappings;
+    dom->mappings = m;
+    iommu_dom_unlock(dom);
+    return 0;
+}
+
+int iommu_unmap(struct iommu_dom *dom, uintptr_t iova, size_t len) {
+    if (!dom || len == 0)
+        return -1;
+
+    iommu_dom_lock(dom);
+    struct iommu_mapping **prev = NULL;
+    struct iommu_mapping *m = find_mapping(dom, iova, len, &prev);
+    if (!m) {
+        iommu_dom_unlock(dom);
+        return -1;
+    }
+    *prev = m->next;
+    iommu_dom_unlock(dom);
+    free(m);
+    return 0;
+}
+
+int iommu_bulk_map(struct iommu_dom *dom, const struct iommu_map_entry *list, size_t count) {
+    size_t i;
+    for (i = 0; i < count; ++i) {
+        if (iommu_map(dom, list[i].iova, list[i].pa, list[i].len) != 0)
+            break;
+    }
+    if (i != count) {
+        /* rollback previously mapped entries */
+        while (i-- > 0)
+            iommu_unmap(dom, list[i].iova, list[i].len);
+        return -1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add simple iommu domain API and implementation
- build iommu module with Makefile.new and CMake
- document usage of the IOMMU functions

## Testing
- `scripts/format-code.sh`
- `make -f Makefile.new` *(fails: Mach headers not found)*