### PR TITLE
Add test build target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,3 +177,6 @@ if(EXISTS "${LITES_SRC_DIR}")
     endif()
 endif()
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests")
+    add_subdirectory(tests)
+endif()

--- a/Makefile.new
+++ b/Makefile.new
@@ -107,6 +107,8 @@ ifneq ($(EMULATOR_SRC),)
 TARGETS += lites_emulator
 endif
 
+TEST_SUBDIRS := $(sort $(dir $(wildcard tests/*/Makefile)))
+
 all: prepare $(TARGETS)
 
 prepare:
@@ -123,7 +125,14 @@ ifneq ($(EMULATOR_SRC),)
 lites_emulator: $(EMULATOR_SRC) $(KERN_SRC)
         $(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(EMULATOR_INCDIRS) $(KERN_INCDIRS) $^ $(MACH_LIBS) $(LDFLAGS) -o $@
 endif
-	
+
 clean:
-	rm -f lites_server lites_emulator
+        rm -f lites_server lites_emulator
+
+test: all
+       @for d in $(TEST_SUBDIRS); do \
+               $(MAKE) -C $$d; \
+       done
+
+.PHONY: all prepare clean test
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,6 @@ Run the resulting `user_pager` alongside `lites_server` to service page faults.
 The VM test in `tests/vm_fault` demonstrates this interaction.
 Build and run it with:
 ```sh
-make -C tests/vm_fault
+make -f Makefile.new test
 ./tests/vm_fault/test_vm_fault
 ```

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+add_executable(test_cap
+    cap/test_cap.c
+    ../src-lites-1.1-2025/server/kern/cap.c
+    ../kern/auth.c
+    ../kern/audit.c)
+target_include_directories(test_cap PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_compile_options(test_cap PRIVATE -std=gnu2x -Wall -Wextra)
+
+add_executable(test_audit
+    audit/test_audit.c
+    ../kern/auth.c
+    ../kern/audit.c)
+target_include_directories(test_audit PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_compile_options(test_audit PRIVATE -std=gnu2x -Wall -Wextra)
+
+add_executable(test_iommu
+    iommu/test_iommu.c
+    ../src-lites-1.1-2025/iommu/iommu.c)
+target_compile_options(test_iommu PRIVATE -std=c2x -Wall -Wextra)
+
+add_executable(test_vm_fault
+    vm_fault/test_vm_fault.c
+    ../src-lites-1.1-2025/server/vm/vm_handlers.c)
+target_compile_options(test_vm_fault PRIVATE -std=c2x -Wall -Wextra)
+


### PR DESCRIPTION
## Summary
- include a test target in `Makefile.new`
- hook tests into the top-level CMake build
- add a CMakeLists under `tests/`
- document the new `make test` usage in the README

## Testing
- `pre-commit run --files Makefile.new CMakeLists.txt tests/CMakeLists.txt README.md` *(fails: command not found)*
- `make -f Makefile.new test -n` *(fails: Mach headers not found)*