### PR TITLE
Modernize headers and add Mach import helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ If prebuilt Mach libraries are present, set `LITES_MACH_LIB_DIR` to their
 location (for example `openmach/lib`).  When the variable is not set and
 `openmach/lib` exists, it will be used automatically.
 
+When neither `LITES_MACH_DIR` nor an `openmach` directory are available, run
+`scripts/import-mach-headers.sh` to populate `localmach/include` from either a
+checked out OpenMach tree or the xkernel sources bundled with this repository.
+
 Example using the makefile:
 
 ```sh

--- a/docs/MODERNIZATION.md
+++ b/docs/MODERNIZATION.md
@@ -40,6 +40,7 @@ already been completed and what is still planned.
 - `mach4/pxk/time.c` uses placeholder values for
   `xGetTime()` marked as "FAKE! TODO! PNR" and needs a proper Mach
   time source.
-- Provide a helper script to extract Mach headers from the xkernel
-  sources into `localmach/include` for systems without an external
+- A helper script `import-mach-headers.sh` now copies Mach headers from either
+  an OpenMach tree or the bundled xkernel sources into `localmach/include` for
+  systems without an external Mach source.
 

--- a/scripts/import-mach-headers.sh
+++ b/scripts/import-mach-headers.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="$ROOT/localmach/include"
+
+copy_headers() {
+    local src="$1"
+    find "$src" -name '*.h' -print0 | while IFS= read -r -d '' file; do
+        rel="${file#$src/}"
+        target="$DEST/$rel"
+        mkdir -p "$(dirname "$target")"
+        cp "$file" "$target"
+    done
+}
+
+if [ -d "$ROOT/openmach/include" ]; then
+    mkdir -p "$DEST"
+    copy_headers "$ROOT/openmach/include"
+    echo "Headers copied from openmach to $DEST"
+    exit 0
+fi
+
+if [ -d "$ROOT/src-lites-1.1-2025/xkernel" ]; then
+    "$ROOT/scripts/extract-xmach-headers.sh"
+    exit 0
+fi
+
+echo "No Mach headers found (openmach or xkernel)" >&2
+exit 1

--- a/src-lites-1.1-2025/xkernel/include/event.h
+++ b/src-lites-1.1-2025/xkernel/include/event.h
@@ -67,31 +67,18 @@ typedef struct Event {
 
 
 
-typedef	void	(* EvFunc)(
-#ifdef __STDC__
-			   Event,
-			   void *
-#endif
-			   );
+typedef void (*EvFunc)(Event, void *);
 
 /* schedule an event that executes f w/ argument a after delay t usec; */
 /* t may equal 0, which implies createprocess */
-Event evSchedule(
-#ifdef __STDC__
-		 EvFunc f, void *a, unsigned t
-#endif
-		 );
+Event evSchedule(EvFunc f, void *a, unsigned t);
 
 
 /*
  * releases a handle to an event; as soon f completes, the resources
  * associated with the event are freed
  */
-void evDetach(
-#ifdef __STDC__
-	      Event e
-#endif
-	      );
+void evDetach(Event e);
 
 /* cancel event e:
  *  returns EVENT_FINISHED if it knows that the event has already executed
@@ -99,42 +86,26 @@ void evDetach(
  *  returns EVENT_RUNNING if the event is currently running
  *  returns EVENT_CANCELLED if the event has been successfully cancelled
  */
-EvCancelReturn evCancel(
-#ifdef __STDC__
-	     Event e
-#endif
-	     );
+EvCancelReturn evCancel(Event e);
 
 
 /* 
  * returns true (non-zero) if an 'evCancel' has been performed on the event
  */
-int evIsCancelled(
-#ifdef __STDC__		  
-		  Event e
-#endif
-		  );
+int evIsCancelled(Event e);
 
 
 /* 
  * Displays a 'ps'-style listing of x-kernel threads
  */
-void evDump(
-#ifdef __STDC__		  
-		  void
-#endif
-		  );
+void evDump(void);
 
 
 /* 
  * Platform-specific check to see if this event is in danger of
  * overrunning the stack, triggering warning/error messages if so. 
  */
-void evCheckStack(
-#ifdef __STDC__
-		  char *
-#endif
-		  );
+void evCheckStack(char *);
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/include/idmap.h
+++ b/src-lites-1.1-2025/xkernel/include/idmap.h
@@ -28,21 +28,12 @@ typedef struct mapelement {
 
 typedef struct map	*Map;
 
-#ifdef __STDC__
 
 typedef xkern_return_t (* XMapResolveFunc)( Map, void *, void ** );
 typedef Bind 	       (* XMapBindFunc)( Map, void *, void * );
 typedef xkern_return_t (* XMapRemoveFunc)( Map, Bind );
 typedef xkern_return_t (* XMapUnbindFunc)( Map, void * );
 
-#else
-
-typedef xkern_return_t (* XMapResolveFunc)();
-typedef Bind 	       (* XMapBindFunc)();
-typedef xkern_return_t (* XMapRemoveFunc)();
-typedef xkern_return_t (* XMapUnbindFunc)();
-
-#endif __STDC__
 
 
 struct map {
@@ -70,7 +61,6 @@ struct map {
 #define MFE_CONTINUE	1
 #define MFE_REMOVE	2
 
-#ifdef __STDC__
 
 typedef	int (*MapForEachFun)( void *key, void *value, void *arg );
 
@@ -86,19 +76,6 @@ extern Bind	mapVarBind(Map, VOID *, int, VOID *);
  */
 extern void	map_init( void );
 
-#else
-
-typedef	int (*MapForEachFun)();
-
-extern void 	mapClose();
-extern Map 	mapCreate();
-extern void	mapForEach();
-extern xkern_return_t mapVarResolve();
-extern Bind	mapVarBind();
-
-extern void	map_init();
-
-#endif __STDC__
 
 
 #endif /* idmap_h */

--- a/src-lites-1.1-2025/xkernel/include/msg.h
+++ b/src-lites-1.1-2025/xkernel/include/msg.h
@@ -30,17 +30,13 @@ typedef struct {
   /* copy from a buffer into the contig at offset; 			*/
   /* return the number of bytes copied					*/
   long (*copyIn)(
-#ifdef __STDC__		
 		 char* from, long offset, long size
-#endif
 		 );
 
   /* copy from the contig at offset to a buffer; 			*/
   /* return the number of bytes copied					*/
   long (*copyOut)(
-#ifdef __STDC__
 		  char* to, long offset, long size
-#endif
 		  );
 
 } MContig;
@@ -51,16 +47,9 @@ typedef struct {
 /* 
  * types of user functions called in ForEach()
  */
-#if defined(__STDC__) || defined(__GNUC__)
 typedef bool (*XCharFun)( char *ptr, long len, void *arg );
 typedef bool (*MContigFun)(MContig *contig, long offset, long len, void *arg); 
 
-#else
-
-typedef bool (*XCharFun)();
-typedef bool (*MContigFun)();
-
-#endif
 /*
  * types of load and store functions for headers
  */
@@ -71,9 +60,7 @@ typedef bool (*MContigFun)();
  * argument passed through msgPush
  */
 typedef void (*MStoreFun)(
-#if defined(__STDC__) || defined(__GNUC__)
 			  void *hdr, char *des, long len, void *arg
-#endif
 			  );
 
 /* function to load the header from a potentially unaligned buffer, 	
@@ -82,12 +69,9 @@ typedef void (*MStoreFun)(
  * argument passed through msgPop
  */
 typedef long (*MLoadFun)(
-#if defined(__STDC__) || defined(__GNUC__)
 			 void *hdr, char *src, long len, void *arg
-#endif
 			 );
 
-#if defined(__STDC__) || defined(__GNUC__)
 
 /* Msg operations */
 
@@ -173,16 +157,13 @@ void msgCleanUp(Msg *this);
 /* long enough */
 void msg2buf( Msg *this, char *buf );
 
-#endif __STDC__
 
 
 /*
  * associate an attribute with a message
  */
 xkern_return_t	msgSetAttr(
-#if defined(__STDC__) || defined(__GNUC__)
 			   Msg *this, int name, VOID *attr, int len
-#endif
 			   );
 
 
@@ -190,9 +171,7 @@ xkern_return_t	msgSetAttr(
  * retrieve an attribute associated with a message
  */
 VOID *		msgGetAttr(
-#if defined(__STDC__) || defined(__GNUC__)
 			  Msg *this, int name
-#endif
 			  );
 
 
@@ -202,9 +181,7 @@ VOID *		msgGetAttr(
 /* (=length of contig), and void *arg (=user-supplied argument), */  
 /* while f returns TRUE */
 void msgForEach(
-#if defined(__STDC__) || defined(__GNUC__)
 		Msg *this, XCharFun f, void *arg
-#endif
 		);
 
 /* for every contig in this Msg, invoke the function f with  */
@@ -213,14 +190,11 @@ void msgForEach(
 /* while f returns TRUE */
 /* the memory described by contig may not be accessible!! */
 void msgForEachContig(
-#if defined(__STDC__) || defined(__GNUC__)
 		      Msg *this, MContigFun f, void *arg
-#endif
 		      );
 
 
 
-#if defined(__STDC__) || defined(__GNUC__)
 
 /************* virtual memory funniness **************/
 /* import a Msg from a different address space */
@@ -248,6 +222,5 @@ void msgShow( Msg *this );
  */
 void msgStats( void );
 
-#endif __STDC__
 
 #endif msg_h

--- a/src-lites-1.1-2025/xkernel/include/part.h
+++ b/src-lites-1.1-2025/xkernel/include/part.h
@@ -15,7 +15,6 @@
 
 #ifndef xtype_h
 #include "xtype.h"
-#endif
 
 /* 
  * Participant library
@@ -38,17 +37,9 @@ typedef struct {
     PartStack	stack;	/* A stack of void* pointers */
 } Part;
 
-#ifdef __STDC__
 
 void	partStackPush( PartStack *s, void *data, int );
 void *	partStackPop( PartStack *s );
-
-#else
-
-void		partStackPush();
-VOID		*partStackPop();
-
-#endif __STDC__
 
 /********************  public declarations ****************/
 
@@ -58,9 +49,7 @@ VOID		*partStackPop();
 /* 
  * Initialize a vector of N participants
  */
-#ifdef __STDC__
 void	partInit( Part *p, int N );
-#endif
 
 /* 
  * push 'data' onto the stack of participant 'p'.  
@@ -76,23 +65,17 @@ void	partInit( Part *p, int N );
 #define partLen( partPtr ) (partPtr->len)
 
 xkern_return_t	partExternalize(
-#ifdef __STDC__
 				Part *, VOID *, int *
-#endif
 				);
 
 void partInternalize(
-#ifdef __STDC__
 				Part *, VOID *
-#endif
 				);
 
 #define partExtLen( _bufPtr )	( *(int *)(_bufPtr) )
 
 int partStackTopByteLen(
-#ifdef __STDC__
 			Part
-#endif
 			);
 
 

--- a/src-lites-1.1-2025/xkernel/include/xtype.h
+++ b/src-lites-1.1-2025/xkernel/include/xtype.h
@@ -26,11 +26,7 @@ typedef int	xmsg_handle_t;
 #define XMSG_ERR_HANDLE		-1
 #define XMSG_ERR_WOULDBLOCK	-2
 
-#if defined(__STDC__) || defined(__GNUC__)
-#   define VOID		void
-#else
-#   define VOID		char
-#endif
+#define VOID         void
 
 typedef	xkern_return_t (*Pfk) ();
 typedef	int (*Pfi) ();
@@ -41,4 +37,4 @@ typedef xmsg_handle_t (*Pfh)();
 
 #define XK_MAX_HOST_LEN		6
 
-#endif ! xtype_h
+#endif /* xtype_h */


### PR DESCRIPTION
## Summary
- modernize xkernel headers to use modern prototypes
- add `import-mach-headers.sh` helper
- document the new script and update modernization notes

## Testing
- `pre-commit run -a` *(fails: `pre-commit: command not found`)*
- `make -f Makefile.new test` *(fails: Mach headers not found)*