### PR TITLE
Improve keystore-demo error checks

### DIFF
--- a/bin/keystore-demo.c
+++ b/bin/keystore-demo.c
@@ -16,7 +16,10 @@ int main(int argc, char *argv[]) {
 
     unsigned char enc[256];
     size_t enc_len;
-    ks_encrypt(argv[1], (const unsigned char *)argv[2], strlen(argv[2]), enc, &enc_len);
+    if (ks_encrypt(argv[1], (const unsigned char *)argv[2], strlen(argv[2]), enc, &enc_len) != 0) {
+        perror("ks_encrypt");
+        return 1;
+    }
 
     printf("ciphertext: ");
     for (size_t i = 0; i < enc_len; i++) {
@@ -26,7 +29,10 @@ int main(int argc, char *argv[]) {
 
     unsigned char dec[256];
     size_t dec_len;
-    ks_decrypt(argv[1], enc, enc_len, dec, &dec_len);
+    if (ks_decrypt(argv[1], enc, enc_len, dec, &dec_len) != 0) {
+        perror("ks_decrypt");
+        return 1;
+    }
     dec[dec_len] = '\0';
     printf("decrypted: %s\n", dec);
     return 0;


### PR DESCRIPTION
## Summary
- verify the return status of `ks_encrypt` and `ks_decrypt`
- abort with an error message if either fails

## Testing
- `make clean && make && ./test_cap` in `tests/cap`
- `pre-commit run --files bin/keystore-demo.c` *(fails: command not found)*