### PR TITLE
Implement MCS based per-core scheduler

### DIFF
--- a/kern/sched.h
+++ b/kern/sched.h
@@ -3,6 +3,20 @@
 
 #include <cthreads.h>
 
+/* Simple MCS lock implementation used by the scheduler. */
+typedef struct mcs_lock_node {
+    struct mcs_lock_node *next;
+    volatile int locked;
+} mcs_lock_node_t;
+
+typedef struct mcs_lock {
+    mcs_lock_node_t *volatile tail;
+} mcs_lock_t;
+
+void mcs_lock_init(mcs_lock_t *lock);
+void mcs_lock_acquire(mcs_lock_t *lock, mcs_lock_node_t *node);
+void mcs_lock_release(mcs_lock_t *lock, mcs_lock_node_t *node);
+
 void schedule_enqueue(cthread_t thread);
 void schedule_dequeue(cthread_t thread);
 void *scheduler_loop(void *arg);


### PR DESCRIPTION
## Summary
- replace mutex guarded run queues with MCS locks
- add simple MCS lock implementation in sched.c and sched.h
- update scheduler to use per-core queues and work stealing with MCS locking
- implement basic timer based preemption with nanosleep

## Testing
- `scripts/run-precommit.sh --files kern/sched.c kern/sched.h` *(fails: could not install pre-commit)*
- `make -f Makefile.new --dry-run` *(fails: Mach headers not found)*