### PR TITLE
Add auth/audit modules with tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,8 @@ if(EXISTS "${LITES_SRC_DIR}")
         "${LITES_SRC_DIR}/include"
         "${LITES_SRC_DIR}/server"
         "${MACH_INCLUDE_DIR}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/kern")
+        "${CMAKE_CURRENT_SOURCE_DIR}/kern"
+        "${CMAKE_CURRENT_SOURCE_DIR}/include")
     if(ARCH STREQUAL "x86_64")
         target_include_directories(lites_server PRIVATE
             "${LITES_SRC_DIR}/include/x86_64")
@@ -154,7 +155,8 @@ if(EXISTS "${LITES_SRC_DIR}")
             "${LITES_SRC_DIR}/include"
             "${LITES_SRC_DIR}/emulator"
             "${MACH_INCLUDE_DIR}"
-            "${CMAKE_CURRENT_SOURCE_DIR}/kern")
+            "${CMAKE_CURRENT_SOURCE_DIR}/kern"
+            "${CMAKE_CURRENT_SOURCE_DIR}/include")
         if(ARCH STREQUAL "x86_64")
             target_include_directories(lites_emulator PRIVATE
                 "${LITES_SRC_DIR}/include/x86_64")

--- a/Makefile.new
+++ b/Makefile.new
@@ -94,7 +94,7 @@ SERVER_DIRS := $(SRCDIR)/server/$(ARCH_DIR) $(SERVER_COMMON_DIRS)
 SERVER_SRC := $(foreach d,$(SERVER_DIRS),$(shell find $(d) -name \*.c -o -name \*.S))
 SERVER_INCDIRS := $(addprefix -I,$(SERVER_DIRS))
 KERN_SRC := $(wildcard kern/*.c)
-KERN_INCDIRS := -Ikern
+KERN_INCDIRS := -Ikern -Iinclude
 
 ifneq ($(wildcard $(SRCDIR)/emulator),)
 EMULATOR_SRC := $(shell find $(SRCDIR)/emulator -name '*.c' -o -name '*.S')

--- a/include/audit.h
+++ b/include/audit.h
@@ -1,0 +1,18 @@
+#ifndef LITES_AUDIT_H
+#define LITES_AUDIT_H
+
+#include <stdint.h>
+
+typedef struct {
+    uint32_t op;
+    uint64_t obj;
+    int result;
+} audit_entry_t;
+
+#define AUDIT_LOG_SIZE 32
+
+extern audit_entry_t audit_log[AUDIT_LOG_SIZE];
+
+void audit_record(uint32_t op, uint64_t obj, int result);
+
+#endif /* LITES_AUDIT_H */

--- a/include/auth.h
+++ b/include/auth.h
@@ -1,0 +1,21 @@
+#ifndef LITES_AUTH_H
+#define LITES_AUTH_H
+
+#include <stdint.h>
+#include "../src-lites-1.1-2025/include/cap.h"
+
+typedef struct cap cap_t;
+
+typedef struct {
+    const cap_t *subject;
+    uint32_t op;
+    uint64_t obj;
+} acl_entry_t;
+
+void acl_add(const cap_t *subject, uint32_t op, uint64_t obj);
+int authorize(const cap_t *subject, uint32_t op, uint64_t obj);
+
+#define CAP_OP_REFINE 1
+#define CAP_OP_REVOKE 2
+
+#endif /* LITES_AUTH_H */

--- a/kern/audit.c
+++ b/kern/audit.c
@@ -1,0 +1,12 @@
+#include "audit.h"
+
+audit_entry_t audit_log[AUDIT_LOG_SIZE];
+static int audit_pos;
+
+void audit_record(uint32_t op, uint64_t obj, int result)
+{
+    audit_log[audit_pos].op = op;
+    audit_log[audit_pos].obj = obj;
+    audit_log[audit_pos].result = result;
+    audit_pos = (audit_pos + 1) % AUDIT_LOG_SIZE;
+}

--- a/kern/auth.c
+++ b/kern/auth.c
@@ -1,0 +1,31 @@
+#include "auth.h"
+#include "audit.h"
+
+#define MAX_ACL 64
+
+static acl_entry_t acl_table[MAX_ACL];
+static int acl_count;
+
+void acl_add(const cap_t *subject, uint32_t op, uint64_t obj)
+{
+    if (acl_count < MAX_ACL) {
+        acl_table[acl_count].subject = subject;
+        acl_table[acl_count].op = op;
+        acl_table[acl_count].obj = obj;
+        acl_count++;
+    }
+}
+
+int authorize(const cap_t *subject, uint32_t op, uint64_t obj)
+{
+    for (int i = 0; i < acl_count; ++i) {
+        if (acl_table[i].subject == subject &&
+            acl_table[i].op == op &&
+            acl_table[i].obj == obj) {
+            audit_record(op, obj, 1);
+            return 1;
+        }
+    }
+    audit_record(op, obj, 0);
+    return 0;
+}

--- a/src-lites-1.1-2025/server/kern/cap.c
+++ b/src-lites-1.1-2025/server/kern/cap.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include "../../include/cap.h"
+#include "auth.h"
 
 static int cap_check_node(const struct cap *c)
 {
@@ -34,6 +35,9 @@ cap_refine(struct cap *parent, unsigned long rights, unsigned int flags)
     if ((rights & parent->rights) != rights)
         return NULL;
 
+    if (!authorize(parent, CAP_OP_REFINE, rights))
+        return NULL;
+
     c = malloc(sizeof(*c));
     if (!c)
         return NULL;
@@ -66,6 +70,8 @@ void
 revoke_capability(struct cap *cap)
 {
     struct cap *child;
+    if (!authorize(cap, CAP_OP_REVOKE, 0))
+        return;
     cap->epoch++;
     for (child = cap->children; child; child = child->next_sibling)
         revoke_capability(child);

--- a/src-lites-1.1-2025/server/serv/ux_syscall.c
+++ b/src-lites-1.1-2025/server/serv/ux_syscall.c
@@ -44,6 +44,7 @@
 #include <serv/syscalltrace.h>
 #include <serv/server_defs.h>
 #include <serv/syscall_subr.h>
+#include "auth.h"
 
 extern struct sysent	sysent[];
 int			nsysent;
@@ -143,6 +144,14 @@ ux_generic_server(mach_msg_header_t *InHeadP, mach_msg_header_t *OutHeadP)
 	assert(p);		/* XXX remove. debug only */
 	if (!p)
 	    return FALSE;
+
+	static struct cap ipc_cap = {0};
+	ipc_cap.rights = 0xffffffff;
+	ipc_cap.epoch = 1;
+	if (!authorize(&ipc_cap, syscode, 0)) {
+	    rep->retcode = EPERM;
+	    return TRUE;
+	}
 
 	/* attach process state to invocation state */
 	pk->k_p = p;

--- a/tests/audit/Makefile
+++ b/tests/audit/Makefile
@@ -1,0 +1,13 @@
+CC ?= gcc
+CFLAGS ?= -std=gnu2x -Wall -Wextra
+
+all: test_audit
+
+
+.PHONY: all clean
+
+test_audit: test_audit.c ../../kern/auth.c ../../kern/audit.c
+	$(CC) $(CFLAGS) -I../../include $^ -o $@
+
+clean:
+		rm -f test_audit

--- a/tests/audit/test_audit.c
+++ b/tests/audit/test_audit.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+#include <stdlib.h>
+#include "../../include/auth.h"
+#include "../../include/audit.h"
+#include "../../src-lites-1.1-2025/include/cap.h"
+
+int main(void)
+{
+    struct cap subject = {0};
+    subject.rights = 0xff;
+    subject.epoch = 1;
+
+    acl_add(&subject, 1, 42); /* allow op 1 on obj 42 */
+
+    /* This should fail and be logged */
+    int ok = authorize(&subject, 2, 43);
+    assert(!ok);
+    assert(audit_log[0].op == 2);
+    assert(audit_log[0].result == 0);
+
+    return 0;
+}

--- a/tests/cap/Makefile
+++ b/tests/cap/Makefile
@@ -1,12 +1,13 @@
 CC ?= gcc
-CFLAGS ?= -std=c2x -Wall -Wextra 
+CFLAGS ?= -std=gnu2x -Wall -Wextra
 
 all: test_cap
 
+
 .PHONY: all clean
 
-test_cap: test_cap.c ../../src-lites-1.1-2025/server/kern/cap.c
-	$(CC) $(CFLAGS) $^ -o $@
+test_cap: test_cap.c ../../src-lites-1.1-2025/server/kern/cap.c ../../kern/auth.c ../../kern/audit.c
+	$(CC) $(CFLAGS) -I../../include $^ -o $@
 
 clean:
-	rm -f test_cap
+		rm -f test_cap

--- a/tests/cap/test_cap.c
+++ b/tests/cap/test_cap.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include "../../src-lites-1.1-2025/include/cap.h"
+#include "../../include/auth.h"
 
 int main(void)
 {
@@ -8,8 +9,11 @@ int main(void)
     root.rights = 0xff;
     root.epoch = 1;
 
+    acl_add(&root, CAP_OP_REFINE, 0x0f);
+    acl_add(&root, CAP_OP_REVOKE, 0);
     struct cap *child = cap_refine(&root, 0x0f, 0);
     assert(child);
+    acl_add(child, CAP_OP_REVOKE, 0);
     assert(child->parent == &root);
     assert(child->rights == 0x0f);
     assert(cap_check(&root));


### PR DESCRIPTION
## Summary
- implement simple ACL-based authorization and auditing
- hook authorization into capability code and syscall dispatch
- add include paths for new headers in build files
- create unit tests for auditing and capabilities

## Testing
- `make -C tests/cap`
- `make -C tests/audit`
- `./tests/cap/test_cap && ./tests/audit/test_audit`