### PR TITLE
Add generic multi‑arch build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,16 @@ if(ARCH STREQUAL "i686")
 elseif(ARCH STREQUAL "x86_64")
     add_compile_options(-m64)
     add_link_options(-m64)
+elseif(ARCH STREQUAL "arm")
+    add_compile_options(-marm)
+elseif(ARCH STREQUAL "riscv64")
+    add_compile_options(-march=rv64imac -mabi=lp64)
+elseif(ARCH STREQUAL "powerpc")
+    add_compile_options(-m32)
+    add_link_options(-m32)
+elseif(ARCH STREQUAL "ia16")
+    add_compile_options(-m16)
+    add_link_options(-m16)
 endif()
 
 include(CheckCCompilerFlag)
@@ -134,7 +144,7 @@ if(EXISTS "${LITES_SRC_DIR}")
     target_include_directories(lites_server PRIVATE
         "${LITES_SRC_DIR}/include"
         "${LITES_SRC_DIR}/server"
-        "${LITES_SRC_DIR}/iommu")
+        "${LITES_SRC_DIR}/iommu"
         "${MACH_INCLUDE_DIR}"
         "${CMAKE_CURRENT_SOURCE_DIR}/kern"
         "${CMAKE_CURRENT_SOURCE_DIR}/include")
@@ -144,6 +154,18 @@ if(EXISTS "${LITES_SRC_DIR}")
     elseif(ARCH STREQUAL "i686")
         target_include_directories(lites_server PRIVATE
             "${LITES_SRC_DIR}/include/i386")
+    elseif(ARCH STREQUAL "arm")
+        target_include_directories(lites_server PRIVATE
+            "${LITES_SRC_DIR}/include/arm")
+    elseif(ARCH STREQUAL "riscv64")
+        target_include_directories(lites_server PRIVATE
+            "${LITES_SRC_DIR}/include/riscv64")
+    elseif(ARCH STREQUAL "powerpc")
+        target_include_directories(lites_server PRIVATE
+            "${LITES_SRC_DIR}/include/powerpc")
+    elseif(ARCH STREQUAL "ia16")
+        target_include_directories(lites_server PRIVATE
+            "${LITES_SRC_DIR}/include/ia16")
     endif()
     target_compile_options(lites_server PRIVATE ${C23_FLAG} ${CFLAGS})
     target_link_options(lites_server PRIVATE ${LDFLAGS})
@@ -159,7 +181,7 @@ if(EXISTS "${LITES_SRC_DIR}")
             "${LITES_SRC_DIR}/emulator"
             "${MACH_INCLUDE_DIR}"
             "${CMAKE_CURRENT_SOURCE_DIR}/kern"
-            "${LITES_SRC_DIR}/iommu")
+            "${LITES_SRC_DIR}/iommu"
             "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
         if(ARCH STREQUAL "x86_64")
@@ -168,6 +190,18 @@ if(EXISTS "${LITES_SRC_DIR}")
         elseif(ARCH STREQUAL "i686")
             target_include_directories(lites_emulator PRIVATE
                 "${LITES_SRC_DIR}/include/i386")
+        elseif(ARCH STREQUAL "arm")
+            target_include_directories(lites_emulator PRIVATE
+                "${LITES_SRC_DIR}/include/arm")
+        elseif(ARCH STREQUAL "riscv64")
+            target_include_directories(lites_emulator PRIVATE
+                "${LITES_SRC_DIR}/include/riscv64")
+        elseif(ARCH STREQUAL "powerpc")
+            target_include_directories(lites_emulator PRIVATE
+                "${LITES_SRC_DIR}/include/powerpc")
+        elseif(ARCH STREQUAL "ia16")
+            target_include_directories(lites_emulator PRIVATE
+                "${LITES_SRC_DIR}/include/ia16")
         endif()
         target_compile_options(lites_emulator PRIVATE ${C23_FLAG} ${CFLAGS})
         target_link_options(lites_emulator PRIVATE ${LDFLAGS})

--- a/Makefile.new
+++ b/Makefile.new
@@ -58,7 +58,7 @@ CFLAGS += -DCONFIG_SCHED_MULTICORE=0
 endif
 
 
-# Translate ARCH into compiler options and cross-compilers
+# Translate ARCH into compiler options and per-architecture includes
 ifeq ($(ARCH),i686)
 CFLAGS += -m32
 LDFLAGS += -m32
@@ -67,12 +67,28 @@ else ifeq ($(ARCH),x86_64)
 CFLAGS += -m64
 LDFLAGS += -m64
 ARCH_INCDIR := -I$(SRCDIR)/include/x86_64
