### PR TITLE
Fix tabs in Makefile.new

### DIFF
--- a/Makefile.new
+++ b/Makefile.new
@@ -119,20 +119,20 @@ prepare:
 	fi
 
 lites_server: $(SERVER_SRC) $(KERN_SRC)
-        $(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(SERVER_INCDIRS) $(KERN_INCDIRS) $^ $(MACH_LIBS) $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(SERVER_INCDIRS) $(KERN_INCDIRS) $^ $(MACH_LIBS) $(LDFLAGS) -o $@
 
 ifneq ($(EMULATOR_SRC),)
 lites_emulator: $(EMULATOR_SRC) $(KERN_SRC)
-        $(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(EMULATOR_INCDIRS) $(KERN_INCDIRS) $^ $(MACH_LIBS) $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(EMULATOR_INCDIRS) $(KERN_INCDIRS) $^ $(MACH_LIBS) $(LDFLAGS) -o $@
 endif
 
 clean:
-        rm -f lites_server lites_emulator
+	rm -f lites_server lites_emulator
 
 test: all
-       @for d in $(TEST_SUBDIRS); do \
-               $(MAKE) -C $$d; \
-       done
+	@for d in $(TEST_SUBDIRS); do \
+	$(MAKE) -C $$d; \
+	done
 
 .PHONY: all prepare clean test
 


### PR DESCRIPTION
## Summary
- fix command tabbing in `Makefile.new`

## Testing
- `pre-commit` *(fails: command not found)*
- `make -f Makefile.new ARCH=x86_64` *(fails: missing Mach headers)*