### PR TITLE
Standardise noreturn usage

### DIFF
--- a/src-lites-1.1-2025/server/kern/init_main.c
+++ b/src-lites-1.1-2025/server/kern/init_main.c
@@ -144,7 +144,7 @@ int	boothowto = RB_KDB;	/* XXX should be ifdeffed */
  * hard work is done in the lower-level initialization routines including
  * startup(), which does memory initialization and autoconfiguration.
  */
-noreturn system_setup()
+_Noreturn void system_setup(void)
 {
 	register struct proc *p;
 	register struct filedesc0 *fdp;

--- a/src-lites-1.1-2025/server/kern/makesyscalls.sh
+++ b/src-lites-1.1-2025/server/kern/makesyscalls.sh
@@ -240,12 +240,12 @@ awk < $1 "
 		} else {
 			printf("extern %s %s", returntype, sname) > sysproto
 		}
-		if (returntype == "noreturn") {
-			libfile= "/dev/null"
-			jacket= "/dev/null"
-			printf("extern noreturn %s", sname) > eproto
-			printf("noreturn %s", sname) > elib
-			printf("noreturn dev_null_%s", sname) > jacket
+               if (returntype == "noreturn") {
+                       libfile= "/dev/null"
+                       jacket= "/dev/null"
+                       printf("_Noreturn void %s", sname) > eproto
+                       printf("_Noreturn void %s", sname) > elib
+                       printf("_Noreturn void dev_null_%s", sname) > jacket
 		} else {
 			libfile=syslibdir "/" sname ".c"
 			jacket= jacketdir "/e_" iname ".c"

--- a/src-lites-1.1-2025/server/serv/server_defs.h
+++ b/src-lites-1.1-2025/server/serv/server_defs.h
@@ -62,7 +62,7 @@
 #include <sys/vnode.h>
 
 /* TYPES */
-typedef volatile void noreturn;
+#include <stdnoreturn.h>
 
 /* PROTOTYPES */
 

--- a/src-lites-1.1-2025/server/serv/server_init.c
+++ b/src-lites-1.1-2025/server/serv/server_init.c
@@ -72,7 +72,7 @@ extern int msgbufmapped;
 extern struct proc *newproc();
 extern void ux_create_thread();
 extern void proc_set_condition_names(struct proc *p); /* in kern_fork.c */
-cthread_fn_t	system_setup();	/* forward */
+_Noreturn void system_setup(void); /* forward */
 
 struct mutex allproc_lock = MUTEX_NAMED_INITIALIZER("allproc_lock");
 int system_procs = 2; /*XXX governed by allproc_lock also.  Start at -3

--- a/src-lites-1.1-2025/server/serv/timer.c
+++ b/src-lites-1.1-2025/server/serv/timer.c
@@ -171,7 +171,7 @@ unsigned int timer_wakeups = 0;	/* for debugging only */
  * The timer thread blocks until a timeout expires and then calls
  * ws_signal_with_locking on the wstate.
  */
-noreturn timer_thread()
+_Noreturn void timer_thread(void)
 {
 	struct timeval now, diff;
 	timer_element_t telt;


### PR DESCRIPTION
## Summary
- include `<stdnoreturn.h>` where `noreturn` is needed
- annotate `system_setup` and `timer_thread` with `_Noreturn`
- update syscall generator script for new noreturn style

## Testing
- `make -f Makefile.new test` *(fails: Mach headers not found)*