### PR TITLE
Add header flattening helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ Their paths are listed in [headers_inventory.csv](headers_inventory.csv) for
 easy reference. Each row in the CSV shows the path to a header relative to the
 repository root.
 
+To gather all these headers into a single directory run
+`scripts/flatten-headers.sh`. The script copies every header into the
+`flattened_include/` directory and automatically renames duplicates by
+embedding the original path in the filename.
+
 ## Building
 
 Lites requires a Mach 3 or Mach 4 kernel and a 4.4BSD userland.  Each

--- a/scripts/flatten-headers.sh
+++ b/scripts/flatten-headers.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="$ROOT/flattened_include"
+
+mkdir -p "$DEST"
+
+copy_header() {
+    local src="$1"
+    local rel="$2"
+    local base
+    base=$(basename "$rel")
+    local target="$DEST/$base"
+    if [ -e "$target" ]; then
+        # avoid collisions by encoding the relative path
+        local enc
+        enc="${rel//\//_}"
+        target="$DEST/$enc"
+    fi
+    cp "$src" "$target"
+}
+
+if [ -f "$ROOT/headers_inventory.csv" ]; then
+    tail -n +2 "$ROOT/headers_inventory.csv" | while IFS= read -r path; do
+        file="$ROOT/${path#./}"
+        [ -f "$file" ] || continue
+        copy_header "$file" "${path#./}"
+    done
+else
+    find "$ROOT" -name '*.h' -print0 \
+        | while IFS= read -r -d '' file; do
+            rel="${file#$ROOT/}"
+            copy_header "$file" "$rel"
+        done
+fi
+
+echo "Headers copied to $DEST"


### PR DESCRIPTION
## Summary
- script to flatten all headers into `flattened_include`
- mention new helper in README

## Testing
- `scripts/run-precommit.sh` *(fails: Could not install pre-commit)*
- `cmake -B build -S tests`
- `cmake --build build`
- `ctest --test-dir build`