+else ifeq ($(ARCH),arm)
+CFLAGS += -marm
+ARCH_INCDIR := -I$(SRCDIR)/include/arm
+else ifeq ($(ARCH),riscv64)
+CFLAGS += -march=rv64imac -mabi=lp64
+ARCH_INCDIR := -I$(SRCDIR)/include/riscv64
+else ifeq ($(ARCH),powerpc)
+CFLAGS += -m32
+LDFLAGS += -m32
+ARCH_INCDIR := -I$(SRCDIR)/include/powerpc
+else ifeq ($(ARCH),ia16)
+CFLAGS += -m16
+LDFLAGS += -m16
+ARCH_INCDIR := -I$(SRCDIR)/include/ia16
 endif
 
 # Map ARCH to the corresponding directory name
 ARCH_DIR := $(ARCH)
 ifeq ($(ARCH),i686)
 ARCH_DIR := i386
+else ifeq ($(ARCH),ia16)
+ARCH_DIR := ia16
 endif
 
 # Directories under server that are architecture independent
@@ -112,11 +128,11 @@ TEST_SUBDIRS := $(sort $(dir $(wildcard tests/*/Makefile)))
 all: prepare $(TARGETS)
 
 prepare:
-	@if [ ! -e $(SRCDIR)/include/machine ]; then \
-	  arch_dir=$(ARCH); \
-	  [ "$$arch_dir" = "i686" ] && arch_dir=i386; \
-	  ln -s $$arch_dir $(SRCDIR)/include/machine; \
-	fi
+        @if [ ! -e $(SRCDIR)/include/machine ]; then \
+          arch_dir=$(ARCH); \
+          [ "$$arch_dir" = "i686" ] && arch_dir=i386; \
+          ln -s $$arch_dir $(SRCDIR)/include/machine; \
+        fi
 
 lites_server: $(SERVER_SRC) $(KERN_SRC)
 	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(SERVER_INCDIRS) $(KERN_INCDIRS) $^ $(MACH_LIBS) $(LDFLAGS) -o $@

--- a/README.md
+++ b/README.md
@@ -104,9 +104,13 @@ For the modernized build system in this repository you can also use
 `Makefile.new` or the provided CMake files.  Both automatically build from
 the `src-lites-1.1-2025` directory when it is present.  Set the `SRCDIR` or
 `LITES_SRC_DIR` variables to override this behaviour.  The tools recognise an
-optional `ARCH` variable, selecting between 64‑bit (`ARCH=x86_64`, default) and
-32‑bit (`ARCH=i686`) builds.  Other architectures were supported in historical
-releases but are not handled by the modern build system.
+`ARCH` variable which selects the target CPU.  Supported values include the
+64‑bit `x86_64` and `riscv64`, 32‑bit `i686`, `arm` and `powerpc`, and the
+16‑bit `ia16`.  The default is `ARCH=x86_64`.
+
+Use `ARCH=ia16` for 16‑bit builds.  Choose `ARCH=i686`, `ARCH=arm` or
+`ARCH=powerpc` for 32‑bit binaries, and `ARCH=x86_64` or `ARCH=riscv64` for
+64‑bit targets.
 Set `SANITIZE=1` to compile with address sanitizer support, which appends
 `-fsanitize=address` to `CFLAGS` and `LDFLAGS`.
 Examples:
@@ -115,11 +119,19 @@ Examples:
 # Using the makefile
 make -f Makefile.new ARCH=i686
 make -f Makefile.new ARCH=x86_64
+make -f Makefile.new ARCH=arm
+make -f Makefile.new ARCH=riscv64
+make -f Makefile.new ARCH=powerpc
+make -f Makefile.new ARCH=ia16
 make -f Makefile.new ARCH=x86_64 SANITIZE=1
 
 # Using CMake (optionally override the source directory)
 cmake -B build -DARCH=i686
 cmake -B build -DARCH=x86_64 -DLITES_SRC_DIR=src-lites-1.1-2025
+cmake -B build -DARCH=arm
+cmake -B build -DARCH=riscv64
+cmake -B build -DARCH=powerpc
+cmake -B build -DARCH=ia16
 cmake --build build
 ```
 


### PR DESCRIPTION
## Summary
- support arm, riscv64, powerpc and ia16 ARCH values in Makefile.new and CMakeLists.txt
- generate per-architecture include paths and flags
- document 16/32/64-bit builds in README

## Testing
- `pre-commit run --files Makefile.new CMakeLists.txt README.md` *(fails: pre-commit not installed)*
- `make -f Makefile.new test` *(fails: Mach headers not found)*