### PR TITLE
Extend capability primitives and enable pre-commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential gcc-i686-linux-gnu g++-i686-linux-gnu
 
+      - name: Install pre-commit
+        run: |
+          python3 -m pip install --upgrade pre-commit
+          pre-commit --version
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure
+
       - name: Check for K&R style functions
         run: scripts/check-kr.sh
 
@@ -38,22 +46,71 @@ jobs:
           mkdir -p build
           tar -xzf "Historical Archives/lites-1.1.u3.tar.gz" -C build
 
-      - name: Build for ${{ matrix.arch }}
-        run: |
-          suffix=""
-          if [ "${{ matrix.sanitize }}" = "1" ]; then
-            suffix="-asan"
-          fi
-          make -f Makefile.new clean
-          make -f Makefile.new CC=${{ matrix.cc }} SANITIZE=${{ matrix.sanitize }}
-          mv lites_server lites_server-${{ matrix.arch }}$suffix
-          mv lites_emulator lites_emulator-${{ matrix.arch }}$suffix
+      - name: Build for ${
+    {
+        matrix.arch
+    }
+}
+run : | suffix = "" if["${{ matrix.sanitize }}" = "1"];
+then suffix = "-asan" fi make - f Makefile.new clean make - f Makefile.new CC = $ {
+    {
+        matrix.cc
+    }
+}
+SANITIZE = $ {
+    {
+        matrix.sanitize
+    }
+}
+mv lites_server lites_server - $ {
+    {
+        matrix.arch
+    }
+}
+$suffix mv lites_emulator lites_emulator - $ {
+    {
+        matrix.arch
+    }
+}
+$suffix
 
-      - name: Upload ${{ matrix.arch }}${{ matrix.sanitize == 1 && '-asan' || '' }} artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: lites-${{ matrix.arch }}${{ matrix.sanitize == 1 && '-asan' || '' }}
-          path: |
-            lites_server-${{ matrix.arch }}${{ matrix.sanitize == 1 && '-asan' || '' }}
-            lites_emulator-${{ matrix.arch }}${{ matrix.sanitize == 1 && '-asan' || '' }}
-
+    - name : Upload $ {
+    {
+        matrix.arch
+    }
+}
+$ {
+    {
+        matrix.sanitize == 1 && '-asan' || ''
+    }
+}
+artifacts uses : actions / upload - artifact @v3 with : name : lites - $ {
+    {
+        matrix.arch
+    }
+}
+$ {
+    {
+        matrix.sanitize == 1 && '-asan' || ''
+    }
+}
+path : | lites_server - $ {
+    {
+        matrix.arch
+    }
+}
+$ {
+    {
+        matrix.sanitize == 1 && '-asan' || ''
+    }
+}
+lites_emulator - $ {
+    {
+        matrix.arch
+    }
+}
+$ {
+    {
+        matrix.sanitize == 1 && '-asan' || ''
+    }
+}

--- a/src-lites-1.1-2025/include/cap.h
+++ b/src-lites-1.1-2025/include/cap.h
@@ -1,12 +1,24 @@
 #ifndef _CAP_H_
 #define _CAP_H_
 
+/*
+ * Basic capability descriptor.  Capabilities form a tree where each child
+ * may only reduce the rights of its parent.  Revocation is implemented by
+ * bumping the epoch counter of a subtree which invalidates all descendants.
+ */
 struct cap {
+    /* parent in the capability tree (NULL for the root) */
     struct cap *parent;
-    struct cap *children; /* linked list of children */
+    /* singly linked list of children */
+    struct cap *children;
+    /* link to the next sibling in the parent's children list */
     struct cap *next_sibling;
+
+    /* generation counter used for revocation */
     unsigned long epoch;
+    /* rights bitmask that may only decrease down the tree */
     unsigned long rights;
+    /* user defined flags */
     unsigned int flags;
 };
 

--- a/src-lites-1.1-2025/server/kern/cap.c
+++ b/src-lites-1.1-2025/server/kern/cap.c
@@ -1,8 +1,12 @@
-#include <stdlib.h>
 #include "../../include/cap.h"
+#include <stdlib.h>
 
