### PR TITLE
Implement minimal pager and VM handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,9 @@ Build it with:
 make -C src-lites-1.1-2025/bin/user_pager
 ```
 Run the resulting `user_pager` alongside `lites_server` to service page faults.
+The VM test in `tests/vm_fault` demonstrates this interaction.
+Build and run it with:
+```sh
+make -C tests/vm_fault
+./tests/vm_fault/test_vm_fault
+```

--- a/docs/technical_notes.md
+++ b/docs/technical_notes.md
@@ -20,3 +20,10 @@ C23 support. GCC 13 or Clang 17 (or newer) are known to work.
 Source files are formatted with `clang-format` using the settings in `.clang-format`. The `scripts/format-code.sh` helper applies the formatter to all tracked C and C++ files.
 
 A repository-wide `.editorconfig` enforces UTF‑8 encoding, LF line endings and four-space indentation.
+
+## User-level pager
+
+`src-lites-1.1-2025/bin/user_pager` implements a trivial pager used by the unit
+tests.  It reads `pf_info_t` structures from a UNIX domain socket and simply
+acknowledges each request, leaving the kernel side to map zero-filled pages.
+The VM tests spawn the pager automatically.

--- a/src-lites-1.1-2025/bin/user_pager/Makefile
+++ b/src-lites-1.1-2025/bin/user_pager/Makefile
@@ -1,11 +1,11 @@
 CC ?= gcc
-CFLAGS ?= -std=c23 -O2
+CFLAGS ?= -std=c2x -O2
 LDFLAGS ?=
 
 all: user_pager
 
 user_pager: main.c
-$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 clean:
-rm -f user_pager
+	 rm -f user_pager

--- a/src-lites-1.1-2025/bin/user_pager/main.c
+++ b/src-lites-1.1-2025/bin/user_pager/main.c
@@ -1,8 +1,29 @@
-#include <mach.h>
+#include <sys/socket.h>
+#include <sys/un.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include "../../include/vm.h"
 
-int main(void) {
-    printf("Sample pager stub\n");
-    /* TODO: implement pager RPC handling */
+/*
+ * Minimal user level pager. It listens on a socket passed as the first
+ * argument. For every fault request it simply acknowledges and provides
+ * zero filled pages implicitly.
+ */
+int main(int argc, char *argv[])
+{
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s <fd>\n", argv[0]);
+        return 1;
+    }
+
+    int fd = atoi(argv[1]);
+    pf_info_t info;
+    char ack = 0;
+    while (read(fd, &info, sizeof(info)) == (ssize_t)sizeof(info)) {
+        /* In a real pager we would map or create a page here. */
+        write(fd, &ack, 1);
+    }
     return 0;
 }

--- a/src-lites-1.1-2025/include/vm.h
+++ b/src-lites-1.1-2025/include/vm.h
@@ -1,7 +1,31 @@
 #ifndef LITES_VM_H
 #define LITES_VM_H
 
-#include <serv/import_mach.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+/* Minimal Mach compatible types used by the modernised VM layer. */
+typedef int            kern_return_t;
+typedef uintptr_t      vm_offset_t;
+typedef int            vm_prot_t;
+typedef int            mach_port_t;
+
+typedef struct { int dummy; } mutex_t;
+
+#ifndef KERN_SUCCESS
+#define KERN_SUCCESS 0
+#endif
+
+#ifndef KERN_FAILURE
+#define KERN_FAILURE 1
+#endif
+
+/* Protection bits */
+#ifndef VM_PROT_READ
+#define VM_PROT_READ     0x1
+#define VM_PROT_WRITE    0x2
+#define VM_PROT_EXECUTE  0x4
+#endif
 
 /*
  * Address space descriptor used by the modernised VM layer.
@@ -11,5 +35,12 @@ typedef struct aspace {
     mach_port_t pager_cap; /* capability for associated pager */
     mutex_t vm_lock;       /* protects mappings */
 } aspace_t;
+
+/* Information passed to the user level pager when a page fault occurs. */
+typedef struct pf_info {
+    vm_offset_t addr;  /* faulting address */
+    vm_prot_t   prot;  /* access that caused the fault */
+    int         flags; /* future use */
+} pf_info_t;
 
 #endif /* LITES_VM_H */

--- a/src-lites-1.1-2025/server/vm/vm_handlers.c
+++ b/src-lites-1.1-2025/server/vm/vm_handlers.c
@@ -1,5 +1,9 @@
-#include <serv/import_mach.h>
-#include <vm.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#include "../../include/vm.h"
 
 /*
  * Basic virtual memory handlers. These are placeholders for
@@ -7,27 +11,41 @@
  */
 
 kern_return_t vm_fault_entry(aspace_t *as, vm_offset_t addr, vm_prot_t prot) {
-    (void)as;
-    (void)addr;
-    (void)prot;
-    /* TODO: handle page faults from Mach */
-    return KERN_FAILURE;
+    if (!as)
+        return KERN_FAILURE;
+
+    pf_info_t info = { .addr = addr, .prot = prot, .flags = 0 };
+    if (as->pager_cap >= 0) {
+        (void)write(as->pager_cap, &info, sizeof(info));
+        char ack;
+        (void)read(as->pager_cap, &ack, 1);
+    }
+
+    size_t psz = (size_t)sysconf(_SC_PAGESIZE);
+    void *res = mmap(addr ? (void *)addr : NULL, psz,
+                     PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE |
+                     (addr ? MAP_FIXED : 0), -1, 0);
+    if (res == MAP_FAILED)
+        return KERN_FAILURE;
+    return KERN_SUCCESS;
 }
 
 kern_return_t map_frame(aspace_t *as, vm_offset_t vaddr, mach_port_t frame, vm_prot_t prot,
                         int flags) {
     (void)as;
-    (void)vaddr;
     (void)frame;
-    (void)prot;
     (void)flags;
-    /* TODO: establish a mapping for the frame */
-    return KERN_FAILURE;
+
+    size_t psz = (size_t)sysconf(_SC_PAGESIZE);
+    void *res = mmap(vaddr ? (void *)vaddr : NULL, psz, prot,
+                     MAP_ANON | MAP_PRIVATE | (vaddr ? MAP_FIXED : 0), -1, 0);
+    return res == MAP_FAILED ? KERN_FAILURE : KERN_SUCCESS;
 }
 
 kern_return_t unmap_frame(aspace_t *as, vm_offset_t vaddr) {
     (void)as;
-    (void)vaddr;
-    /* TODO: remove mapping at the given address */
-    return KERN_FAILURE;
+    size_t psz = (size_t)sysconf(_SC_PAGESIZE);
+    if (munmap((void *)vaddr, psz) == -1)
+        return KERN_FAILURE;
+    return KERN_SUCCESS;
 }

--- a/tests/vm_fault/Makefile
+++ b/tests/vm_fault/Makefile
@@ -1,0 +1,12 @@
+CC ?= gcc
+CFLAGS ?= -std=c2x -Wall -Wextra
+
+all: test_vm_fault
+
+.PHONY: all clean
+
+test_vm_fault: test_vm_fault.c ../../src-lites-1.1-2025/server/vm/vm_handlers.c
+	$(CC) $(CFLAGS) $^ -o $@
+
+clean:
+	 rm -f test_vm_fault

--- a/tests/vm_fault/test_vm_fault.c
+++ b/tests/vm_fault/test_vm_fault.c
@@ -1,0 +1,45 @@
+#include <assert.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "../../src-lites-1.1-2025/include/vm.h"
+
+extern kern_return_t vm_fault_entry(aspace_t *, vm_offset_t, vm_prot_t);
+extern kern_return_t unmap_frame(aspace_t *, vm_offset_t);
+
+int main(void)
+{
+    int sv[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
+
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0) {
+        close(sv[0]);
+        char fdstr[16];
+        snprintf(fdstr, sizeof(fdstr), "%d", sv[1]);
+        execl("./src-lites-1.1-2025/bin/user_pager/user_pager", "user_pager", fdstr, NULL);
+        perror("execl");
+        _exit(1);
+    }
+
+    close(sv[1]);
+    aspace_t as = { .pml_root = 0, .pager_cap = sv[0] };
+
+    vm_offset_t addr = 0x1000000;
+    assert(vm_fault_entry(&as, addr, VM_PROT_READ | VM_PROT_WRITE) == KERN_SUCCESS);
+
+    int *p = (int *)addr;
+    *p = 42;
+    assert(*p == 42);
+
+    assert(unmap_frame(&as, addr) == KERN_SUCCESS);
+
+    close(sv[0]);
+    waitpid(pid, NULL, 0);
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- flesh out VM handlers to allocate pages and talk to a pager
- define minimal Mach types in `vm.h` along with `pf_info_t`
- implement a trivial user-level pager
- document how to build and run the pager and test
- add a simple unit test exercising page fault handling

## Testing
- `make -C src-lites-1.1-2025/bin/user_pager`
- `make -C tests/vm_fault`
- `./tests/vm_fault/test_vm_fault`