### PR TITLE
Update system_setup to _Noreturn

### DIFF
--- a/src-lites-1.1-2025/include/sys/cdefs.h
+++ b/src-lites-1.1-2025/include/sys/cdefs.h
@@ -20,6 +20,15 @@
 #define __dead2
 #define __pure2
 #endif
+#ifndef _Noreturn
+# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+/* _Noreturn is a keyword */
+# elif defined(__GNUC__)
+#  define _Noreturn __attribute__((__noreturn__))
+# else
+#  define _Noreturn
+# endif
+#endif
 #define __dead
 #define __unused       __attribute__((__unused__))
 

--- a/src-lites-1.1-2025/server/kern/init_main.c
+++ b/src-lites-1.1-2025/server/kern/init_main.c
@@ -144,7 +144,7 @@ int	boothowto = RB_KDB;	/* XXX should be ifdeffed */
  * hard work is done in the lower-level initialization routines including
  * startup(), which does memory initialization and autoconfiguration.
  */
-noreturn system_setup()
+_Noreturn void system_setup(void)
 {
 	register struct proc *p;
 	register struct filedesc0 *fdp;

--- a/src-lites-1.1-2025/server/serv/server_defs.h
+++ b/src-lites-1.1-2025/server/serv/server_defs.h
@@ -62,7 +62,7 @@
 #include <sys/vnode.h>
 
 /* TYPES */
-typedef volatile void noreturn;
+typedef _Noreturn void noreturn;
 
 /* PROTOTYPES */
 

--- a/src-lites-1.1-2025/server/serv/server_init.c
+++ b/src-lites-1.1-2025/server/serv/server_init.c
@@ -72,7 +72,7 @@ extern int msgbufmapped;
 extern struct proc *newproc();
 extern void ux_create_thread();
 extern void proc_set_condition_names(struct proc *p); /* in kern_fork.c */
-cthread_fn_t	system_setup();	/* forward */
+_Noreturn void system_setup(void);	/* forward */
 
 struct mutex allproc_lock = MUTEX_NAMED_INITIALIZER("allproc_lock");
 int system_procs = 2; /*XXX governed by allproc_lock also.  Start at -3


### PR DESCRIPTION
## Summary
- support standard `_Noreturn` in `sys/cdefs.h`
- use `_Noreturn` alias in `server_defs.h`
- declare `system_setup` as `_Noreturn void system_setup(void)`
- update definition of `system_setup`

## Testing
- `make -C tests/audit`
- `./tests/audit/test_audit`
- `scripts/run-precommit.sh --files src-lites-1.1-2025/include/sys/cdefs.h src-lites-1.1-2025/server/serv/server_defs.h src-lites-1.1-2025/server/kern/init_main.c src-lites-1.1-2025/server/serv/server_init.c` *(fails: Could not install pre-commit)*