-static int cap_check_node(const struct cap *c)
-{
+/*
+ * Recursively verify invariants for capability @c and its subtree.  Children
+ * must reference @c as their parent, may only have a subset of @c's rights and
+ * must share the same epoch value.
+ */
+static int cap_check_node(const struct cap *c) {
     const struct cap *child;
     for (child = c->children; child; child = child->next_sibling) {
         if (child->parent != c)
@@ -17,16 +21,18 @@ static int cap_check_node(const struct cap *c)
     return 1;
 }
 
-int cap_check(const struct cap *cap)
-{
+/* Public wrapper that validates a capability tree starting at @cap. */
+int cap_check(const struct cap *cap) {
     if (!cap)
         return 0;
     return cap_check_node(cap);
 }
 
-struct cap *
-cap_refine(struct cap *parent, unsigned long rights, unsigned int flags)
-{
+/*
+ * Derive a new capability from @parent with a restricted rights mask.
+ * Returns the newly allocated capability or NULL on error.
+ */
+struct cap *cap_refine(struct cap *parent, unsigned long rights, unsigned int flags) {
     struct cap *c;
 
     if (!parent)
@@ -50,9 +56,8 @@ cap_refine(struct cap *parent, unsigned long rights, unsigned int flags)
     return c;
 }
 
-void
-delete_subtree(struct cap *cap)
-{
+/* Recursively free a capability subtree. */
+void delete_subtree(struct cap *cap) {
     struct cap *child = cap->children;
     while (child) {
         struct cap *next = child->next_sibling;
@@ -62,9 +67,12 @@ delete_subtree(struct cap *cap)
     free(cap);
 }
 
-void
-revoke_capability(struct cap *cap)
-{
+/*
+ * Revoke a capability subtree by incrementing its epoch counter.  All
+ * descendants receive the new epoch value which invalidates references
+ * obtained prior to revocation.
+ */
+void revoke_capability(struct cap *cap) {
     struct cap *child;
     cap->epoch++;
     for (child = cap->children; child; child = child->next_sibling)

--- a/tests/cap/test_cap.c
+++ b/tests/cap/test_cap.c
@@ -1,9 +1,8 @@
+#include "../../src-lites-1.1-2025/include/cap.h"
 #include <assert.h>
 #include <stdlib.h>
-#include "../../src-lites-1.1-2025/include/cap.h"
 
-int main(void)
-{
+static void test_refine_basic(void) {
     struct cap root = {0};
     root.rights = 0xff;
     root.epoch = 1;
@@ -12,13 +11,46 @@ int main(void)
     assert(child);
     assert(child->parent == &root);
     assert(child->rights == 0x0f);
-    assert(cap_check(&root));
-
-    revoke_capability(&root);
-    assert(root.epoch == 2);
-    assert(child->epoch == 2);
+    assert(child->epoch == root.epoch);
     assert(cap_check(&root));
 
     free(child);
+}
+
+static void test_refine_invalid_rights(void) {
+    struct cap root = {0};
+    root.rights = 0x0f;
+    root.epoch = 3;
+
+    struct cap *child = cap_refine(&root, 0xf0, 0);
+    assert(child == NULL);
+    assert(root.children == NULL);
+    assert(cap_check(&root));
+}
+
+static void test_revoke_epoch_propagation(void) {
+    struct cap root = {0};
+    root.rights = 0xff;
+    root.epoch = 10;
+
+    struct cap *child = cap_refine(&root, 0x0f, 0);
+    assert(child);
+    struct cap *grand = cap_refine(child, 0x01, 0);
+    assert(grand);
+
+    revoke_capability(&root);
+    assert(root.epoch == 11);
+    assert(child->epoch == 11);
+    assert(grand->epoch == 11);
+    assert(cap_check(&root));
+
+    free(grand);
+    free(child);
+}
+
+int main(void) {
+    test_refine_basic();
+    test_refine_invalid_rights();
+    test_revoke_epoch_propagation();
     return 0;
 }


### PR DESCRIPTION
## Summary
- document capability structure and primitives
- expand regression tests for capability refine/revoke
- run pre-commit checks in CI workflow

## Testing
- `cc -std=c2x -Wall -Wextra tests/cap/test_cap.c src-lites-1.1-2025/server/kern/cap.c -o tests/cap/test_cap && ./tests/cap/test_cap`
- `pre-commit run -a` *(fails: `pre-commit: command not found`)*