### PR TITLE
Remove obsolete prototype guards

### DIFF
--- a/src-lites-1.1-2025/xkernel-obj/SYS.h
+++ b/src-lites-1.1-2025/xkernel-obj/SYS.h
@@ -22,13 +22,8 @@
 
 #include <mach/machine/asm.h>
 
-#ifdef __STDC__
 #define	SYSCALL(x)	ENTRY(x); movl	$(SYS_ ## x), %eax; SVC; jb LCL(cerror)
 #define	PSEUDO(x,y)	ENTRY(x); movl	$(SYS_ ## y), %eax; SVC
-#else __STDC__
-#define	SYSCALL(x)	ENTRY(x); movl	$SYS_/**/x, %eax; SVC; jb LCL(cerror)
-#define	PSEUDO(x,y)	ENTRY(x); movl	$SYS_/**/y, %eax; SVC
-#endif __STDC__
 #define	CALL(x,y)	calls $x, EXT(y)
 
 	.globl	LCL(cerror)

--- a/src-lites-1.1-2025/xkernel-obj/search.h
+++ b/src-lites-1.1-2025/xkernel-obj/search.h
@@ -16,14 +16,14 @@ typedef	_BSD_SIZE_T_	size_t;
 #endif
 
 __BEGIN_DECLS
-extern void	*bsearch __P((const void *, const void *, size_t, size_t,
-			      int (*)(const void *, const void *)));
-extern void	*lfind __P((const void *, const void *, size_t *, size_t,
-			      int (*)(const void *, const void *)));
-extern void	*lsearch __P((const void *, const void *, size_t *, size_t,
-			      int (*)(const void *, const void *)));
-extern void	 insque __P((void *, void *));
-extern void	 remque __P((void *));
+extern void	*bsearch (const void *, const void *, size_t, size_t,
+			      int (*)(const void *, const void *));
+extern void	*lfind (const void *, const void *, size_t *, size_t,
+			      int (*)(const void *, const void *));
+extern void	*lsearch (const void *, const void *, size_t *, size_t,
+			      int (*)(const void *, const void *));
+extern void	 insque (void *, void *);
+extern void	 remque (void *);
 __END_DECLS
 
 #endif

--- a/src-lites-1.1-2025/xkernel/include/gc.h
+++ b/src-lites-1.1-2025/xkernel/include/gc.h
@@ -32,9 +32,7 @@
  */
 
 void	initSessionCollector(
-#ifdef __STDC__
 			     Map m, int interval, Pfv destructor, char *msg
-#endif
 			     );
 
 

--- a/src-lites-1.1-2025/xkernel/include/gethost.h
+++ b/src-lites-1.1-2025/xkernel/include/gethost.h
@@ -6,8 +6,4 @@
  */
 
 
-#ifdef __STDC__
         xkern_return_t xk_gethostbyname(char *, IPhost *);
-#else
-	xkern_return_t xk_gethostbyname();
-#endif

--- a/src-lites-1.1-2025/xkernel/include/list.h
+++ b/src-lites-1.1-2025/xkernel/include/list.h
@@ -39,7 +39,6 @@ typedef	struct list_entry	*list_entry_t;
 #define	delist(list)		delist_head(list)
 
 
-#ifdef __STDC__
 
 list_entry_t	delist_head( list_t );
 list_entry_t	delist_head_strong( list_t );
@@ -49,15 +48,5 @@ void 		enlist_tail( list_t, list_entry_t );
 void		list_init( list_t );
 
 
-#else
-
-list_entry_t	delist_head();
-list_entry_t	delist_head_strong();
-list_entry_t	delist_tail();
-void 		enlist_head();
-void 		enlist_tail();
-void		list_init();
-
-#endif __STDC__
 
 #endif list_h

--- a/src-lites-1.1-2025/xkernel/include/md5hash.h
+++ b/src-lites-1.1-2025/xkernel/include/md5hash.h
@@ -50,13 +50,7 @@ typedef struct {
 } MD5_CTX;
 
 
-#ifdef __STDC__
 void MD5Init (MD5_CTX *);
 void MD5Update (MD5_CTX *, unsigned char *, unsigned int);
 void MD5Final (MD5_CTX *);
-#else
-void MD5Init ();
-void MD5Update ();
-void MD5Final ();
-#endif __STDC__
 

--- a/src-lites-1.1-2025/xkernel/include/netmask.h
+++ b/src-lites-1.1-2025/xkernel/include/netmask.h
@@ -22,9 +22,7 @@
  * netMaskAdd -- add 'mask' to the table as the netmask for 'net'
  */
 int	netMaskAdd(
-#ifdef __STDC__
 		   IPhost *net, IPhost *mask
-#endif
 		   );
 
 
@@ -33,9 +31,7 @@ int	netMaskAdd(
  * any other netmask routines.
  */
 void	netMaskInit(
-#ifdef __STDC__
 		    void
-#endif
 		    );
 
 /* 
@@ -44,9 +40,7 @@ void	netMaskInit(
  * the address class is used.
  */
 void	netMaskFind(
-#ifdef __STDC__
 		    IPhost *mask, IPhost *host
-#endif
 		    );
 
 
@@ -56,9 +50,7 @@ void	netMaskFind(
  * being used.
  */
 void	netMaskDefault(
-#ifdef __STDC__
 		    IPhost *mask, IPhost *host
-#endif
 		    );
 
 
@@ -67,9 +59,7 @@ void	netMaskDefault(
  * same subnet
  */
 int	netMaskSubnetsEqual(
-#ifdef __STDC__
 			 IPhost *, IPhost *
-#endif
 			 );
 
 
@@ -78,9 +68,7 @@ int	netMaskSubnetsEqual(
  * same net
  */
 int	netMaskNetsEqual(
-#ifdef __STDC__
 			 IPhost *, IPhost *
-#endif
 			 );
 
 
@@ -95,9 +83,7 @@ int	netMaskNetsEqual(
  *  or	3) having ones in the entire address
  */
 int	netMaskIsBroadcast(
-#ifdef __STDC__
 			   IPhost *
-#endif
 			   );
 
 extern IPhost	IP_LOCAL_BCAST;

--- a/src-lites-1.1-2025/xkernel/include/prot/arp.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/arp.h
@@ -23,11 +23,9 @@
 #include "ip.h"
 #endif
 
-#ifdef __STDC__
 
 void		arp_init( XObj );
 
-#endif
 
 #define ARP_INSTALL 		( ARP_CTL * MAXOPS + 0 )
 #define ARP_GETMYBINDING	( ARP_CTL * MAXOPS + 1 )
@@ -42,11 +40,7 @@ typedef struct {
  * kludge to let the sunos simulator's ethernet driver simulate broadcast
  */
 
-#ifdef __STDC__
 typedef int	(ArpForEachFunc)( ArpBinding *, VOID * );
-#else
-typedef int	(ArpForEachFunc)();
-#endif __STDC__
 
 typedef struct {
     VOID		*v;

--- a/src-lites-1.1-2025/xkernel/include/prot/auth.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/auth.h
@@ -2,11 +2,9 @@
 #define AUTH_H
 
 
-#ifdef __STDC__
 
 void auth_init( XObj );
 
-#endif
 
 
 #endif 

--- a/src-lites-1.1-2025/xkernel/include/prot/bid.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/bid.h
@@ -13,10 +13,8 @@
 #ifndef bid_h
 #define bid_h
    
-#  ifdef __STDC__
 
 void	bid_init( XObj );
 
-#  endif
 
 #endif  ! bid_h

--- a/src-lites-1.1-2025/xkernel/include/prot/bidctl.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/bidctl.h
@@ -18,11 +18,9 @@
 #ifndef bidctl_h
 #define bidctl_h
    
-#  ifdef __STDC__
 
 void		bidctl_init( XObj );
 
-#  endif
 
 
 typedef	u_int	BootId;

--- a/src-lites-1.1-2025/xkernel/include/prot/blast.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/blast.h
@@ -16,10 +16,8 @@
 #define BLAST_SETOUTSTANDINGMSGS (BLAST_CTL*MAXOPS + 0)
 #define BLAST_GETOUTSTANDINGMSGS (BLAST_CTL*MAXOPS + 1)
 
-#  ifdef __STDC__
 
 void		blast_init( XObj );
 
-#  endif
 
 #endif blast_h

--- a/src-lites-1.1-2025/xkernel/include/prot/chan.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/chan.h
@@ -30,10 +30,8 @@ typedef struct {
     unsigned int timeout;
 } chan_info_t; 
     
-#ifdef __STDC__
 
 void	chan_init( XObj );
 
-#endif
 
 #endif chan_h

--- a/src-lites-1.1-2025/xkernel/include/prot/crypt.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/crypt.h
@@ -35,11 +35,9 @@
 
 
 
-#  ifdef __STDC__
 
 void	crypt_init( XObj );
 
-#  endif
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/include/prot/eth.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/eth.h
@@ -45,10 +45,8 @@
 
 #define	MAX_IEEE802_3_DATA_SZ	1500
 
-#  ifdef __STDC__
 
 void	eth_init( XObj );
 
-#  endif
 
 #endif eth_h

--- a/src-lites-1.1-2025/xkernel/include/prot/icmp.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/icmp.h
@@ -51,10 +51,8 @@
 #define ICMP_ECHO_CTL		(ICMP_CTL * MAXOPS + 0)
 
 
-#  ifdef __STDC__
 
 void	icmp_init( XObj );
 
-#  endif
 
 #endif icmp_h

--- a/src-lites-1.1-2025/xkernel/include/prot/ip.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/ip.h
@@ -37,11 +37,9 @@ typedef struct ippseudohdr {
 #define IP_LOCAL_BCAST_HOST	{ 255, 255, 255, 255 }
 
 
-#  ifdef __STDC__
 
 void	ip_init( XObj );
 
-#  endif
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/include/prot/join.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/join.h
@@ -22,11 +22,9 @@
 #define JOINSETCONTROL 		(JOIN_CTL*MAXOPS + 4)
 
 
-#  ifdef __STDC__
 
 void	join_init( XObj );
 
-#  endif
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/include/prot/mselect.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/mselect.h
@@ -13,10 +13,8 @@
 #ifndef mselect_h
 #define mselect_h
    
-#  ifdef __STDC__
 
 void	mselect_init( XObj );
 
-#  endif
 
 #endif  ! mselect_h

--- a/src-lites-1.1-2025/xkernel/include/prot/select.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/select.h
@@ -13,10 +13,8 @@
 #ifndef select_h
 #define select_h
    
-#  ifdef __STDC__
 
 void	select_init( XObj );
 
-#  endif
 
 #endif  ! select_h

--- a/src-lites-1.1-2025/xkernel/include/prot/sunrpc.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/sunrpc.h
@@ -45,11 +45,9 @@
 #define SUNRPC_GETPORT		(SUNRPC_CTL*MAXOPS+21)
 
 
-#  ifdef __STDC__
 
 void	sunrpc_init( XObj );
 
-#  endif
 
 #endif
 

--- a/src-lites-1.1-2025/xkernel/include/prot/tcp.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/tcp.h
@@ -41,11 +41,9 @@
 #define TCP_SETRCVACKALWAYS	(TCP_CTL*MAXOPS + 14)	
 	/* Implicitly does a SETRCVBUFSPACE on each xPop */
 
-#  ifdef __STDC__
 
 void	tcp_init( XObj );
 
-#  endif
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/include/prot/udp.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/udp.h
@@ -22,11 +22,9 @@
 #define UDP_GETFREEPROTNUM	(UDP_CTL * MAXOPS + 2)
 #define UDP_RELEASEPROTNUM	(UDP_CTL * MAXOPS + 3)
 
-#  ifdef __STDC__
 
 void	udp_init( XObj );
 
-#  endif
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/include/prot/vcache.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/vcache.h
@@ -13,10 +13,8 @@
 #ifndef vcache_h
 #define vcache_h
    
-#  ifdef __STDC__
 
 void	vcache_init( XObj );
 
-#  endif
 
 #endif  ! vcache_h

--- a/src-lites-1.1-2025/xkernel/include/prot/vchan.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/vchan.h
@@ -20,10 +20,8 @@
 #define VCHAN_DECCONCURRENCY (VCHAN_CTL*MAXOPS + 1)
 
 
-#  ifdef __STDC__
 
 void	vchan_init( XObj );
 
-#  endif
 
 #endif

--- a/src-lites-1.1-2025/xkernel/include/prot/vdisorder.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/vdisorder.h
@@ -13,11 +13,9 @@
 #ifndef vdisorder_h
 #define vdisorder_h
    
-#  ifdef __STDC__
 
 void	vdisorder_init( XObj );
 
-#  endif
 
 #define VDISORDER_CTL	TMP3_CTL
 

--- a/src-lites-1.1-2025/xkernel/include/prot/vdrop.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/vdrop.h
@@ -13,11 +13,9 @@
 #ifndef vdrop_h
 #define vdrop_h
    
-#  ifdef __STDC__
 
 void	vdrop_init( XObj );
 
-#  endif
 
 #define VDROP_GETINTERVAL	(VDROP_CTL * MAXOPS + 0)
 #define VDROP_SETINTERVAL	(VDROP_CTL * MAXOPS + 1)

--- a/src-lites-1.1-2025/xkernel/include/prot/vmux.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/vmux.h
@@ -13,10 +13,8 @@
 #ifndef vmux_h
 #define vmux_h
    
-#  ifdef __STDC__
 
 void	vmux_init( XObj );
 
-#  endif
 
 #endif  ! vmux_h

--- a/src-lites-1.1-2025/xkernel/include/prot/vnet.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/vnet.h
@@ -76,10 +76,8 @@ typedef union {
  */
 
 
-#  ifdef __STDC__
 
 void	vnet_init( XObj );
 
-#  endif
 
 #endif ! vnet_h

--- a/src-lites-1.1-2025/xkernel/include/prot/vsize.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/vsize.h
@@ -13,10 +13,8 @@
 #ifndef vsize_h
 #define vsize_h
    
-#  ifdef __STDC__
 
 void	vsize_init( XObj );
 
-#  endif
 
 #endif  ! vsize_h

--- a/src-lites-1.1-2025/xkernel/include/prot/vtap.h
+++ b/src-lites-1.1-2025/xkernel/include/prot/vtap.h
@@ -11,11 +11,9 @@
 #ifndef vtap_h
 #define vtap_h
    
-#  ifdef __STDC__
 
 void	vtap_init( XObj );
 
-#  endif
 #define VTAP_ENABLETAP       (VTAP_CTL * MAXOPS + 0)
 #define VTAP_DISABLETAP      (VTAP_CTL * MAXOPS + 1)
 #define VTAP_PRINTCHARS      (VTAP_CTL * MAXOPS + 2)

--- a/src-lites-1.1-2025/xkernel/include/prottbl.h
+++ b/src-lites-1.1-2025/xkernel/include/prottbl.h
@@ -26,9 +26,7 @@
  * If no entry for this protocol exists, -1 is returned.
  */
 extern long	protTblGetId(
-#ifdef __STDC__
 			 char *protocolName
-#endif
 			 );
 
 /* 
@@ -37,9 +35,7 @@ extern long	protTblGetId(
  * should be considered an error.
  */
 extern long	relProtNum(
-#ifdef __STDC__
 			   XObj hlp, XObj llp
-#endif
 			   );
 
 
@@ -53,9 +49,7 @@ extern void	prottbl_init( void );
  */
 void
 protTblDisplayMap(
-#    ifdef __STDC__
 		  void
-#    endif
 		  );
 #  endif  XK_DEBUG
 

--- a/src-lites-1.1-2025/xkernel/include/romopt.h
+++ b/src-lites-1.1-2025/xkernel/include/romopt.h
@@ -19,10 +19,8 @@
 #endif
 
 typedef xkern_return_t	(* XObjRomOptFunc)(
-#ifdef __STDC__
 				       XObj, char **, int numFields,
 				        int line, void *
-#endif
 				       );
 
 typedef struct {
@@ -33,10 +31,8 @@ typedef struct {
 
 
 typedef xkern_return_t	(* RomOptFunc)(
-#ifdef __STDC__
 				       char **, int numFields,
 				       int line, void *
-#endif
 				       );
 
 typedef struct {
@@ -67,17 +63,13 @@ typedef struct {
  * RomOpt array.
  */
 xkern_return_t	findXObjRomOpts(
-#ifdef __STDC__
 			    XObj, XObjRomOpt *, int numOpts, VOID *arg
-#endif
 			    );
 
 
 
 xkern_return_t	findRomOpts(
-#ifdef __STDC__
 			    char *, RomOpt *, int numOpts, VOID *arg
-#endif
 			    );
 
 

--- a/src-lites-1.1-2025/xkernel/include/rwlock.h
+++ b/src-lites-1.1-2025/xkernel/include/rwlock.h
@@ -24,22 +24,17 @@ typedef struct rwlock {
 	Semaphore	readersSem, writersSem;
 	int		flags;
 	void		(* destroyFunc)(
-#ifdef __STDC__
 			      struct rwlock *, void *
-#endif
 			      );
 	VOID		*destFuncArg;
 } ReadWriteLock;
 
 
 typedef	void	(*RwlDestroyFunc)(
-#if defined(__STDC__)
 					   ReadWriteLock *, void *
-#endif
 					   );
 
 
-#ifdef __STDC__
 
 xkern_return_t	readerLock( ReadWriteLock * );
 void		readerUnlock( ReadWriteLock * );
@@ -49,16 +44,5 @@ void		rwLockInit( ReadWriteLock * );
 xkern_return_t	writerLock( ReadWriteLock * );
 void		writerUnlock( ReadWriteLock * );
 
-#else
-
-xkern_return_t	readerLock();
-void		readerUnlock();
-void		rwLockDestroy();
-void		rwLockDump();
-void		rwLockInit();
-xkern_return_t	writerLock();
-void		writerUnlock();
-
-#endif __STDC__
 
 #endif rwlock_h

--- a/src-lites-1.1-2025/xkernel/include/shahash.h
+++ b/src-lites-1.1-2025/xkernel/include/shahash.h
@@ -5,14 +5,8 @@ typedef struct {
   unsigned long h0,h1,h2,h3,h4;
   unsigned long data[80]; }  SHA_state;
 
-#ifdef __STDC__
 void sha_setup(SHA_state *);
 void sha_store(SHA_state *, unsigned char *, int count);
 void sha_finish(SHA_state *);
-#else
-void sha_setup();
-void sha_store();
-void sha_finish();
-#endif
 
 

--- a/src-lites-1.1-2025/xkernel/include/upi.h
+++ b/src-lites-1.1-2025/xkernel/include/upi.h
@@ -42,7 +42,6 @@ typedef	struct xobj {
   int   rcnt;
   int	id;
   int	*traceVar;
-#if __STDC__
   struct xobj *
     (* open)( struct xobj *, struct xobj *, struct xobj *, Part * );
   enum xkret	(* close)( struct xobj * );
@@ -63,24 +62,6 @@ typedef	struct xobj {
   int		(* control)( struct xobj *, int, char *, int );
   enum xkret	(* duplicate)( struct xobj * );
   enum xkret	(* shutdown)( struct xobj * );
-#else
-  Pfo	open;
-  Pfk 	close;
-  Pfk   closedone;
-  Pfk	openenable;
-  Pfk	opendisable;
-  Pfk	opendisableall;
-  Pfk	opendone;
-  Pfk 	demux;
-  Pfk 	calldemux;
-  Pfk 	pop;
-  Pfk 	callpop;
-  Pfh 	push;
-  Pfk 	call;
-  Pfi 	control; 
-  Pfk	duplicate;
-  Pfk	shutdown;
-#endif  
   int 	numdown;
   int	downlistsz;
   unsigned char	idle;
@@ -122,7 +103,6 @@ extern char **globalArgv;
 
 /* protocol and session operations */
 
-#ifdef __STDC__
 
 extern	XObj xOpen( XObj hlpRcv, XObj hlpType, XObj llp, Part *p );
 extern	xkern_return_t
@@ -156,34 +136,9 @@ xkern_return_t	defaultVirtualOpenDisable( XObj, Map, XObj, XObj, XObj *,
 xkern_return_t	defaultVirtualOpenEnable( XObj, Map, XObj, XObj, XObj *,
 					  Part *);
 
-#else
-
-extern	XObj xOpen();
-extern	xkern_return_t  xOpenEnable();
-extern	xkern_return_t  xOpenDisable();
-extern	xkern_return_t  xOpenDone();
-extern	xkern_return_t  xCloseDone();
-extern	xkern_return_t  xClose();
-extern	xkern_return_t  xDemux();
-extern	xkern_return_t  xCallDemux();
-extern	xmsg_handle_t 	xPush();
-extern	xkern_return_t  xCall();
-extern	int  		xControl();
-extern  xkern_return_t  xDuplicate();
-extern  xkern_return_t	xShutDown();
-
-typedef void	(* DisableAllFunc)();
-
-xkern_return_t	defaultOpenDisable();
-xkern_return_t	defaultOpenEnable();
-xkern_return_t	defaultVirtualOpenDisable();
-xkern_return_t	defaultVirtualOpenEnable();
-
-#endif
 
 /* initialization operations */
 
-#ifdef __STDC__
 
 extern	XObj xCreateSessn(Pfv f, XObj hlpRcv, XObj hlpType, XObj llp,
 			  int downc, XObj *downv);
@@ -192,18 +147,9 @@ extern	XObj xCreateProtl(Pfv f, char *nm, char *inst, int *trace,
 extern	xkern_return_t  xDestroy(XObj s);
 extern  void		upiInit( void );
 
-#else
-
-extern XObj 		xCreateSessn();
-extern XObj 		xCreateProtl();
-extern xkern_return_t	xDestroy();
-extern void		upiInit();
-
-#endif
 
 /* utility routines */
 
-#ifdef __STDC__
 
 extern	XObj 	xGetProtlByName(char *name);
 extern  bool	xIsValidXObj( XObj );
@@ -212,16 +158,6 @@ extern	XObj 	xGetDown(XObj self, int i);
 extern	void	xPrintXObj( XObj );
 extern  void	xRapture( void );
 
-#else
-
-extern	XObj 	xGetProtlByName();
-extern  bool	xIsValidXObj();
-extern	xkern_return_t  xSetDown();
-extern	XObj 	xGetDown();
-extern	void	xPrintXObj();
-extern  void	xRapture();
-
-#endif __STDC__
 
 
 /* object macros */
@@ -301,21 +237,12 @@ enum {
 #include "ip_host.h"
 #include "eth_host.h"
 
-#ifdef __STDC__
 
 extern xkern_return_t	str2ipHost( IPhost *, char * );
 extern xkern_return_t	str2ethHost( ETHhost *, char * );
 extern char *	ipHostStr( IPhost * );
 extern char *	ethHostStr( ETHhost * );
 
-#else
-
-extern xkern_return_t	str2ipHost();
-extern xkern_return_t	str2ethHost();
-extern char *	ipHostStr();
-extern char *	ethHostStr();
-
-#endif __STDC__
 
 
 extern XObj	xNullProtl;

--- a/src-lites-1.1-2025/xkernel/include/upi_inline.h
+++ b/src-lites-1.1-2025/xkernel/include/upi_inline.h
@@ -30,17 +30,10 @@
 #else
 #  define FUNC_TYPE xkern_return_t
 
-#  ifdef __STDC__
 
 FUNC_TYPE	xPop( XObj, XObj, Msg *, void * );
 FUNC_TYPE	xCallPop( XObj, XObj, Msg *, void *, Msg * );
 
-#  else 
-
-FUNC_TYPE	xPop();
-FUNC_TYPE	xCallPop();
-
-#  endif __STDC__
 #endif XK_USE_INLINE
 
 

--- a/src-lites-1.1-2025/xkernel/include/x_util.h
+++ b/src-lites-1.1-2025/xkernel/include/x_util.h
@@ -13,26 +13,15 @@
 #ifndef x_util_h
 #define x_util_h
 
-#ifdef __STDC__
 
 extern void	Delay( int );
 extern void	Kabort( char * );
 
-#else
-
-extern void	Delay();
-extern void	Kabort();
-
-#endif __STDC__
 
 /* 
  * non-ANSI compilers gripe about the _n##U usage while GCC gives
  * warning messages about the u_long cast.
  */
-#ifdef __STDC__
 #   define UNSIGNED(_n)	_n##U
-#else
-#   define UNSIGNED(_n)	((u_long)(_n))
-#endif
 
 #endif ! x_util_h

--- a/src-lites-1.1-2025/xkernel/include/xk_debug.h
+++ b/src-lites-1.1-2025/xkernel/include/xk_debug.h
@@ -54,19 +54,11 @@ extern	char errBuf[250];
 #endif
 
 
-#ifdef __STDC__
 
 void	xTraceLock( void );
 void	xTraceUnlock( void );
 void	xTraceInit( void );
 
-#else
-
-void	xTraceLock();
-void	xTraceUnlock();
-void	xTraceInit();
-
-#endif
 
 
 #if defined(XK_DEBUG) || defined(lint)
@@ -74,7 +66,6 @@ void	xTraceInit();
 #define PRETRACE(l) { int __i=l; xTraceLock();  while(__i--) putchar(' '); }
 #define POSTTRACE { putchar('\n'); xTraceUnlock(); }
 
-#ifdef __STDC__
 #define XPASTE(X,Y) X##Y
 #define PASTE(X,Y) XPASTE(X,Y)
 
@@ -129,61 +120,6 @@ void	xTraceInit();
 	    	POSTTRACE;		\
 	    }				\
 	} while (0)
-#else
-#define D___I(X) X
-
-
-#   define xIfTrace(t, l) \
-	if (D___I(trace)t >= l)
-#   define xTrace0(t, l, f) 			\
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f); 			\
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace1(t, l, f, arg1) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-		printf(f, arg1); 		\
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace2(t, l, f, arg1, arg2) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f, arg1, arg2); 		\
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace3(t, l, f, arg1, arg2, arg3) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f, arg1, arg2, arg3); 	\
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace4(t, l, f, arg1, arg2, arg3, arg4) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f, arg1, arg2, arg3, arg4); \
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace5(t, l, f, arg1, arg2, arg3, arg4, arg5) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f, arg1, arg2, arg3, arg4, arg5); \
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#endif /* __STDC__ */
 
 #   define xIfTraceP( _obj, _lev ) \
 	if ( *(_obj)->traceVar >= (_lev) )
@@ -275,9 +211,7 @@ void	xTraceInit();
 #endif	/* XK_DEBUG */
 
 extern void	xError(
-#ifdef __STDC__
 		       char *
-#endif
 		       );
 
 #endif	/* xk_debug_h */

--- a/src-lites-1.1-2025/xkernel/include/xtime.h
+++ b/src-lites-1.1-2025/xkernel/include/xtime.h
@@ -20,12 +20,10 @@ typedef struct {
   long usec;
 } XTime;
 
-#ifdef __STDC__
 
 /* set *t to the current time of day */
 void xGetTime(XTime *t);
 
-#endif __STDC__
 
 
 /* 

--- a/src-lites-1.1-2025/xkernel/lib/include/gmp.h
+++ b/src-lites-1.1-2025/xkernel/lib/include/gmp.h
@@ -66,11 +66,7 @@ typedef struct
 typedef unsigned long int	mp_limb;
 typedef long int		mp_limb_signed;
 typedef mp_limb *		mp_ptr;
-#ifdef __STDC__
 typedef const mp_limb *		mp_srcptr;
-#else
-typedef mp_limb *		mp_srcptr;
-#endif
 typedef long int		mp_size;
 
 /* Structure for rational numbers.  Zero is represented as 0/any, i.e.
@@ -95,7 +91,6 @@ typedef struct
 #endif
 } MP_RAT;
 
-#ifdef __STDC__
 void mp_set_memory_functions (void *(*) (size_t),
 			      void *(*) (void *, size_t, size_t),
 			      void (*) (void *, size_t));
@@ -163,7 +158,6 @@ void mpz_inp_raw (MP_INT *, FILE *);
 void mpz_inp_str (MP_INT *, FILE *, int);
 void mpz_out_raw (FILE *, const MP_INT *);
 void mpz_out_str (FILE *, int, const MP_INT *);
-#endif
 
 void mpz_array_init (MP_INT [], size_t, mp_size);
 void mpz_random (MP_INT *, mp_size);
@@ -204,106 +198,5 @@ mp_size mpn_rshiftci (mp_ptr, mp_srcptr, mp_size, unsigned int, mp_limb);
 mp_size mpn_sqrt (mp_ptr, mp_ptr, mp_srcptr, mp_size);
 int mpn_cmp (mp_srcptr, mp_srcptr, mp_size);
 
-#else /* ! __STDC__ */
-void mp_set_memory_functions ();
-
-/**************** Integer (i.e. Z) routines.  ****************/
-
-void mpz_init ();
-void mpz_set ();
-void mpz_set_ui ();
-void mpz_set_si ();
-int mpz_set_str ();
-void mpz_init_set ();
-void mpz_init_set_ui ();
-void mpz_init_set_si ();
-int mpz_init_set_str ();
-unsigned long int mpz_get_ui ();
-long int mpz_get_si ();
-char * mpz_get_str ();
-void mpz_clear ();
-void * _mpz_realloc ();
-void mpz_add ();
-void mpz_add_ui ();
-void mpz_sub ();
-void mpz_sub_ui ();
-void mpz_mul ();
-void mpz_mul_ui ();
-void mpz_div ();
-void mpz_div_ui ();
-void mpz_mod ();
-void mpz_mod_ui ();
-void mpz_divmod ();
-void mpz_divmod_ui ();
-void mpz_mdiv ();
-void mpz_mdiv_ui ();
-void mpz_mmod ();
-unsigned long int mpz_mmod_ui ();
-void mpz_mdivmod ();
-unsigned long int mpz_mdivmod_ui ();
-void mpz_sqrt ();
-void mpz_sqrtrem ();
-int mpz_perfect_square_p ();
-int mpz_probab_prime_p ();
-void mpz_powm ();
-void mpz_powm_ui ();
-void mpz_pow_ui ();
-void mpz_fac_ui ();
-void mpz_gcd ();
-void mpz_gcdext ();
-void mpz_neg ();
-void mpz_com ();
-void mpz_abs ();
-int mpz_cmp ();
-int mpz_cmp_ui ();
-int mpz_cmp_si ();
-void mpz_mul_2exp ();
-void mpz_div_2exp ();
-void mpz_mod_2exp ();
-void mpz_and ();
-void mpz_ior ();
-void mpz_xor ();
-
-void mpz_inp_raw ();
-void mpz_inp_str ();
-void mpz_out_raw ();
-void mpz_out_str ();
-
-void mpz_array_init ();
-void mpz_random ();
-void mpz_random2 ();
-size_t mpz_size ();
-size_t mpz_sizeinbase ();
-
-/**************** Rational (i.e. Q) routines.  ****************/
-
-void mpq_init ();
-void mpq_clear ();
-void mpq_set ();
-void mpq_set_ui ();
-void mpq_set_si ();
-void mpq_add ();
-void mpq_sub ();
-void mpq_mul ();
-void mpq_div ();
-void mpq_neg ();
-int mpq_cmp ();
-void mpq_inv ();
-void mpq_set_num ();
-void mpq_set_den ();
-void mpq_get_num ();
-void mpq_get_den ();
-
-/************ Low level positive-integer (i.e. N) routines.  ************/
-
-mp_limb mpn_add ();
-mp_size mpn_sub ();
-mp_size mpn_mul ();
-mp_size mpn_div ();
-mp_limb mpn_lshift ();
-mp_size mpn_rshift ();
-mp_size mpn_rshiftci ();
-int mpn_cmp ();
-#endif /* __STDC__ */
 
 #endif /* __GMP_H__ */

--- a/src-lites-1.1-2025/xkernel/mach3/api/netipc/hdr-utils.h
+++ b/src-lites-1.1-2025/xkernel/mach3/api/netipc/hdr-utils.h
@@ -39,18 +39,10 @@ extern short (*unpermute_int16[4])();
 extern float (*unpermute_real32[4])();
 extern mach_msg_type_t (*unpermute_msg_type[4])();
 
-#ifdef __STDC__
 extern int arch_unpermute_index( enum SOURCE_BYTE_ARCH );
 extern long  nop_64(char *);
 extern int   nop_32(char *);
 extern short nop_16(char *);
 extern char  nop_8(char *);
-#else
-extern int arch_unpermute_index( );
-extern long  nop_64();
-extern int   nop_32();
-extern short nop_16();
-extern char  nop_8();
-#endif
 #endif HDRUTILS
 

--- a/src-lites-1.1-2025/xkernel/mach3/api/netipc/machripc_xfer.h
+++ b/src-lites-1.1-2025/xkernel/mach3/api/netipc/machripc_xfer.h
@@ -23,7 +23,6 @@ typedef int	NetPortNumber;
 					      PORT_NUMBER_NETLEN)
 
 
-#ifdef __STDC__
 
 char *	portNumStr();
 
@@ -103,9 +102,7 @@ extern void		mnetportLoad( char *src, mportNetRep *dst );
  */
 extern void		mnetportStore( mportNetRep *src, char *dst );
 
-#endif
 
-#endif __STDC__
 
 
 #  define mnetportLoad( _src, _dst )				\

--- a/src-lites-1.1-2025/xkernel/mach3/api/netipc/nns.h
+++ b/src-lites-1.1-2025/xkernel/mach3/api/netipc/nns.h
@@ -13,11 +13,9 @@
 #ifndef nns_h
 #define nns_h
 
-#  ifdef __STDC__
 
 void	nns_init( XObj );
 
-#  endif
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach3/api/proxy/lproxy.h
+++ b/src-lites-1.1-2025/xkernel/mach3/api/proxy/lproxy.h
@@ -10,7 +10,6 @@
  * $Date: 1993/09/16 22:02:19 $
  */
 
-#ifdef __STDC__
 
 kern_return_t	do_lproxy_dumpXObj( mach_port_t,
 				    xkern_return_t *,
@@ -57,5 +56,4 @@ kern_return_t	do_lproxy_xOpenDone( mach_port_t,
 				    xobj_ext_id_t,
 				    xobj_ext_id_t );
 
-#endif
 

--- a/src-lites-1.1-2025/xkernel/mach3/api/proxy/proxy_util.h
+++ b/src-lites-1.1-2025/xkernel/mach3/api/proxy/proxy_util.h
@@ -15,9 +15,7 @@
 
 
 typedef 	void	(* DeallocFunc)(
-#ifdef __STDC__
 					VOID *, int
-#endif
 					);
 typedef struct {
     bool		valid;
@@ -28,7 +26,6 @@ typedef struct {
 
 
 
-#ifdef __STDC__
 
 void		lingeringMsgClear( void );
 void		lingeringMsgSave( DeallocFunc, VOID *, int );
@@ -42,37 +39,7 @@ void		oolToMsg( char *, int, Msg * );
 void	oolFreeIncoming( VOID *, int );
 void	oolFreeOutgoing( VOID *, int );
 
-#  else
 
-/* 
- * Deallocate the virtual memory region containing 'p'.  
- */
-void	oolFree( VOID *, int );
-
-#  endif  /* XKMACHKERNEL */
-
-#else	/* ! __STDC__ */
-
-void	lingeringMsgClear();
-void	lingeringMsgSave();
-bool	msgIsContiguous();
-bool	msgIsOkToMangle();
-
-#  ifdef XKMACHKERNEL
-
-void	oolFreeIncoming();
-void	oolFreeOutgoing();
-
-#  else
-
-/* 
- * Deallocate the virtual memory region containing 'p'.  
- */
-void	oolFree();
-
-#  endif  /* XKMACHKERNEL */
-
-#endif /* __STDC__ */
 
 
 #endif /* ! proxy_util_h */

--- a/src-lites-1.1-2025/xkernel/mach3/api/proxy/uproxy.h
+++ b/src-lites-1.1-2025/xkernel/mach3/api/proxy/uproxy.h
@@ -10,7 +10,6 @@
  * $Date: 1993/09/21 00:23:23 $
  */
 
-#ifdef __STDC__
 
 kern_return_t	do_uproxy_abort( PORT_TYPE,
 				PORT_TYPE);
@@ -96,4 +95,3 @@ kern_return_t	do_uproxy_xCall( PORT_TYPE,
 				xk_msg_attr_t,
 				mach_msg_type_number_t );
 
-#endif

--- a/src-lites-1.1-2025/xkernel/mach3/include/assert.h
+++ b/src-lites-1.1-2025/xkernel/mach3/include/assert.h
@@ -18,11 +18,7 @@
 #endif
 
 #ifndef XKMACHKERNEL
-#  ifdef __STDC__
 extern void abort(void);
-#  else
-extern void abort();
-#  endif __STDC__
 #  define ABORT abort
 #  define PRINT(A,B,C) fprintf(stderr, (A), (B), (C))
 #else

--- a/src-lites-1.1-2025/xkernel/mach3/include/event_i.h
+++ b/src-lites-1.1-2025/xkernel/mach3/include/event_i.h
@@ -25,7 +25,6 @@
 
 #ifdef XK_THREAD_TRACE
 
-#  ifdef __STDC__
 
 /* 
  * evMarkBlocked -- mark the current thread as blocked on the given
@@ -41,7 +40,6 @@ void	evMarkBlocked( Semaphore * );
  */
 void	evMarkRunning( void );
 
-#  endif
 
 /* 
  * localEventMap -- contains all x-kernel event structures.  Event
@@ -52,10 +50,8 @@ extern Map	localEventMap;
 
 #endif
 
-#ifdef __STDC__
 
 void	evInit( int );
 
-#endif
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach3/include/kern_process_msg.h
+++ b/src-lites-1.1-2025/xkernel/mach3/include/kern_process_msg.h
@@ -43,17 +43,10 @@ extern struct list_head	xkIncomingData;
 extern int		xkIncomingData_lock;
 
 
-#ifdef __STDC__
 
 void			xkBufferPoolInit( void );
 void			xkFillThreadPool( void );
 
-#else
-
-void			xkBufferPoolInit();
-void			xkFillThreadPool();
-
-#endif __STDC__
 
 #endif ! process_msg_h
 

--- a/src-lites-1.1-2025/xkernel/mach3/include/platform.h
+++ b/src-lites-1.1-2025/xkernel/mach3/include/platform.h
@@ -38,19 +38,11 @@
 #include "msg_s.h"
 
 
-#ifdef __STDC__
 
 extern	char *	xMalloc( unsigned );
 extern  void 	xFree( char * );
 extern  void	xMallocInit( void );
 
-#else
-
-extern	char *	xMalloc(  );
-extern  void 	xFree(  );
-extern  void	xMallocInit();
-
-#endif __STDC__
 
 
 extern char *strcpy();
@@ -64,19 +56,11 @@ extern char *strcpy();
 #endif
 
 
-#ifdef __STDC__
 
 void	evInit( int );
 u_short inCkSum( Msg *m, u_short *buf, int len );
 u_short ocsum( u_short *buf, int count );
 
-#else
-
-void	evInit();
-u_short inCkSum( );
-u_short ocsum(  );
-
-#endif __STDC__
 
 
 typedef long *Unspec;

--- a/src-lites-1.1-2025/xkernel/mach3/include/process.h
+++ b/src-lites-1.1-2025/xkernel/mach3/include/process.h
@@ -123,15 +123,9 @@ typedef struct sSemaphore {
 #define semWait(S) { if (--(S)->count < 0) realP(S); }
 #define semSignal(S) { if (++(S)->count <= 0) realV(S); }
 
-#ifdef __STDC__
 extern void semInit( Semaphore *, unsigned int );
 extern void realP( Semaphore * );
 extern void realV( Semaphore * );
-#else
-extern void semInit( );
-extern void realP( );
-extern void realV( );
-#endif
 
 extern Process *Active;
 extern int	SignalsPossible;
@@ -205,7 +199,6 @@ extern int tracexklock;
 #endif XKLOCKDEBUG
 
 
-#ifdef __STDC__
 
 void	CreateKernelProcess( Pfi, int, int, int, int );
 bool	CreateProcess();
@@ -220,7 +213,6 @@ void	xkThreadDumpStats( void );
 #  ifndef XKMACHKERNEL
 void	VAll( Semaphore * );
 void	max_cthread_priority( void );
-#  endif
 
 #endif
 

--- a/src-lites-1.1-2025/xkernel/mach3/include/process_msg.h
+++ b/src-lites-1.1-2025/xkernel/mach3/include/process_msg.h
@@ -68,17 +68,10 @@ extern ProtectedQueue	xkInQueue;
 extern ProtectedQueue	xkFreeQueue;
 
 
-#ifdef __STDC__
 
 void			xkBufferPoolInit( void );
 void			xkFillThreadPool( void );
 
-#else
-
-void			xkBufferPoolInit();
-void			xkFillThreadPool();
-
-#endif __STDC__
 
 #endif ! process_msg_h
 

--- a/src-lites-1.1-2025/xkernel/mach3/include/shepherd.h
+++ b/src-lites-1.1-2025/xkernel/mach3/include/shepherd.h
@@ -23,11 +23,7 @@ typedef enum xkShepType_e xkShepType_t;
  *
  */
 kern_return_t
-#ifdef __STDC__
 shepInit( int count );
-#else
-shepInit();
-#endif __STDC__
 
 /*
  * Invoke a shepherd thread
@@ -45,9 +41,5 @@ shepInit();
  *
  */
 kern_return_t
-#ifdef __STDC__
 xInvokeShepherd(xkShepType_t type, void (*func)( char * ), char *arg  );
-#else
-xInvokeShepherd();
-#endif __STDC__
 

--- a/src-lites-1.1-2025/xkernel/mach3/include/xk_mach.h
+++ b/src-lites-1.1-2025/xkernel/mach3/include/xk_mach.h
@@ -16,7 +16,6 @@
 
 #include <mach/error.h>
 
-#ifdef __STDC__
 
 #ifndef XKMACHKERNEL
 
@@ -36,7 +35,6 @@ int			cthread_kernel_limit( void );
 void			cthread_set_kernel_limit( int );
 void			cthread_wire( void );
 
-#endif ! XKMACHKERNEL
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach3/inkernel/include/proxy_util.h
+++ b/src-lites-1.1-2025/xkernel/mach3/inkernel/include/proxy_util.h
@@ -1,1 +1,45 @@
-../../../mach3/api/proxy/proxy_util.h
+/*     
+ * $RCSfile: proxy_util.h,v $
+ *
+ * x-kernel v3.2
+ *
+ * Copyright (c) 1993,1991,1990  Arizona Board of Regents
+ *
+ *
+ * $Revision: 1.3 $
+ * $Date: 1993/07/16 00:47:18 $
+ */
+
+#ifndef proxy_util_h
+#define proxy_util_h
+
+
+typedef 	void	(* DeallocFunc)(
+					VOID *, int
+					);
+typedef struct {
+    bool		valid;
+    DeallocFunc		func;
+    VOID		*arg;
+    int			len;
+} LingeringMsg;
+
+
+
+
+void		lingeringMsgClear( void );
+void		lingeringMsgSave( DeallocFunc, VOID *, int );
+bool		msgIsOkToMangle( Msg *m, char **machMsg, int offset );
+bool		msgIsContiguous( Msg *m );
+xkern_return_t	msgToOol( Msg *, char **, DeallocFunc *, VOID **arg );
+void		oolToMsg( char *, int, Msg * );
+
+#  ifdef XKMACHKERNEL
+
+void	oolFreeIncoming( VOID *, int );
+void	oolFreeOutgoing( VOID *, int );
+
+
+
+
+#endif /* ! proxy_util_h */

--- a/src-lites-1.1-2025/xkernel/mach3/user/netipc/test/unxk.h
+++ b/src-lites-1.1-2025/xkernel/mach3/user/netipc/test/unxk.h
@@ -13,12 +13,10 @@ typedef struct {
   long usec;
 } XTime;
 
-#ifdef __STDC__
 
 /* set *t to the current time of day */
 void xGetTime(XTime *t);
 
-#endif __STDC__
 /* end of xtime.h stuff */
 
 /* just hacked together */
@@ -55,19 +53,11 @@ enum { GETMYHOST = 0 };
 /* end of stuff from trace.h */
 
 /* from merge/include/xk_debug.h */
-#ifdef __STDC__
 
 void	xTraceLock( void );
 void	xTraceUnlock( void );
 void	xTraceInit( void );
 
-#else
-
-void	xTraceLock();
-void	xTraceUnlock();
-void	xTraceInit();
-
-#endif
 
 
 #if defined(XK_DEBUG) || defined(lint)
@@ -75,7 +65,6 @@ void	xTraceInit();
 #define PRETRACE(l) { int __i=l; xTraceLock();  while(__i--) putchar(' '); }
 #define POSTTRACE { putchar('\n'); xTraceUnlock(); }
 
-#ifdef __STDC__
 #define XPASTE(X,Y) X##Y
 #define PASTE(X,Y) XPASTE(X,Y)
 
@@ -131,62 +120,6 @@ void	xTraceInit();
 	    }				\
 	} while (0)
 #else
-#define D___I(X) X
-
-
-#   define xIfTrace(t, l) \
-	if (D___I(trace)t >= l)
-#   define xTrace0(t, l, f) 			\
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f); 			\
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace1(t, l, f, arg1) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-		printf(f, arg1); 		\
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace2(t, l, f, arg1, arg2) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f, arg1, arg2); 		\
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace3(t, l, f, arg1, arg2, arg3) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f, arg1, arg2, arg3); 	\
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace4(t, l, f, arg1, arg2, arg3, arg4) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f, arg1, arg2, arg3, arg4); \
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace5(t, l, f, arg1, arg2, arg3, arg4, arg5) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f, arg1, arg2, arg3, arg4, arg5); \
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-
-#endif /* __STDC__ */
-#else
 
 #   define xIfTrace(t, l) if (0)
 #   define xTrace0(t, l, f)
@@ -199,9 +132,7 @@ void	xTraceInit();
 #endif	/* XK_DEBUG */
 
 extern void	xError(
-#ifdef __STDC__
 		       char *
-#endif
 		       );
 /* end of xk_debug.h stuff */
 

--- a/src-lites-1.1-2025/xkernel/mach3/user/socket/xsi_main.h
+++ b/src-lites-1.1-2025/xkernel/mach3/user/socket/xsi_main.h
@@ -42,13 +42,8 @@ extern int xsi_cid;
 
 #if defined(XK_DEBUG) || defined(lint)
 
-#ifdef __STDC__
 # define XPASTE(X,Y) X##Y
 # define PASTE(X,Y) XPASTE(X,Y)
-#else
-# define XPASTE(X,Y) X/**/Y
-# define PASTE(X,Y) XPASTE(X,Y)
-#endif
 
 #ifdef TRACE_SYSLOG
 

--- a/src-lites-1.1-2025/xkernel/mach4/api/netipc/hdr-utils.h
+++ b/src-lites-1.1-2025/xkernel/mach4/api/netipc/hdr-utils.h
@@ -39,18 +39,10 @@ extern short (*unpermute_int16[4])();
 extern float (*unpermute_real32[4])();
 extern mach_msg_type_t (*unpermute_msg_type[4])();
 
-#ifdef __STDC__
 extern int arch_unpermute_index( enum SOURCE_BYTE_ARCH );
 extern long  nop_64(char *);
 extern int   nop_32(char *);
 extern short nop_16(char *);
 extern char  nop_8(char *);
-#else
-extern int arch_unpermute_index( );
-extern long  nop_64();
-extern int   nop_32();
-extern short nop_16();
-extern char  nop_8();
-#endif
 #endif HDRUTILS
 

--- a/src-lites-1.1-2025/xkernel/mach4/api/netipc/machripc_xfer.h
+++ b/src-lites-1.1-2025/xkernel/mach4/api/netipc/machripc_xfer.h
@@ -23,7 +23,6 @@ typedef int	NetPortNumber;
 					      PORT_NUMBER_NETLEN)
 
 
-#ifdef __STDC__
 
 char *	portNumStr();
 
@@ -103,9 +102,7 @@ extern void		mnetportLoad( char *src, mportNetRep *dst );
  */
 extern void		mnetportStore( mportNetRep *src, char *dst );
 
-#endif
 
-#endif __STDC__
 
 
 #  define mnetportLoad( _src, _dst )				\

--- a/src-lites-1.1-2025/xkernel/mach4/api/netipc/nns.h
+++ b/src-lites-1.1-2025/xkernel/mach4/api/netipc/nns.h
@@ -13,11 +13,9 @@
 #ifndef nns_h
 #define nns_h
 
-#  ifdef __STDC__
 
 void	nns_init( XObj );
 
-#  endif
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach4/api/proxy/lproxy.h
+++ b/src-lites-1.1-2025/xkernel/mach4/api/proxy/lproxy.h
@@ -10,7 +10,6 @@
  * $Date: 1993/09/16 22:02:19 $
  */
 
-#ifdef __STDC__
 
 kern_return_t	do_lproxy_dumpXObj( mach_port_t,
 				    xkern_return_t *,
@@ -57,5 +56,4 @@ kern_return_t	do_lproxy_xOpenDone( mach_port_t,
 				    xobj_ext_id_t,
 				    xobj_ext_id_t );
 
-#endif
 

--- a/src-lites-1.1-2025/xkernel/mach4/api/proxy/proxy_util.h
+++ b/src-lites-1.1-2025/xkernel/mach4/api/proxy/proxy_util.h
@@ -15,9 +15,7 @@
 
 
 typedef 	void	(* DeallocFunc)(
-#ifdef __STDC__
 					VOID *, int
-#endif
 					);
 typedef struct {
     bool		valid;
@@ -28,7 +26,6 @@ typedef struct {
 
 
 
-#ifdef __STDC__
 
 void		lingeringMsgClear( void );
 void		lingeringMsgSave( DeallocFunc, VOID *, int );
@@ -42,37 +39,7 @@ void		oolToMsg( char *, int, Msg * );
 void	oolFreeIncoming( VOID *, int );
 void	oolFreeOutgoing( VOID *, int );
 
-#  else
 
-/* 
- * Deallocate the virtual memory region containing 'p'.  
- */
-void	oolFree( VOID *, int );
-
-#  endif  /* XKMACHKERNEL */
-
-#else	/* ! __STDC__ */
-
-void	lingeringMsgClear();
-void	lingeringMsgSave();
-bool	msgIsContiguous();
-bool	msgIsOkToMangle();
-
-#  ifdef XKMACHKERNEL
-
-void	oolFreeIncoming();
-void	oolFreeOutgoing();
-
-#  else
-
-/* 
- * Deallocate the virtual memory region containing 'p'.  
- */
-void	oolFree();
-
-#  endif  /* XKMACHKERNEL */
-
-#endif /* __STDC__ */
 
 
 #endif /* ! proxy_util_h */

--- a/src-lites-1.1-2025/xkernel/mach4/api/proxy/uproxy.h
+++ b/src-lites-1.1-2025/xkernel/mach4/api/proxy/uproxy.h
@@ -10,7 +10,6 @@
  * $Date: 1993/09/21 00:23:23 $
  */
 
-#ifdef __STDC__
 
 kern_return_t	do_uproxy_abort( PORT_TYPE,
 				PORT_TYPE);
@@ -96,4 +95,3 @@ kern_return_t	do_uproxy_xCall( PORT_TYPE,
 				xk_msg_attr_t,
 				mach_msg_type_number_t );
 
-#endif

--- a/src-lites-1.1-2025/xkernel/mach4/include/assert.h
+++ b/src-lites-1.1-2025/xkernel/mach4/include/assert.h
@@ -18,11 +18,7 @@
 #endif
 
 #if !defined(XKMACHKERNEL) && !defined(XKMACH4)
-#  ifdef __STDC__
 extern void abort(void);
-#  else
-extern void abort();
-#  endif __STDC__
 #  define ABORT abort
 #  define PRINT(A,B,C) fprintf(stderr, (A), (B), (C))
 #else

--- a/src-lites-1.1-2025/xkernel/mach4/include/event_i.h
+++ b/src-lites-1.1-2025/xkernel/mach4/include/event_i.h
@@ -25,7 +25,6 @@
 
 #ifdef XK_THREAD_TRACE
 
-#  ifdef __STDC__
 
 /* 
  * evMarkBlocked -- mark the current thread as blocked on the given
@@ -41,7 +40,6 @@ void	evMarkBlocked( Semaphore * );
  */
 void	evMarkRunning( void );
 
-#  endif
 
 /* 
  * localEventMap -- contains all x-kernel event structures.  Event
@@ -52,10 +50,8 @@ extern Map	localEventMap;
 
 #endif
 
-#ifdef __STDC__
 
 void	evInit( int );
 
-#endif
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach4/include/kern_process_msg.h
+++ b/src-lites-1.1-2025/xkernel/mach4/include/kern_process_msg.h
@@ -43,17 +43,10 @@ extern struct list_head	xkIncomingData;
 extern int		xkIncomingData_lock;
 
 
-#ifdef __STDC__
 
 void			xkBufferPoolInit( void );
 void			xkFillThreadPool( void );
 
-#else
-
-void			xkBufferPoolInit();
-void			xkFillThreadPool();
-
-#endif __STDC__
 
 #endif ! process_msg_h
 

--- a/src-lites-1.1-2025/xkernel/mach4/include/platform.h
+++ b/src-lites-1.1-2025/xkernel/mach4/include/platform.h
@@ -37,19 +37,11 @@
 #include "msg_s.h"
 
 
-#ifdef __STDC__
 
 extern	char *	xMalloc( unsigned );
 extern  void 	xFree( char * );
 extern  void	xMallocInit( void );
 
-#else
-
-extern	char *	xMalloc(  );
-extern  void 	xFree(  );
-extern  void	xMallocInit();
-
-#endif __STDC__
 
 
 extern char *strcpy();
@@ -63,19 +55,11 @@ extern char *strcpy();
 #endif
 
 
-#ifdef __STDC__
 
 void	evInit( int );
 u_short inCkSum( Msg *m, u_short *buf, int len );
 u_short ocsum( u_short *buf, int count );
 
-#else
-
-void	evInit();
-u_short inCkSum( );
-u_short ocsum(  );
-
-#endif __STDC__
 
 
 typedef long *Unspec;

--- a/src-lites-1.1-2025/xkernel/mach4/include/process.h
+++ b/src-lites-1.1-2025/xkernel/mach4/include/process.h
@@ -123,15 +123,9 @@ typedef struct sSemaphore {
 #define semWait(S) { if (--(S)->count < 0) realP(S); }
 #define semSignal(S) { if (++(S)->count <= 0) realV(S); }
 
-#ifdef __STDC__
 extern void semInit( Semaphore *, unsigned int );
 extern void realP( Semaphore * );
 extern void realV( Semaphore * );
-#else
-extern void semInit( );
-extern void realP( );
-extern void realV( );
-#endif
 
 extern Process *Active;
 extern int	SignalsPossible;
@@ -205,7 +199,6 @@ extern int tracexklock;
 #endif XKLOCKDEBUG
 
 
-#ifdef __STDC__
 
 void	CreateKernelProcess( Pfi, int, int, int, int );
 bool	CreateProcess();
@@ -220,7 +213,6 @@ void	xkThreadDumpStats( void );
 #  ifndef XKMACHKERNEL
 void	VAll( Semaphore * );
 void	max_cthread_priority( void );
-#  endif
 
 #endif
 

--- a/src-lites-1.1-2025/xkernel/mach4/include/process_msg.h
+++ b/src-lites-1.1-2025/xkernel/mach4/include/process_msg.h
@@ -68,17 +68,10 @@ extern ProtectedQueue	xkInQueue;
 extern ProtectedQueue	xkFreeQueue;
 
 
-#ifdef __STDC__
 
 void			xkBufferPoolInit( void );
 void			xkFillThreadPool( void );
 
-#else
-
-void			xkBufferPoolInit();
-void			xkFillThreadPool();
-
-#endif __STDC__
 
 #endif ! process_msg_h
 

--- a/src-lites-1.1-2025/xkernel/mach4/include/shepherd.h
+++ b/src-lites-1.1-2025/xkernel/mach4/include/shepherd.h
@@ -23,11 +23,7 @@ typedef enum xkShepType_e xkShepType_t;
  *
  */
 kern_return_t
-#ifdef __STDC__
 shepInit( int count );
-#else
-shepInit();
-#endif __STDC__
 
 /*
  * Invoke a shepherd thread
@@ -45,9 +41,5 @@ shepInit();
  *
  */
 kern_return_t
-#ifdef __STDC__
 xInvokeShepherd(xkShepType_t type, void (*func)( char * ), char *arg  );
-#else
-xInvokeShepherd();
-#endif __STDC__
 

--- a/src-lites-1.1-2025/xkernel/mach4/include/xk_mach.h
+++ b/src-lites-1.1-2025/xkernel/mach4/include/xk_mach.h
@@ -16,7 +16,6 @@
 
 #include <mach/error.h>
 
-#ifdef __STDC__
 
 #ifndef XKMACHKERNEL
 
@@ -36,7 +35,6 @@ int			cthread_kernel_limit( void );
 void			cthread_set_kernel_limit( int );
 void			cthread_wire( void );
 
-#endif ! XKMACHKERNEL
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/arp.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/arp.h
@@ -23,11 +23,9 @@
 #include "ip.h"
 #endif
 
-#ifdef __STDC__
 
 void		arp_init( XObj );
 
-#endif
 
 #define ARP_INSTALL 		( ARP_CTL * MAXOPS + 0 )
 #define ARP_GETMYBINDING	( ARP_CTL * MAXOPS + 1 )
@@ -42,11 +40,7 @@ typedef struct {
  * kludge to let the sunos simulator's ethernet driver simulate broadcast
  */
 
-#ifdef __STDC__
 typedef int	(ArpForEachFunc)( ArpBinding *, VOID * );
-#else
-typedef int	(ArpForEachFunc)();
-#endif __STDC__
 
 typedef struct {
     VOID		*v;

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/arp_i.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/arp_i.h
@@ -73,21 +73,12 @@ typedef struct ARPprotlstate {
 } PSTATE;
 
 
-#ifdef __STDC__
 
 void		arpPlatformInit( XObj );
 void		arpSendRequest( ArpWait * );
 void		newArpWait( ArpWait *, XObj, IPhost *, ArpStatus * );
 void		newRarpWait( ArpWait *, XObj, ETHhost *, ArpStatus * );
 
-#else
-
-void		arpPlatformInit();
-void		arpSendRequest();
-void		newArpWait();
-void		newRarpWait();
-
-#endif
 
 
 extern int	tracearpp;

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/arp_table.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/arp_table.h
@@ -18,9 +18,7 @@ typedef struct arpent	*ArpTbl;
  * Returns 0 if the lookup was successful and -1 if it was not.
  */
 int	arpLookup(
-#ifdef __STDC__
 		  XObj, IPhost *, ETHhost *
-#endif
 		  );
 
 /*
@@ -29,9 +27,7 @@ int	arpLookup(
  * Returns 0 if the lookup was successful and -1 if it was not.
  */
 int	arpRevLookup(
-#ifdef __STDC__
 		     XObj, IPhost *, ETHhost *
-#endif
 		     );
 
 /*
@@ -40,18 +36,14 @@ int	arpRevLookup(
  * Returns 0 if the lookup was successful and -1 if it was not.
  */
 int	arpRevLookupTable(
-#ifdef __STDC__
 			  XObj, IPhost *, ETHhost *
-#endif
 			  );
 
 /*
  * Initialize the arp table.
  */
 ArpTbl	arpTableInit(
-#ifdef __STDC__
 		     void
-#endif
 		     );
 
 /*
@@ -62,9 +54,7 @@ ArpTbl	arpTableInit(
  * the address could not be resolved
  */
 void 	arpSaveBinding(
-#ifdef __STDC__
 		       ArpTbl, IPhost *ip, ETHhost *eth
-#endif
 		       );
 
 
@@ -75,9 +65,7 @@ void 	arpSaveBinding(
  */
 void
 arpTblPurge(
-#ifdef __STDC__
 	    ArpTbl, IPhost *
-#endif
 	    );
 
 
@@ -86,9 +74,7 @@ arpTblPurge(
  * remains in the cache.
  */
 void	arpLock(
-#ifdef __STDC__
 		ArpTbl, IPhost *h
-#endif
 		);
 
 
@@ -98,7 +84,5 @@ void	arpLock(
  */
 void
 arpForEach( 
-#ifdef __STDC__
     ArpTbl, ArpForEach *
-#endif
 	   );

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/assert.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/assert.h
@@ -18,11 +18,7 @@
 #endif
 
 #ifndef XKMACHKERNEL
-#  ifdef __STDC__
 extern void abort(void);
-#  else
-extern void abort();
-#  endif __STDC__
 #  define ABORT abort
 #  define PRINT(A,B,C) fprintf(stderr, (A), (B), (C))
 #else

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/auth.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/auth.h
@@ -2,11 +2,9 @@
 #define AUTH_H
 
 
-#ifdef __STDC__
 
 void auth_init( XObj );
 
-#endif
 
 
 #endif 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/bid.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/bid.h
@@ -13,10 +13,8 @@
 #ifndef bid_h
 #define bid_h
    
-#  ifdef __STDC__
 
 void	bid_init( XObj );
 
-#  endif
 
 #endif  ! bid_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/bidctl.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/bidctl.h
@@ -18,11 +18,9 @@
 #ifndef bidctl_h
 #define bidctl_h
    
-#  ifdef __STDC__
 
 void		bidctl_init( XObj );
 
-#  endif
 
 
 typedef	u_int	BootId;

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/bidctl_i.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/bidctl_i.h
@@ -115,7 +115,6 @@ extern int	tracebidctlp;
 #define BIDCTL_BCAST_QUERY_DELAY	3 * 1000	/* 3 seconds */
 
 
-#ifdef __STDC__
 
 void	bidctlBcastBoot( XObj );
 xkern_return_t	bidctlDestroy( BidctlState * );
@@ -134,24 +133,5 @@ void	bidctlTimer( Event, VOID * );
 void	bidctlTimeout( Event, VOID * );
 void	bidctlTransition( BidctlState *, BidctlHdr * );
 
-#else
-
-void	bidctlBcastBoot();
-xkern_return_t	bidctlDestroy();
-void	bidctlDispState();
-char *	bidctlFsmStr();
-void	bidctlHdrDump();
-void	bidctlHdrStore();
-BootId	bidctlNewId();
-void	bidctlOutput();
-void	bidctlReleaseWaiters();
-BootId	bidctlReqTag();
-void	bidctlSemWait();
-void	bidctlStartQuery();
-void	bidctlTimer();
-void	bidctlTimeout();
-void	bidctlTransition();
-
-#endif
 
 #endif  ! bootid_i_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/blast.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/blast.h
@@ -16,10 +16,8 @@
 #define BLAST_SETOUTSTANDINGMSGS (BLAST_CTL*MAXOPS + 0)
 #define BLAST_GETOUTSTANDINGMSGS (BLAST_CTL*MAXOPS + 1)
 
-#  ifdef __STDC__
 
 void		blast_init( XObj );
 
-#  endif
 
 #endif blast_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/blast_internal.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/blast_internal.h
@@ -126,7 +126,6 @@ typedef int PassiveID;
 extern BlastMask	blastFullMask[];
 extern int 		traceblastp;
 
-#ifdef __STDC__
 
 xmsg_handle_t	blastPush( XObj, Msg * );
 int		blastControlSessn( XObj, int, char *, int );
@@ -151,33 +150,7 @@ void	blastShowMstate( MSG_STATE *m, char *message );
 char *	blastShowMask( BLAST_MASK_PROTOTYPE );
 
 
-#else
 
-xmsg_handle_t	blastPush();
-int		blastControlSessn();
-int		blastControlProtl();
-void		blastDecIrc();
-xkern_return_t	blastPop();
-xkern_return_t	blastDemux();
-XObj		blastCreateSessn();
-void		blast_mapFlush();
-int		blast_freeSendSeq();
-int		blast_Retransmit();
-long		blastHdrLoad();
-void		blastHdrStore();
-MSG_STATE *	blastNewMstate();
-xkern_return_t	blastSenderPop();
-int		blast_mask_to_i();
-
-#ifdef XK_DEBUG
-void	blast_phdr();
-char *	blastOpStr();
-void	blastShowActiveKey();
-void	blastShowMstate();
-char *	blastShowMask();
-#endif XK_DEBUG
-
-#endif __STDC__
 
 #endif
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/blast_mask32.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/blast_mask32.h
@@ -21,11 +21,7 @@
  * non-ANSI compilers gripe about the _n##U usage while GCC gives
  * warning messages about the u_long cast.
  */
-#ifdef __STDC__
 #   define UNSIGNED(_n)	_n##U
-#else
-#   define UNSIGNED(_n)	((u_long)(_n))
-#endif
 
 typedef u_long	BlastMask;
 #define BLAST_MASK_PROTOTYPE	BlastMask

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/blast_mask64.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/blast_mask64.h
@@ -29,11 +29,7 @@ typedef struct {
  * non-ANSI compilers gripe about the _n##U usage while GCC gives
  * warning messages about the u_long cast.
  */
-#ifdef __STDC__
 #   define UNSIGNED(_n)	_n##U
-#else
-#   define UNSIGNED(_n)	((u_long)(_n))
-#endif
 
 #define BLAST_MAX_FRAGS	64
 #define BLAST_FULL_MASK(_m, _n)				\
@@ -86,12 +82,10 @@ extern int	abs();
 #      define FUNCTYPE	static 
 #  endif /* GNUC */
 
-#  ifdef __STDC__
 
 FUNCTYPE int	BLAST_MASK_IS_BIT_SET( BlastMask *, int );
 FUNCTYPE void	BLAST_MASK_SET_BIT( BlastMask *, int );
 
-#  endif __STDC__
 
 FUNCTYPE int
 BLAST_MASK_IS_BIT_SET( m, n )

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/blast_stack.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/blast_stack.h
@@ -18,18 +18,9 @@ typedef struct stack {
 } *Stack;
 
 
-#ifdef __STDC__
 
 Stack	stackCreate( int size );
 VOID *	stackPop( Stack );
 int	stackPush( Stack, VOID *);
 void	stackDestroy( Stack );
 
-#else 
-
-Stack	stackCreate();
-VOID * 	stackPop();
-int	stackPush();
-void	stackDestroy();
-
-#endif

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/chan.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/chan.h
@@ -30,10 +30,8 @@ typedef struct {
     unsigned int timeout;
 } chan_info_t; 
     
-#ifdef __STDC__
 
 void	chan_init( XObj );
 
-#endif
 
 #endif chan_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/chan_internal.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/chan_internal.h
@@ -146,12 +146,9 @@ typedef unsigned int PassiveID;
 
 
 typedef		int	(* MapChainForEachFun)(
-#ifdef __STDC__
 					       VOID *, VOID *
-#endif					       
 					       );
 
-#ifdef __STDC__
 
 typedef		XObj (ChanOpenFunc)( XObj, XObj, XObj, ActiveID *, int );
 
@@ -194,48 +191,6 @@ void		chanMapChainAddObject( VOID *, Map, IPhost *, long, int );
 int		chanMapChainApply( Map, IPhost *, MapChainForEachFun );
 Map		chanMapChainFollow( Map, IPhost *, long );
 
-#else
-
-typedef		XObj (ChanOpenFunc)();
-
-xkern_return_t	chanAddIdleSessn();
-xkern_return_t	chanBidctlRegister();
-int		chanCheckMsgLen();
-SEQ_STAT 	chanCheckSeq();
-void		chanClientIdleRespond();
-void		chanClientPeerRebooted();
-int		chanControlSessn();
-XObj 		chanCreateSessn();
-void		chanDestroy();
-void		chanDispKey();
-void		chanEventFlush();
-void		chanFreeResources();
-Map 		chanGetChanMap();
-Map 		chanGetMap();
-long		chanGetProtNum();
-void		chanHdrStore();
-void		chanInternalClose();
-int		chanMapRemove();
-xkern_return_t 	chanOpenEnable();
-xkern_return_t 	chanOpenDisable();
-xkern_return_t 	chanOpenDisableAll();
-void		chanRemoveActive();
-int		chanRemoveIdleSessns();
-xmsg_handle_t	chanReply();
-xmsg_handle_t	chanResend();
-char * 		chanStateStr();
-void		chanServerPeerRebooted();
-XObj		chanOpen();
-char * 		chanStatusStr();
-XObj		chanSvcOpen();
-void		chanTimeout();
-void 		pChanHdr();
-
-void		chanMapChainAddObject();
-int		chanMapChainApply();
-Map		chanMapChainFollow();
-
-#endif
 
 
 extern	int	tracechanp;

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/crypt.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/crypt.h
@@ -35,11 +35,9 @@
 
 
 
-#  ifdef __STDC__
 
 void	crypt_init( XObj );
 
-#  endif
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/eth.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/eth.h
@@ -45,10 +45,8 @@
 
 #define	MAX_IEEE802_3_DATA_SZ	1500
 
-#  ifdef __STDC__
 
 void	eth_init( XObj );
 
-#  endif
 
 #endif eth_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/eth_i.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/eth_i.h
@@ -56,36 +56,20 @@ typedef struct {
  */
 extern ETHhost ethBcastHost;
 
-#ifdef __STDC__
 
 void	ethCtlrInit( ETHhost host );
 void	getLocalEthHost( ETHhost *host );
 int	SetPromiscuous( void );
 void	ethCtlrXmit( Msg *msg, ETHhost *dst, int type );
 
-#else
-
-void	ethCtlrInit();
-void	getLocalEthHost();
-int	SetPromiscuous();
-void	ethCtlrXmit();
-
-#endif
 
 /*
  * Interface presented to driver from protocol
  */
 
-#ifdef __STDC__
 
 xkern_return_t	eth_demux( Msg, int, ETHhost, ETHhost );
 void		ethSendUp( Msg *, ETHhost *, int );
 
-#else
-
-xkern_return_t	eth_demux();
-void		ethSendUp();
-
-#endif
 
 #endif  ! eth_i_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/event.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/event.h
@@ -68,18 +68,14 @@ typedef struct Event {
 
 
 typedef	void	(* EvFunc)(
-#ifdef __STDC__
 			   Event,
 			   void *
-#endif
 			   );
 
 /* schedule an event that executes f w/ argument a after delay t usec; */
 /* t may equal 0, which implies createprocess */
 Event evSchedule(
-#ifdef __STDC__
 		 EvFunc f, void *a, unsigned t
-#endif
 		 );
 
 
@@ -88,9 +84,7 @@ Event evSchedule(
  * associated with the event are freed
  */
 void evDetach(
-#ifdef __STDC__
 	      Event e
-#endif
 	      );
 
 /* cancel event e:
@@ -100,9 +94,7 @@ void evDetach(
  *  returns EVENT_CANCELLED if the event has been successfully cancelled
  */
 EvCancelReturn evCancel(
-#ifdef __STDC__
 	     Event e
-#endif
 	     );
 
 
@@ -110,9 +102,7 @@ EvCancelReturn evCancel(
  * returns true (non-zero) if an 'evCancel' has been performed on the event
  */
 int evIsCancelled(
-#ifdef __STDC__		  
 		  Event e
-#endif
 		  );
 
 
@@ -120,9 +110,7 @@ int evIsCancelled(
  * Displays a 'ps'-style listing of x-kernel threads
  */
 void evDump(
-#ifdef __STDC__		  
 		  void
-#endif
 		  );
 
 
@@ -131,9 +119,7 @@ void evDump(
  * overrunning the stack, triggering warning/error messages if so. 
  */
 void evCheckStack(
-#ifdef __STDC__
 		  char *
-#endif
 		  );
 
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/event_i.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/event_i.h
@@ -25,7 +25,6 @@
 
 #ifdef XK_THREAD_TRACE
 
-#  ifdef __STDC__
 
 /* 
  * evMarkBlocked -- mark the current thread as blocked on the given
@@ -41,7 +40,6 @@ void	evMarkBlocked( Semaphore * );
  */
 void	evMarkRunning( void );
 
-#  endif
 
 /* 
  * localEventMap -- contains all x-kernel event structures.  Event
@@ -52,10 +50,8 @@ extern Map	localEventMap;
 
 #endif
 
-#ifdef __STDC__
 
 void	evInit( int );
 
-#endif
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/gc.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/gc.h
@@ -32,9 +32,7 @@
  */
 
 void	initSessionCollector(
-#ifdef __STDC__
 			     Map m, int interval, Pfv destructor, char *msg
-#endif
 			     );
 
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/gethost.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/gethost.h
@@ -6,8 +6,4 @@
  */
 
 
-#ifdef __STDC__
         xkern_return_t xk_gethostbyname(char *, IPhost *);
-#else
-	xkern_return_t xk_gethostbyname();
-#endif

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/hdr-utils.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/hdr-utils.h
@@ -39,18 +39,10 @@ extern short (*unpermute_int16[4])();
 extern float (*unpermute_real32[4])();
 extern mach_msg_type_t (*unpermute_msg_type[4])();
 
-#ifdef __STDC__
 extern int arch_unpermute_index( enum SOURCE_BYTE_ARCH );
 extern long  nop_64(char *);
 extern int   nop_32(char *);
 extern short nop_16(char *);
 extern char  nop_8(char *);
-#else
-extern int arch_unpermute_index( );
-extern long  nop_64();
-extern int   nop_32();
-extern short nop_16();
-extern char  nop_8();
-#endif
 #endif HDRUTILS
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/icmp.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/icmp.h
@@ -51,10 +51,8 @@
 #define ICMP_ECHO_CTL		(ICMP_CTL * MAXOPS + 0)
 
 
-#  ifdef __STDC__
 
 void	icmp_init( XObj );
 
-#  endif
 
 #endif icmp_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/icmp_internal.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/icmp_internal.h
@@ -88,7 +88,6 @@ typedef struct {
 } mapId;
 
 
-#ifdef __STDC__
 
 int 	icmpSendEchoReq(XObj s, int msgLength);
 void 	icmpPopEchoRep(XObj p, Msg *m);
@@ -96,15 +95,6 @@ void 	icmpHdrStore(void *hdr, char *netHdr, long len, void *);
 void 	icmpEchoStore(void *hdr, char *netHdr, long len, void *);
 long 	icmpEchoLoad(void *hdr, char *netHdr, long len, void *);
 
-#else
-
-int 	icmpSendEchoReq();
-void 	icmpPopEchoRep();
-void 	icmpHdrStore();
-void 	icmpEchoStore();
-long 	icmpEchoLoad();
-
-#endif
 
 
 extern int traceicmpp;

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/idmap.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/idmap.h
@@ -28,21 +28,12 @@ typedef struct mapelement {
 
 typedef struct map	*Map;
 
-#ifdef __STDC__
 
 typedef xkern_return_t (* XMapResolveFunc)( Map, void *, void ** );
 typedef Bind 	       (* XMapBindFunc)( Map, void *, void * );
 typedef xkern_return_t (* XMapRemoveFunc)( Map, Bind );
 typedef xkern_return_t (* XMapUnbindFunc)( Map, void * );
 
-#else
-
-typedef xkern_return_t (* XMapResolveFunc)();
-typedef Bind 	       (* XMapBindFunc)();
-typedef xkern_return_t (* XMapRemoveFunc)();
-typedef xkern_return_t (* XMapUnbindFunc)();
-
-#endif __STDC__
 
 
 struct map {
@@ -70,7 +61,6 @@ struct map {
 #define MFE_CONTINUE	1
 #define MFE_REMOVE	2
 
-#ifdef __STDC__
 
 typedef	int (*MapForEachFun)( void *key, void *value, void *arg );
 
@@ -86,19 +76,6 @@ extern Bind	mapVarBind(Map, VOID *, int, VOID *);
  */
 extern void	map_init( void );
 
-#else
-
-typedef	int (*MapForEachFun)();
-
-extern void 	mapClose();
-extern Map 	mapCreate();
-extern void	mapForEach();
-extern xkern_return_t mapVarResolve();
-extern Bind	mapVarBind();
-
-extern void	map_init();
-
-#endif __STDC__
 
 
 #endif /* idmap_h */

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/ip.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/ip.h
@@ -37,11 +37,9 @@ typedef struct ippseudohdr {
 #define IP_LOCAL_BCAST_HOST	{ 255, 255, 255, 255 }
 
 
-#  ifdef __STDC__
 
 void	ip_init( XObj );
 
-#  endif
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/ip_i.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/ip_i.h
@@ -157,7 +157,6 @@ typedef struct FragList {
 #define ERR_FRAG ((Fragtable *)-1)
 
 
-#ifdef __STDC__
 
 int		ipControlProtl( XObj, int, char *, int );
 int		ipControlSessn( XObj, int, char *, int );
@@ -184,31 +183,6 @@ xmsg_handle_t	ipSend( XObj s, XObj lls, Msg *msg, IPheader *hdr );
 xkern_return_t	ipStdPop( XObj, XObj, Msg *, VOID * );
 void		scheduleIpFragCollector( PState * );
 
-#else
-
-int		ipControlProtl();
-int		ipControlSessn();
-XObj		ipCreatePassiveSessn();
-xkern_return_t	ipDemux();
-Enable *	ipFindEnable();
-xkern_return_t 	ipForwardPop();
-void		ipFreeFragList();
-void		ipFreeFragtable();
-xkern_return_t 	ipFwdBcastPop();
-int		ipGetHdr();
-void		ipHdrStore();
-int		ipIsMyAddr();
-xkern_return_t	ipMsgComplete();
-void		ipProcessRomFile();
-xkern_return_t	ipReassemble();
-int		ipRemoteNet();
-void		ipRouteChanged();
-int		ipSameNet();
-xmsg_handle_t	ipSend();
-xkern_return_t	ipStdPop();
-void		scheduleIpFragCollector();
-
-#endif
 
 extern int 	traceipp;
 extern IPhost	ipSiteGateway;

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/join.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/join.h
@@ -22,11 +22,9 @@
 #define JOINSETCONTROL 		(JOIN_CTL*MAXOPS + 4)
 
 
-#  ifdef __STDC__
 
 void	join_init( XObj );
 
-#  endif
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/kern_process_msg.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/kern_process_msg.h
@@ -43,17 +43,10 @@ extern struct list_head	xkIncomingData;
 extern int		xkIncomingData_lock;
 
 
-#ifdef __STDC__
 
 void			xkBufferPoolInit( void );
 void			xkFillThreadPool( void );
 
-#else
-
-void			xkBufferPoolInit();
-void			xkFillThreadPool();
-
-#endif __STDC__
 
 #endif ! process_msg_h
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/list.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/list.h
@@ -39,7 +39,6 @@ typedef	struct list_entry	*list_entry_t;
 #define	delist(list)		delist_head(list)
 
 
-#ifdef __STDC__
 
 list_entry_t	delist_head( list_t );
 list_entry_t	delist_head_strong( list_t );
@@ -49,15 +48,5 @@ void 		enlist_tail( list_t, list_entry_t );
 void		list_init( list_t );
 
 
-#else
-
-list_entry_t	delist_head();
-list_entry_t	delist_head_strong();
-list_entry_t	delist_tail();
-void 		enlist_head();
-void 		enlist_tail();
-void		list_init();
-
-#endif __STDC__
 
 #endif list_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/lproxy.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/lproxy.h
@@ -10,7 +10,6 @@
  * $Date: 1993/09/16 22:02:19 $
  */
 
-#ifdef __STDC__
 
 kern_return_t	do_lproxy_dumpXObj( mach_port_t,
 				    xkern_return_t *,
@@ -57,5 +56,4 @@ kern_return_t	do_lproxy_xOpenDone( mach_port_t,
 				    xobj_ext_id_t,
 				    xobj_ext_id_t );
 
-#endif
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/machripc_xfer.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/machripc_xfer.h
@@ -23,7 +23,6 @@ typedef int	NetPortNumber;
 					      PORT_NUMBER_NETLEN)
 
 
-#ifdef __STDC__
 
 char *	portNumStr();
 
@@ -103,9 +102,7 @@ extern void		mnetportLoad( char *src, mportNetRep *dst );
  */
 extern void		mnetportStore( mportNetRep *src, char *dst );
 
-#endif
 
-#endif __STDC__
 
 
 #  define mnetportLoad( _src, _dst )				\

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/md5hash.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/md5hash.h
@@ -50,13 +50,7 @@ typedef struct {
 } MD5_CTX;
 
 
-#ifdef __STDC__
 void MD5Init (MD5_CTX *);
 void MD5Update (MD5_CTX *, unsigned char *, unsigned int);
 void MD5Final (MD5_CTX *);
-#else
-void MD5Init ();
-void MD5Update ();
-void MD5Final ();
-#endif __STDC__
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/mselect.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/mselect.h
@@ -13,10 +13,8 @@
 #ifndef mselect_h
 #define mselect_h
    
-#  ifdef __STDC__
 
 void	mselect_init( XObj );
 
-#  endif
 
 #endif  ! mselect_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/msg.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/msg.h
@@ -30,17 +30,13 @@ typedef struct {
   /* copy from a buffer into the contig at offset; 			*/
   /* return the number of bytes copied					*/
   long (*copyIn)(
-#ifdef __STDC__		
 		 char* from, long offset, long size
-#endif
 		 );
 
   /* copy from the contig at offset to a buffer; 			*/
   /* return the number of bytes copied					*/
   long (*copyOut)(
-#ifdef __STDC__
 		  char* to, long offset, long size
-#endif
 		  );
 
 } MContig;
@@ -51,16 +47,9 @@ typedef struct {
 /* 
  * types of user functions called in ForEach()
  */
-#if defined(__STDC__) || defined(__GNUC__)
 typedef bool (*XCharFun)( char *ptr, long len, void *arg );
 typedef bool (*MContigFun)(MContig *contig, long offset, long len, void *arg); 
 
-#else
-
-typedef bool (*XCharFun)();
-typedef bool (*MContigFun)();
-
-#endif
 /*
  * types of load and store functions for headers
  */
@@ -71,9 +60,7 @@ typedef bool (*MContigFun)();
  * argument passed through msgPush
  */
 typedef void (*MStoreFun)(
-#if defined(__STDC__) || defined(__GNUC__)
 			  void *hdr, char *des, long len, void *arg
-#endif
 			  );
 
 /* function to load the header from a potentially unaligned buffer, 	
@@ -82,12 +69,9 @@ typedef void (*MStoreFun)(
  * argument passed through msgPop
  */
 typedef long (*MLoadFun)(
-#if defined(__STDC__) || defined(__GNUC__)
 			 void *hdr, char *src, long len, void *arg
-#endif
 			 );
 
-#if defined(__STDC__) || defined(__GNUC__)
 
 /* Msg operations */
 
@@ -173,16 +157,13 @@ void msgCleanUp(Msg *this);
 /* long enough */
 void msg2buf( Msg *this, char *buf );
 
-#endif __STDC__
 
 
 /*
  * associate an attribute with a message
  */
 xkern_return_t	msgSetAttr(
-#if defined(__STDC__) || defined(__GNUC__)
 			   Msg *this, int name, VOID *attr, int len
-#endif
 			   );
 
 
@@ -190,9 +171,7 @@ xkern_return_t	msgSetAttr(
  * retrieve an attribute associated with a message
  */
 VOID *		msgGetAttr(
-#if defined(__STDC__) || defined(__GNUC__)
 			  Msg *this, int name
-#endif
 			  );
 
 
@@ -202,9 +181,7 @@ VOID *		msgGetAttr(
 /* (=length of contig), and void *arg (=user-supplied argument), */  
 /* while f returns TRUE */
 void msgForEach(
-#if defined(__STDC__) || defined(__GNUC__)
 		Msg *this, XCharFun f, void *arg
-#endif
 		);
 
 /* for every contig in this Msg, invoke the function f with  */
@@ -213,14 +190,11 @@ void msgForEach(
 /* while f returns TRUE */
 /* the memory described by contig may not be accessible!! */
 void msgForEachContig(
-#if defined(__STDC__) || defined(__GNUC__)
 		      Msg *this, MContigFun f, void *arg
-#endif
 		      );
 
 
 
-#if defined(__STDC__) || defined(__GNUC__)
 
 /************* virtual memory funniness **************/
 /* import a Msg from a different address space */
@@ -248,6 +222,5 @@ void msgShow( Msg *this );
  */
 void msgStats( void );
 
-#endif __STDC__
 
 #endif msg_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/netmask.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/netmask.h
@@ -22,9 +22,7 @@
  * netMaskAdd -- add 'mask' to the table as the netmask for 'net'
  */
 int	netMaskAdd(
-#ifdef __STDC__
 		   IPhost *net, IPhost *mask
-#endif
 		   );
 
 
@@ -33,9 +31,7 @@ int	netMaskAdd(
  * any other netmask routines.
  */
 void	netMaskInit(
-#ifdef __STDC__
 		    void
-#endif
 		    );
 
 /* 
@@ -44,9 +40,7 @@ void	netMaskInit(
  * the address class is used.
  */
 void	netMaskFind(
-#ifdef __STDC__
 		    IPhost *mask, IPhost *host
-#endif
 		    );
 
 
@@ -56,9 +50,7 @@ void	netMaskFind(
  * being used.
  */
 void	netMaskDefault(
-#ifdef __STDC__
 		    IPhost *mask, IPhost *host
-#endif
 		    );
 
 
@@ -67,9 +59,7 @@ void	netMaskDefault(
  * same subnet
  */
 int	netMaskSubnetsEqual(
-#ifdef __STDC__
 			 IPhost *, IPhost *
-#endif
 			 );
 
 
@@ -78,9 +68,7 @@ int	netMaskSubnetsEqual(
  * same net
  */
 int	netMaskNetsEqual(
-#ifdef __STDC__
 			 IPhost *, IPhost *
-#endif
 			 );
 
 
@@ -95,9 +83,7 @@ int	netMaskNetsEqual(
  *  or	3) having ones in the entire address
  */
 int	netMaskIsBroadcast(
-#ifdef __STDC__
 			   IPhost *
-#endif
 			   );
 
 extern IPhost	IP_LOCAL_BCAST;

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/nns.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/nns.h
@@ -13,11 +13,9 @@
 #ifndef nns_h
 #define nns_h
 
-#  ifdef __STDC__
 
 void	nns_init( XObj );
 
-#  endif
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/part.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/part.h
@@ -38,17 +38,10 @@ typedef struct {
     PartStack	stack;	/* A stack of void* pointers */
 } Part;
 
-#ifdef __STDC__
 
 void	partStackPush( PartStack *s, void *data, int );
 void *	partStackPop( PartStack *s );
 
-#else
-
-void		partStackPush();
-VOID		*partStackPop();
-
-#endif __STDC__
 
 /********************  public declarations ****************/
 
@@ -58,9 +51,7 @@ VOID		*partStackPop();
 /* 
  * Initialize a vector of N participants
  */
-#ifdef __STDC__
 void	partInit( Part *p, int N );
-#endif
 
 /* 
  * push 'data' onto the stack of participant 'p'.  
@@ -76,23 +67,17 @@ void	partInit( Part *p, int N );
 #define partLen( partPtr ) (partPtr->len)
 
 xkern_return_t	partExternalize(
-#ifdef __STDC__
 				Part *, VOID *, int *
-#endif
 				);
 
 void partInternalize(
-#ifdef __STDC__
 				Part *, VOID *
-#endif
 				);
 
 #define partExtLen( _bufPtr )	( *(int *)(_bufPtr) )
 
 int partStackTopByteLen(
-#ifdef __STDC__
 			Part
-#endif
 			);
 
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/platform.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/platform.h
@@ -40,19 +40,11 @@
 #include "msg_s.h"
 
 
-#ifdef __STDC__
 
 extern	char *	xMalloc( unsigned );
 extern  void 	xFree( char * );
 extern  void	xMallocInit( void );
 
-#else
-
-extern	char *	xMalloc(  );
-extern  void 	xFree(  );
-extern  void	xMallocInit();
-
-#endif __STDC__
 
 
 extern char *strcpy();
@@ -66,19 +58,11 @@ extern char *strcpy();
 #endif
 
 
-#ifdef __STDC__
 
 void	evInit( int );
 u_short inCkSum( Msg *m, u_short *buf, int len );
 u_short ocsum( u_short *buf, int count );
 
-#else
-
-void	evInit();
-u_short inCkSum( );
-u_short ocsum(  );
-
-#endif __STDC__
 
 
 typedef long *Unspec;

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/port_mgr.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/port_mgr.h
@@ -18,7 +18,6 @@
  */
 
 
-#ifdef __STDC__
 #define XPASTE(X,Y) X##Y
 #define PASTE(X,Y) XPASTE(X,Y)
 
@@ -51,4 +50,3 @@ int	PASTE(NAME, DuplicatePort) ( void *, long );
  */
 void	PASTE(NAME, ReleasePort) ( void *, long );
 
-#endif

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/process.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/process.h
@@ -123,15 +123,9 @@ typedef struct sSemaphore {
 #define semWait(S) { if (--(S)->count < 0) realP(S); }
 #define semSignal(S) { if (++(S)->count <= 0) realV(S); }
 
-#ifdef __STDC__
 extern void semInit( Semaphore *, unsigned int );
 extern void realP( Semaphore * );
 extern void realV( Semaphore * );
-#else
-extern void semInit( );
-extern void realP( );
-extern void realV( );
-#endif
 
 extern Process *Active;
 extern int	SignalsPossible;
@@ -205,7 +199,6 @@ extern int tracexklock;
 #endif XKLOCKDEBUG
 
 
-#ifdef __STDC__
 
 void	CreateKernelProcess( Pfi, int, int, int, int );
 bool	CreateProcess();
@@ -220,7 +213,6 @@ void	xkThreadDumpStats( void );
 #  ifndef XKMACHKERNEL
 void	VAll( Semaphore * );
 void	max_cthread_priority( void );
-#  endif
 
 #endif
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/process_msg.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/process_msg.h
@@ -68,17 +68,10 @@ extern ProtectedQueue	xkInQueue;
 extern ProtectedQueue	xkFreeQueue;
 
 
-#ifdef __STDC__
 
 void			xkBufferPoolInit( void );
 void			xkFillThreadPool( void );
 
-#else
-
-void			xkBufferPoolInit();
-void			xkFillThreadPool();
-
-#endif __STDC__
 
 #endif ! process_msg_h
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/prottbl.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/prottbl.h
@@ -26,9 +26,7 @@
  * If no entry for this protocol exists, -1 is returned.
  */
 extern long	protTblGetId(
-#ifdef __STDC__
 			 char *protocolName
-#endif
 			 );
 
 /* 
@@ -37,9 +35,7 @@ extern long	protTblGetId(
  * should be considered an error.
  */
 extern long	relProtNum(
-#ifdef __STDC__
 			   XObj hlp, XObj llp
-#endif
 			   );
 
 
@@ -53,9 +49,7 @@ extern void	prottbl_init( void );
  */
 void
 protTblDisplayMap(
-#    ifdef __STDC__
 		  void
-#    endif
 		  );
 #  endif  XK_DEBUG
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/prottbl_i.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/prottbl_i.h
@@ -41,7 +41,6 @@ typedef struct {
 
 
 
-#ifdef __STDC__
 
 /* 
  * protTblAddProt -- Create an entry in the protocol map binding 'name'
@@ -82,7 +81,6 @@ void		protTblInitMaps( void );
 char *	protIdToStr( long );
 
 
-#endif __STDC__
 
 
 #endif !prottbl_i_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/proxy_util.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/proxy_util.h
@@ -15,9 +15,7 @@
 
 
 typedef 	void	(* DeallocFunc)(
-#ifdef __STDC__
 					VOID *, int
-#endif
 					);
 typedef struct {
     bool		valid;
@@ -28,7 +26,6 @@ typedef struct {
 
 
 
-#ifdef __STDC__
 
 void		lingeringMsgClear( void );
 void		lingeringMsgSave( DeallocFunc, VOID *, int );
@@ -42,37 +39,7 @@ void		oolToMsg( char *, int, Msg * );
 void	oolFreeIncoming( VOID *, int );
 void	oolFreeOutgoing( VOID *, int );
 
-#  else
 
-/* 
- * Deallocate the virtual memory region containing 'p'.  
- */
-void	oolFree( VOID *, int );
-
-#  endif  /* XKMACHKERNEL */
-
-#else	/* ! __STDC__ */
-
-void	lingeringMsgClear();
-void	lingeringMsgSave();
-bool	msgIsContiguous();
-bool	msgIsOkToMangle();
-
-#  ifdef XKMACHKERNEL
-
-void	oolFreeIncoming();
-void	oolFreeOutgoing();
-
-#  else
-
-/* 
- * Deallocate the virtual memory region containing 'p'.  
- */
-void	oolFree();
-
-#  endif  /* XKMACHKERNEL */
-
-#endif /* __STDC__ */
 
 
 #endif /* ! proxy_util_h */

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/rat.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/rat.h
@@ -9,11 +9,9 @@
 #include "ip.h"
 #endif
 
-#  ifdef __STDC__
 
 void    rat_init( XObj );
 
-#  endif
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/romopt.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/romopt.h
@@ -19,10 +19,8 @@
 #endif
 
 typedef xkern_return_t	(* XObjRomOptFunc)(
-#ifdef __STDC__
 				       XObj, char **, int numFields,
 				        int line, void *
-#endif
 				       );
 
 typedef struct {
@@ -33,10 +31,8 @@ typedef struct {
 
 
 typedef xkern_return_t	(* RomOptFunc)(
-#ifdef __STDC__
 				       char **, int numFields,
 				       int line, void *
-#endif
 				       );
 
 typedef struct {
@@ -67,17 +63,13 @@ typedef struct {
  * RomOpt array.
  */
 xkern_return_t	findXObjRomOpts(
-#ifdef __STDC__
 			    XObj, XObjRomOpt *, int numOpts, VOID *arg
-#endif
 			    );
 
 
 
 xkern_return_t	findRomOpts(
-#ifdef __STDC__
 			    char *, RomOpt *, int numOpts, VOID *arg
-#endif
 			    );
 
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/route.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/route.h
@@ -42,7 +42,6 @@ typedef struct {
 
 #include "ip_i.h"
 
-#ifdef __STDC__
 
 /* 
  * Initialize the routing tables and set the default router to be the
@@ -56,14 +55,5 @@ xkern_return_t	rt_add_def( PState *, IPhost * );
 xkern_return_t	rt_get( RouteTable *, IPhost *, route * );
 void		rt_delete( RouteTable *, IPhost *, IPhost * );
 
-#else
-
-xkern_return_t 	rt_init();
-xkern_return_t 	rt_add();
-xkern_return_t	rt_add_def();
-xkern_return_t	rt_get();
-void		rt_delete();
-
-#endif __STDC__
 
 #endif  ! route_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/rrx.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/rrx.h
@@ -20,7 +20,6 @@
 #ifndef rrx_h
 #define rrx_h
 
-#ifdef __STDC__
 
 void		rrx_init( XObj );
 
@@ -38,13 +37,5 @@ xkern_return_t	rrxMoveReceiveRights( IPhost h, MsgId id, mnetport **np );
 void		rrxTransferComplete( IPhost , MsgId );
 
 
-#else
-
-void		rrx_init();
-xkern_return_t	rrxMoveReceiveRights();
-void		rrxTransferComplete();
-
-
-#endif __STDC__
 
 #endif  ! rrx_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/rrx_i.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/rrx_i.h
@@ -124,7 +124,6 @@ typedef struct {
 
 
 
-#ifdef __STDC__
 
 
 long		rrxLoadReply( VOID *, char *, long, VOID * );
@@ -139,21 +138,6 @@ void		rrxStoreRequest( RrxReqOutgoing *, Msg * );
  */
 void		rrxReqDispose( RrxReqMsg * );
 
-#else
-
-long		rrxLoadReply();
-void		rrxStoreReply();
-xkern_return_t	rrxLoadRequest();
-void		rrxStoreRequest();
-
-/* 
- * Headers loaded with rrxLoadRequest include dynamically allocated
- * storage.  rrxReqDispose should be called for each of these
- * headers. 
- */
-void		rrxReqDispose();
-
-#endif
 
 
 #endif  ! rrx_i_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/rwlock.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/rwlock.h
@@ -24,22 +24,17 @@ typedef struct rwlock {
 	Semaphore	readersSem, writersSem;
 	int		flags;
 	void		(* destroyFunc)(
-#ifdef __STDC__
 			      struct rwlock *, void *
-#endif
 			      );
 	VOID		*destFuncArg;
 } ReadWriteLock;
 
 
 typedef	void	(*RwlDestroyFunc)(
-#if defined(__STDC__)
 					   ReadWriteLock *, void *
-#endif
 					   );
 
 
-#ifdef __STDC__
 
 xkern_return_t	readerLock( ReadWriteLock * );
 void		readerUnlock( ReadWriteLock * );
@@ -49,16 +44,5 @@ void		rwLockInit( ReadWriteLock * );
 xkern_return_t	writerLock( ReadWriteLock * );
 void		writerUnlock( ReadWriteLock * );
 
-#else
-
-xkern_return_t	readerLock();
-void		readerUnlock();
-void		rwLockDestroy();
-void		rwLockDump();
-void		rwLockInit();
-xkern_return_t	writerLock();
-void		writerUnlock();
-
-#endif __STDC__
 
 #endif rwlock_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/sb.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/sb.h
@@ -46,7 +46,6 @@ extern struct sb_i *sbifreelist;
 #define sbinew(s) { if ((s) = sbifreelist) sbifreelist = (s)->next; else (s) = (struct sb_i *)xMalloc(sizeof(struct sb_i)); }
 #define sbifree(s) { (s)->next = sbifreelist; sbifreelist = (s); }
 
-#ifdef __STDC__
 
 extern void	sbappend( struct sb *, Msg * );
 extern void 	sbcollect( struct sb *, Msg *, int off, int len, int delete );
@@ -54,14 +53,5 @@ extern void 	sbflush( struct sb * );
 extern void 	sbdrop( struct sb * , int len );
 extern void 	sbdelete( struct sb * );
 
-#else
-
-extern void	sbappend();
-extern void 	sbcollect();
-extern void 	sbflush();
-extern void 	sbdrop();
-extern void 	sbdelete();
-
-#endif __STDC__
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/select.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/select.h
@@ -13,10 +13,8 @@
 #ifndef select_h
 #define select_h
    
-#  ifdef __STDC__
 
 void	select_init( XObj );
 
-#  endif
 
 #endif  ! select_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/select_i.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/select_i.h
@@ -41,7 +41,6 @@ typedef long PassiveKey;
 
 extern int	traceselectp;
 
-#ifdef __STDC__
 
 void		selectCommonInit( XObj );
 XObj		selectCommonOpen( XObj, XObj, XObj, Part *, long );
@@ -52,18 +51,6 @@ int		selectCommonControlSessn( XObj, int, char *, int );
 xkern_return_t	selectCallDemux( XObj, XObj, Msg *, Msg * );
 xkern_return_t	selectDemux( XObj, XObj, Msg * );
 
-#else
-
-void		selectCommonInit();
-XObj		selectCommonOpen();
-xkern_return_t	selectCommonOpenDisable();
-xkern_return_t 	selectCommonOpenEnable();
-int		selectControlProtl();
-int		selectCommonControlSessn();
-xkern_return_t	selectDemux();
-xkern_return_t	selectCallDemux();
-
-#endif __STDC__
 
 
 #endif	! select_i_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/shahash.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/shahash.h
@@ -5,14 +5,8 @@ typedef struct {
   unsigned long h0,h1,h2,h3,h4;
   unsigned long data[80]; }  SHA_state;
 
-#ifdef __STDC__
 void sha_setup(SHA_state *);
 void sha_store(SHA_state *, unsigned char *, int count);
 void sha_finish(SHA_state *);
-#else
-void sha_setup();
-void sha_store();
-void sha_finish();
-#endif
 
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/shepherd.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/shepherd.h
@@ -23,11 +23,7 @@ typedef enum xkShepType_e xkShepType_t;
  *
  */
 kern_return_t
-#ifdef __STDC__
 shepInit( int count );
-#else
-shepInit();
-#endif __STDC__
 
 /*
  * Invoke a shepherd thread
@@ -45,9 +41,5 @@ shepInit();
  *
  */
 kern_return_t
-#ifdef __STDC__
 xInvokeShepherd(xkShepType_t type, void (*func)( char * ), char *arg  );
-#else
-xInvokeShepherd();
-#endif __STDC__
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/srx.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/srx.h
@@ -19,7 +19,6 @@
 #define srx_h
 
 
-#ifdef __STDC__
 
 /* 
  * Used to notify SRX that a message with ports transferred by SRX has
@@ -33,11 +32,5 @@ void		srxTransferComplete( IPhost , MsgId );
  */
 xkern_return_t	srxMoveSendRights( IPhost h, MsgId id, mnetport **np );
 
-#else
-
-void		srxTransferComplete();
-xkern_return_t	srxMoveSendRights();
-
-#endif __STDC__
 
 #endif  ! srx_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/srx_i.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/srx_i.h
@@ -107,22 +107,12 @@ typedef enum {
 extern	XferHost	srxMyXferHost;
 extern	int		tracesrxp;
 
-#ifdef __STDC__
 
 xkern_return_t	srxLoadReply( SrxRepMsg *, Msg * );
 xkern_return_t	srxLoadRequest( SrxReqMsg *, Msg * );
 void		srxStoreReply( SrxRepMsg *, Msg * );
 void		srxStoreRequest( SrxReqOutgoing *, Msg * );
 
-#else
-
-xkern_return_t	srxLoadReply();
-xkern_return_t	srxLoadRequest();
-void		srxStoreReply();
-void		srxStoreRequest();
-
-
-#endif
 
 
 #endif  ! srx_i_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/sunrpc.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/sunrpc.h
@@ -45,11 +45,9 @@
 #define SUNRPC_GETPORT		(SUNRPC_CTL*MAXOPS+21)
 
 
-#  ifdef __STDC__
 
 void	sunrpc_init( XObj );
 
-#  endif
 
 #endif
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/sunrpc_i.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/sunrpc_i.h
@@ -103,7 +103,6 @@ typedef struct pstate {
 extern int tracesunrpcp;
 extern struct opaque_auth sunrpcAuthDummy;
 
-#ifdef __STDC__
 
 long		sunrpcHdrLoad( void *, char *, long, void * );
 int		sunrpcEncodeHdr( Msg *, SunrpcHdr * );
@@ -119,22 +118,5 @@ xkern_return_t	sunrpcCall( XObj s, Msg *msg, Msg *reply_ptr );
 void		sunrpcGetProcServer( XObj );
 void		sunrpcSendError( int errorCode, XObj lls, int xid, void *arg );
 
-#else
-
-long		sunrpcHdrLoad();
-int		sunrpcEncodeHdr();
-int		sunrpcControlProtl();
-int 		sunrpcControlSessn();
-void		sunrpcAuthFree();
-u_short		sunrpcGetPort();
-xkern_return_t 	sunrpcClientDemux();
-xkern_return_t	sunrpcServerDemux();
-xkern_return_t	sunrpcPop();
-int		sunrpcPush();
-xkern_return_t	sunrpcCall();
-void		sunrpcGetProcServer();
-void		sunrpcSendError();
-
-#endif __STDC__
 
 #endif sunrpc_i_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/tcp.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/tcp.h
@@ -41,11 +41,9 @@
 #define TCP_SETRCVACKALWAYS	(TCP_CTL*MAXOPS + 14)	
 	/* Implicitly does a SETRCVBUFSPACE on each xPop */
 
-#  ifdef __STDC__
 
 void	tcp_init( XObj );
 
-#  endif
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/tcp_internal.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/tcp_internal.h
@@ -251,7 +251,6 @@ typedef struct {
 extern char *tcpstates[];
 extern long	tcpIpProtocolNum;
 
-#if defined(__STDC__) || defined(__GNUC__)
 
 /*
  * in_hacks.c
@@ -341,95 +340,5 @@ int	tcp_reass( struct tcpcb *, struct tcphdr *, XObj, Msg *, Msg * );
 void	tcp_trace(int, int, struct tcpcb *, struct tcpiphdr *, int );
 char *	tcpFlagStr( int );
 
-#else
-
-/*
- * in_hacks.c
- */
-int	in_pcballoc();
-void	in_pcbdisconnect();
-void 	in_pcbdetach();
-bool	in_broadcast();
-u_short	in_cksum();
-
-/*
- * tcp_subr.c
- */
-struct tcpiphdr *	tcp_template();
-struct tcpcb *	tcp_newtcpcb();
-struct tcpcb *	tcp_drop();
-struct tcpcb * 	tcp_destroy();
-void	tcp_notify();
-void	tcp_quench();
-void	tcp_respond();
- 
-/*
- * tcp_hdr.c
- */
-void 	tcpHdrStore();
-void 	tcpOptionsStore();
-long	tcpOptionsLoad();
-long 	tcpHdrLoad();
-
-/*
- * tcp_timer.c
- */
-void	tcp_fasttimo();
-void	tcp_slowtimo();
-void	tcp_canceltimers();
-struct tcpcb *	tcp_timers();
-
-/*
- * tcp_x.c
- */
-void	delete_tcpstate();
-struct tcpstate	*	new_tcpstate();
-void	sorwakeup();
-void	sowwakeup();
-void	soabort();
-void	socantsendmore();
-void	socantrcvmore();
-void	sohasoutofband();
-void	soisdisconnected();
-void	soisdisconnecting();
-void	soisconnected();
-void	soisconnecting();
-int	soreserve();
-XObj	sonewconn();
-void	tcpSemWait();
-void	tcpSemSignal();
-void	tcpSemInit();
-void	tcpVAll();
-
-/* 
- * tcp_output.c
- */
-int	tcp_output();
-void	tcp_setpersist();
-
-/* 
- * tcp_usrreq.c
- */
-int	tcp_attach();
-int	tcp_usrreq();
-struct tcpcb *tcp_disconnect();
-struct tcpcb *tcp_usrclosed();
-
-/* 
- * tcp_input.c
- */
-void	print_reass();
-xkern_return_t	tcp_input();
-int	tcp_mss();
-xkern_return_t	tcpPop();
-int	tcp_reass();
-
-/* 
- * tcp_debug.c
- */
-void	tcp_trace();
-char *	tcpFlagStr();
-
-#endif __STDC__
 
 #include "insque.h"

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/udp.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/udp.h
@@ -22,11 +22,9 @@
 #define UDP_GETFREEPROTNUM	(UDP_CTL * MAXOPS + 2)
 #define UDP_RELEASEPROTNUM	(UDP_CTL * MAXOPS + 3)
 
-#  ifdef __STDC__
 
 void	udp_init( XObj );
 
-#  endif
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/upi.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/upi.h
@@ -42,7 +42,6 @@ typedef	struct xobj {
   int   rcnt;
   int	id;
   int	*traceVar;
-#if __STDC__
   struct xobj *
     (* open)( struct xobj *, struct xobj *, struct xobj *, Part * );
   enum xkret	(* close)( struct xobj * );
@@ -63,24 +62,6 @@ typedef	struct xobj {
   int		(* control)( struct xobj *, int, char *, int );
   enum xkret	(* duplicate)( struct xobj * );
   enum xkret	(* shutdown)( struct xobj * );
-#else
-  Pfo	open;
-  Pfk 	close;
-  Pfk   closedone;
-  Pfk	openenable;
-  Pfk	opendisable;
-  Pfk	opendisableall;
-  Pfk	opendone;
-  Pfk 	demux;
-  Pfk 	calldemux;
-  Pfk 	pop;
-  Pfk 	callpop;
-  Pfh 	push;
-  Pfk 	call;
-  Pfi 	control; 
-  Pfk	duplicate;
-  Pfk	shutdown;
-#endif  
   int 	numdown;
   int	downlistsz;
   unsigned char	idle;
@@ -122,7 +103,6 @@ extern char **globalArgv;
 
 /* protocol and session operations */
 
-#ifdef __STDC__
 
 extern	XObj xOpen( XObj hlpRcv, XObj hlpType, XObj llp, Part *p );
 extern	xkern_return_t
@@ -156,34 +136,9 @@ xkern_return_t	defaultVirtualOpenDisable( XObj, Map, XObj, XObj, XObj *,
 xkern_return_t	defaultVirtualOpenEnable( XObj, Map, XObj, XObj, XObj *,
 					  Part *);
 
-#else
-
-extern	XObj xOpen();
-extern	xkern_return_t  xOpenEnable();
-extern	xkern_return_t  xOpenDisable();
-extern	xkern_return_t  xOpenDone();
-extern	xkern_return_t  xCloseDone();
-extern	xkern_return_t  xClose();
-extern	xkern_return_t  xDemux();
-extern	xkern_return_t  xCallDemux();
-extern	xmsg_handle_t 	xPush();
-extern	xkern_return_t  xCall();
-extern	int  		xControl();
-extern  xkern_return_t  xDuplicate();
-extern  xkern_return_t	xShutDown();
-
-typedef void	(* DisableAllFunc)();
-
-xkern_return_t	defaultOpenDisable();
-xkern_return_t	defaultOpenEnable();
-xkern_return_t	defaultVirtualOpenDisable();
-xkern_return_t	defaultVirtualOpenEnable();
-
-#endif
 
 /* initialization operations */
 
-#ifdef __STDC__
 
 extern	XObj xCreateSessn(Pfv f, XObj hlpRcv, XObj hlpType, XObj llp,
 			  int downc, XObj *downv);
@@ -192,18 +147,9 @@ extern	XObj xCreateProtl(Pfv f, char *nm, char *inst, int *trace,
 extern	xkern_return_t  xDestroy(XObj s);
 extern  void		upiInit( void );
 
-#else
-
-extern XObj 		xCreateSessn();
-extern XObj 		xCreateProtl();
-extern xkern_return_t	xDestroy();
-extern void		upiInit();
-
-#endif
 
 /* utility routines */
 
-#ifdef __STDC__
 
 extern	XObj 	xGetProtlByName(char *name);
 extern  bool	xIsValidXObj( XObj );
@@ -212,16 +158,6 @@ extern	XObj 	xGetDown(XObj self, int i);
 extern	void	xPrintXObj( XObj );
 extern  void	xRapture( void );
 
-#else
-
-extern	XObj 	xGetProtlByName();
-extern  bool	xIsValidXObj();
-extern	xkern_return_t  xSetDown();
-extern	XObj 	xGetDown();
-extern	void	xPrintXObj();
-extern  void	xRapture();
-
-#endif __STDC__
 
 
 /* object macros */
@@ -301,21 +237,12 @@ enum {
 #include "ip_host.h"
 #include "eth_host.h"
 
-#ifdef __STDC__
 
 extern xkern_return_t	str2ipHost( IPhost *, char * );
 extern xkern_return_t	str2ethHost( ETHhost *, char * );
 extern char *	ipHostStr( IPhost * );
 extern char *	ethHostStr( ETHhost * );
 
-#else
-
-extern xkern_return_t	str2ipHost();
-extern xkern_return_t	str2ethHost();
-extern char *	ipHostStr();
-extern char *	ethHostStr();
-
-#endif __STDC__
 
 
 extern XObj	xNullProtl;

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/upi_inline.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/upi_inline.h
@@ -30,17 +30,10 @@
 #else
 #  define FUNC_TYPE xkern_return_t
 
-#  ifdef __STDC__
 
 FUNC_TYPE	xPop( XObj, XObj, Msg *, void * );
 FUNC_TYPE	xCallPop( XObj, XObj, Msg *, void *, Msg * );
 
-#  else 
-
-FUNC_TYPE	xPop();
-FUNC_TYPE	xCallPop();
-
-#  endif __STDC__
 #endif XK_USE_INLINE
 
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/uproxy.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/uproxy.h
@@ -10,7 +10,6 @@
  * $Date: 1993/09/21 00:23:23 $
  */
 
-#ifdef __STDC__
 
 kern_return_t	do_uproxy_abort( PORT_TYPE,
 				PORT_TYPE);
@@ -96,4 +95,3 @@ kern_return_t	do_uproxy_xCall( PORT_TYPE,
 				xk_msg_attr_t,
 				mach_msg_type_number_t );
 
-#endif

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/vcache.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/vcache.h
@@ -13,10 +13,8 @@
 #ifndef vcache_h
 #define vcache_h
    
-#  ifdef __STDC__
 
 void	vcache_init( XObj );
 
-#  endif
 
 #endif  ! vcache_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/vchan.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/vchan.h
@@ -20,10 +20,8 @@
 #define VCHAN_DECCONCURRENCY (VCHAN_CTL*MAXOPS + 1)
 
 
-#  ifdef __STDC__
 
 void	vchan_init( XObj );
 
-#  endif
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/vdisorder.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/vdisorder.h
@@ -13,11 +13,9 @@
 #ifndef vdisorder_h
 #define vdisorder_h
    
-#  ifdef __STDC__
 
 void	vdisorder_init( XObj );
 
-#  endif
 
 #define VDISORDER_CTL	TMP3_CTL
 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/vdrop.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/vdrop.h
@@ -13,11 +13,9 @@
 #ifndef vdrop_h
 #define vdrop_h
    
-#  ifdef __STDC__
 
 void	vdrop_init( XObj );
 
-#  endif
 
 #define VDROP_GETINTERVAL	(VDROP_CTL * MAXOPS + 0)
 #define VDROP_SETINTERVAL	(VDROP_CTL * MAXOPS + 1)

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/vmux.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/vmux.h
@@ -13,10 +13,8 @@
 #ifndef vmux_h
 #define vmux_h
    
-#  ifdef __STDC__
 
 void	vmux_init( XObj );
 
-#  endif
 
 #endif  ! vmux_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/vnet.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/vnet.h
@@ -76,10 +76,8 @@ typedef union {
  */
 
 
-#  ifdef __STDC__
 
 void	vnet_init( XObj );
 
-#  endif
 
 #endif ! vnet_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/vsize.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/vsize.h
@@ -13,10 +13,8 @@
 #ifndef vsize_h
 #define vsize_h
    
-#  ifdef __STDC__
 
 void	vsize_init( XObj );
 
-#  endif
 
 #endif  ! vsize_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/vtap.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/vtap.h
@@ -11,11 +11,9 @@
 #ifndef vtap_h
 #define vtap_h
    
-#  ifdef __STDC__
 
 void	vtap_init( XObj );
 
-#  endif
 #define VTAP_ENABLETAP       (VTAP_CTL * MAXOPS + 0)
 #define VTAP_DISABLETAP      (VTAP_CTL * MAXOPS + 1)
 #define VTAP_PRINTCHARS      (VTAP_CTL * MAXOPS + 2)

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/x_stdio.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/x_stdio.h
@@ -17,7 +17,6 @@
 
 #include <stdio.h>
 
-#ifdef __STDC__
 
 int	fclose( FILE * );
 int	fflush( FILE * );
@@ -27,17 +26,6 @@ int	printf( char *, ... );
 int	sscanf( char *, char *, ... );
 void	setbuf( FILE *, char * );
 
-#else 
-
-int	fclose();
-int	fflush();
-int	fprintf();
-int	fscanf();
-int	printf();
-int	sscanf();
-void	setbuf();
-
-#endif
 
 int	_flsbuf();
 int	_filbuf();

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/x_util.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/x_util.h
@@ -13,26 +13,15 @@
 #ifndef x_util_h
 #define x_util_h
 
-#ifdef __STDC__
 
 extern void	Delay( int );
 extern void	Kabort( char * );
 
-#else
-
-extern void	Delay();
-extern void	Kabort();
-
-#endif __STDC__
 
 /* 
  * non-ANSI compilers gripe about the _n##U usage while GCC gives
  * warning messages about the u_long cast.
  */
-#ifdef __STDC__
 #   define UNSIGNED(_n)	_n##U
-#else
-#   define UNSIGNED(_n)	((u_long)(_n))
-#endif
 
 #endif ! x_util_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/xfer.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/xfer.h
@@ -72,7 +72,6 @@ typedef int	SendCount;
 #define SENDCOUNT_NETLEN	4
 
 
-#ifdef __STDC__
 
 
 /* 
@@ -143,21 +142,5 @@ void		xferTransferMapRemove( Map, IPhost *h, MsgId id );
 char *		xferHostStr( XferHost * );
 
 
-#else
-
-typedef 	void	(* XferRemFunc)();
-typedef 	void	(* LockRemFunc)();
-
-XObj		xferOpen();
-int		xferConfirmBid();
-void		xferCreateMaps();
-char *		xferHostStr();
-void		xferLockedMapAdd();
-void		xferLockedMapRemove();
-void		xferPeerRebooted();
-void		xferTransferMapAdd();
-void		xferTransferMapRemove();
-
-#endif __STDC__
 
 #endif  ! xfer_h

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/xk_debug.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/xk_debug.h
@@ -54,19 +54,11 @@ extern	char errBuf[250];
 #endif
 
 
-#ifdef __STDC__
 
 void	xTraceLock( void );
 void	xTraceUnlock( void );
 void	xTraceInit( void );
 
-#else
-
-void	xTraceLock();
-void	xTraceUnlock();
-void	xTraceInit();
-
-#endif
 
 
 #if defined(XK_DEBUG) || defined(lint)
@@ -74,7 +66,6 @@ void	xTraceInit();
 #define PRETRACE(l) { int __i=l; xTraceLock();  while(__i--) putchar(' '); }
 #define POSTTRACE { putchar('\n'); xTraceUnlock(); }
 
-#ifdef __STDC__
 #define XPASTE(X,Y) X##Y
 #define PASTE(X,Y) XPASTE(X,Y)
 
@@ -129,61 +120,6 @@ void	xTraceInit();
 	    	POSTTRACE;		\
 	    }				\
 	} while (0)
-#else
-#define D___I(X) X
-
-
-#   define xIfTrace(t, l) \
-	if (D___I(trace)t >= l)
-#   define xTrace0(t, l, f) 			\
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f); 			\
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace1(t, l, f, arg1) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-		printf(f, arg1); 		\
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace2(t, l, f, arg1, arg2) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f, arg1, arg2); 		\
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace3(t, l, f, arg1, arg2, arg3) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f, arg1, arg2, arg3); 	\
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace4(t, l, f, arg1, arg2, arg3, arg4) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f, arg1, arg2, arg3, arg4); \
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace5(t, l, f, arg1, arg2, arg3, arg4, arg5) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f, arg1, arg2, arg3, arg4, arg5); \
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#endif /* __STDC__ */
 
 #   define xIfTraceP( _obj, _lev ) \
 	if ( *(_obj)->traceVar >= (_lev) )
@@ -275,9 +211,7 @@ void	xTraceInit();
 #endif	/* XK_DEBUG */
 
 extern void	xError(
-#ifdef __STDC__
 		       char *
-#endif
 		       );
 
 #endif	/* xk_debug_h */

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/xk_mach.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/xk_mach.h
@@ -16,7 +16,6 @@
 
 #include <mach/error.h>
 
-#ifdef __STDC__
 
 #ifndef XKMACHKERNEL
 
@@ -36,7 +35,6 @@ int			cthread_kernel_limit( void );
 void			cthread_set_kernel_limit( int );
 void			cthread_wire( void );
 
-#endif ! XKMACHKERNEL
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/xtime.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/xtime.h
@@ -20,12 +20,10 @@ typedef struct {
   long usec;
 } XTime;
 
-#ifdef __STDC__
 
 /* set *t to the current time of day */
 void xGetTime(XTime *t);
 
-#endif __STDC__
 
 
 /* 

--- a/src-lites-1.1-2025/xkernel/mach4/inkernel/include/xtype.h
+++ b/src-lites-1.1-2025/xkernel/mach4/inkernel/include/xtype.h
@@ -27,11 +27,7 @@ typedef int	xmsg_handle_t;
 #define XMSG_ERR_HANDLE		-1
 #define XMSG_ERR_WOULDBLOCK	-2
 
-#if defined(__STDC__) || defined(__GNUC__)
 #   define VOID		void
-#else
-#   define VOID		char
-#endif
 
 typedef	xkern_return_t (*Pfk) ();
 typedef	int (*Pfi) ();

--- a/src-lites-1.1-2025/xkernel/mach4/user/netipc/test/unxk.h
+++ b/src-lites-1.1-2025/xkernel/mach4/user/netipc/test/unxk.h
@@ -13,12 +13,10 @@ typedef struct {
   long usec;
 } XTime;
 
-#ifdef __STDC__
 
 /* set *t to the current time of day */
 void xGetTime(XTime *t);
 
-#endif __STDC__
 /* end of xtime.h stuff */
 
 /* just hacked together */
@@ -55,19 +53,11 @@ enum { GETMYHOST = 0 };
 /* end of stuff from trace.h */
 
 /* from merge/include/xk_debug.h */
-#ifdef __STDC__
 
 void	xTraceLock( void );
 void	xTraceUnlock( void );
 void	xTraceInit( void );
 
-#else
-
-void	xTraceLock();
-void	xTraceUnlock();
-void	xTraceInit();
-
-#endif
 
 
 #if defined(XK_DEBUG) || defined(lint)
@@ -75,7 +65,6 @@ void	xTraceInit();
 #define PRETRACE(l) { int __i=l; xTraceLock();  while(__i--) putchar(' '); }
 #define POSTTRACE { putchar('\n'); xTraceUnlock(); }
 
-#ifdef __STDC__
 #define XPASTE(X,Y) X##Y
 #define PASTE(X,Y) XPASTE(X,Y)
 
@@ -131,62 +120,6 @@ void	xTraceInit();
 	    }				\
 	} while (0)
 #else
-#define D___I(X) X
-
-
-#   define xIfTrace(t, l) \
-	if (D___I(trace)t >= l)
-#   define xTrace0(t, l, f) 			\
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f); 			\
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace1(t, l, f, arg1) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-		printf(f, arg1); 		\
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace2(t, l, f, arg1, arg2) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f, arg1, arg2); 		\
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace3(t, l, f, arg1, arg2, arg3) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f, arg1, arg2, arg3); 	\
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace4(t, l, f, arg1, arg2, arg3, arg4) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f, arg1, arg2, arg3, arg4); \
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-#   define xTrace5(t, l, f, arg1, arg2, arg3, arg4, arg5) \
-	do {					\
-	    if (D___I(trace)t >= l) { 		\
-	    	PRETRACE(l); 			\
-	    	printf(f, arg1, arg2, arg3, arg4, arg5); \
-	    	POSTTRACE; 			\
-	    }					\
-	} while (0)
-
-#endif /* __STDC__ */
-#else
 
 #   define xIfTrace(t, l) if (0)
 #   define xTrace0(t, l, f)
@@ -199,9 +132,7 @@ void	xTraceInit();
 #endif	/* XK_DEBUG */
 
 extern void	xError(
-#ifdef __STDC__
 		       char *
-#endif
 		       );
 /* end of xk_debug.h stuff */
 

--- a/src-lites-1.1-2025/xkernel/mach4/user/socket/xsi_main.h
+++ b/src-lites-1.1-2025/xkernel/mach4/user/socket/xsi_main.h
@@ -42,13 +42,8 @@ extern int xsi_cid;
 
 #if defined(XK_DEBUG) || defined(lint)
 
-#ifdef __STDC__
 # define XPASTE(X,Y) X##Y
 # define PASTE(X,Y) XPASTE(X,Y)
-#else
-# define XPASTE(X,Y) X/**/Y
-# define PASTE(X,Y) XPASTE(X,Y)
-#endif
 
 #ifdef TRACE_SYSLOG
 

--- a/src-lites-1.1-2025/xkernel/netbsd/include/assert.h
+++ b/src-lites-1.1-2025/xkernel/netbsd/include/assert.h
@@ -15,11 +15,9 @@
 
 #include <stdio.h>
 
-#ifdef __STDC__
 
 #ifndef X_NETBSD
 extern int fprintf(FILE *, char *, ...);
-#endif
 extern void abort(void);
 
 #else

--- a/src-lites-1.1-2025/xkernel/netbsd/include/event_i.h
+++ b/src-lites-1.1-2025/xkernel/netbsd/include/event_i.h
@@ -35,7 +35,6 @@
 
 #ifdef XK_THREAD_TRACE
 
-#  ifdef __STDC__
 
 /* 
  * evMarkBlocked -- mark the current thread as blocked on the given
@@ -51,7 +50,6 @@ void	evMarkBlocked( Semaphore * );
  */
 void	evMarkRunning( void );
 
-#  endif
 
 /* 
  * localEventMap -- contains all x-kernel event structures.  Event
@@ -62,10 +60,8 @@ extern Map	localEventMap;
 
 #endif
 
-#ifdef __STDC__
 
 void	evInit( void );
 
-#endif
 
 #endif

--- a/src-lites-1.1-2025/xkernel/netbsd/include/machine.h
+++ b/src-lites-1.1-2025/xkernel/netbsd/include/machine.h
@@ -13,12 +13,10 @@
 #ifndef machine_h
 #define machine_h
 
-#ifdef __STDC__
 
 void	cancelSignalHandler( int );
 void	init_clock( Pfv, long );
 void	installSignalHandler( int, Pfi, VOID * );
 
-#endif
 
 #endif machine_h

--- a/src-lites-1.1-2025/xkernel/netbsd/include/platform.h
+++ b/src-lites-1.1-2025/xkernel/netbsd/include/platform.h
@@ -32,14 +32,12 @@
 #include "xtype.h"
 
 
-#ifdef __STDC__
 
 u_short ocsum( u_short *buf, int count );
 u_short ocsum_simple( u_short *buf, int count );
 u_short inCkSum( Msg *m, u_short *buf, int len );
 #ifndef X_NETBSD
 int	atoi( char * );
-#endif
 char *	inet_ntoa( struct in_addr );
 
 extern	char *	xMalloc( unsigned );

--- a/src-lites-1.1-2025/xkernel/netbsd/include/process.h
+++ b/src-lites-1.1-2025/xkernel/netbsd/include/process.h
@@ -79,7 +79,6 @@ typedef struct sSemaphore {
 } Semaphore;
 
 
-#ifdef __STDC__
 
 extern void LWP_Init( void );
 
@@ -89,7 +88,6 @@ extern realV( Semaphore * );
 
 #ifdef X_NETBSD
 typedef int mon_t;
-#endif
 
 extern mon_t	master_monitor;
 #define xk_master_lock() 	mon_enter( master_monitor )
@@ -103,7 +101,6 @@ int	CreateProcess4( Pfi, short, int, int, int, int );
 int	CreateProcess5( Pfi, short, int, int, int, int, int );
 int	CreateProcess6( Pfi, short, int, int, int, int, int, int );
 
-#endif __STDC__
 
 #define semWait(S) { if (--(S)->count < 0) realP(S); }
 #define semSignal(S) { if (++(S)->count <= 0) realV(S); }

--- a/src-lites-1.1-2025/xkernel/netbsd/include/x_libc.h
+++ b/src-lites-1.1-2025/xkernel/netbsd/include/x_libc.h
@@ -19,14 +19,12 @@
 
 #include <string.h>
 
-#ifdef __STDC__
 
 #ifndef X_NETBSD
 extern void     bcopy( char *, char *, int );
 extern int	bcmp( char *, char *, int );
 extern void     bzero( char *, int );
 extern int	qsort( char *, int, int, int(*)());
-#endif
 
 extern int	lwp_self();
 
@@ -36,6 +34,5 @@ extern void     bcopy();
 extern int	bcmp();
 extern void     bzero();
 
-#endif  __STDC__
 
 #endif  ! x_libc_h

--- a/src-lites-1.1-2025/xkernel/oddlibs/netdb.h
+++ b/src-lites-1.1-2025/xkernel/oddlibs/netdb.h
@@ -96,29 +96,29 @@ struct	protoent {
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS
-void		endhostent __P((void));
-void		endnetent __P((void));
-void		endprotoent __P((void));
-void		endservent __P((void));
-struct hostent	*gethostbyaddr __P((const char *, int, int));
-struct hostent	*gethostbyname __P((const char *));
-struct hostent	*gethostent __P((void));
-struct netent	*getnetbyaddr __P((long, int)); /* u_long? */
-struct netent	*getnetbyname __P((const char *));
-struct netent	*getnetent __P((void));
-struct protoent	*getprotobyname __P((const char *));
-struct protoent	*getprotobynumber __P((int));
-struct protoent	*getprotoent __P((void));
-struct servent	*getservbyname __P((const char *, const char *));
-struct servent	*getservbyport __P((int, const char *));
-struct servent	*getservent __P((void));
-void		herror __P((const char *));
-char		*hstrerror __P((int));
-void		sethostent __P((int));
-/* void		sethostfile __P((const char *)); */
-void		setnetent __P((int));
-void		setprotoent __P((int));
-void		setservent __P((int));
+void		endhostent (void);
+void		endnetent (void);
+void		endprotoent (void);
+void		endservent (void);
+struct hostent	*gethostbyaddr (const char *, int, int);
+struct hostent	*gethostbyname (const char *);
+struct hostent	*gethostent (void);
+struct netent	*getnetbyaddr (long, int); /* u_long? */
+struct netent	*getnetbyname (const char *);
+struct netent	*getnetent (void);
+struct protoent	*getprotobyname (const char *);
+struct protoent	*getprotobynumber (int);
+struct protoent	*getprotoent (void);
+struct servent	*getservbyname (const char *, const char *);
+struct servent	*getservbyport (int, const char *);
+struct servent	*getservent (void);
+void		herror (const char *);
+char		*hstrerror (int);
+void		sethostent (int);
+/* void		sethostfile (const char *); */
+void		setnetent (int);
+void		setprotoent (int);
+void		setservent (int);
 __END_DECLS
 
 #endif /* !_NETDB_H_ */

--- a/src-lites-1.1-2025/xkernel/oddlibs/netinet/in.h
+++ b/src-lites-1.1-2025/xkernel/oddlibs/netinet/in.h
@@ -235,12 +235,12 @@ struct ip_mreq {
 
 
 #ifdef KERNEL
-int	 in_broadcast __P((struct in_addr, struct ifnet *));
-int	 in_canforward __P((struct in_addr));
-int	 in_cksum __P((struct mbuf *, int));
-int	 in_localaddr __P((struct in_addr));
-u_long	 in_netof __P((struct in_addr));
-void	 in_socktrim __P((struct sockaddr_in *));
+int	 in_broadcast (struct in_addr, struct ifnet *);
+int	 in_canforward (struct in_addr);
+int	 in_cksum (struct mbuf *, int);
+int	 in_localaddr (struct in_addr);
+u_long	 in_netof (struct in_addr);
+void	 in_socktrim (struct sockaddr_in *);
 #endif
 
 #endif /* _NETINET_IN_H_ */

--- a/src-lites-1.1-2025/xkernel/oddlibs/p_defs.h
+++ b/src-lites-1.1-2025/xkernel/oddlibs/p_defs.h
@@ -54,8 +54,7 @@
  * in between its arguments.  __CONCAT can also concatenate double-quoted
  * strings produced by the __STRING macro, but this only works with ANSI C.
  */
-#if defined(__STDC__) || defined(__cplusplus)
-#define	__P(protos)	protos		/* full-blown ANSI C */
+#define __P(protos) protos
 #define	__CONCAT(x,y)	x ## y
 #define	__STRING(x)	#x
 
@@ -64,38 +63,8 @@
 #define	__volatile	volatile
 #if defined(__cplusplus)
 #define	__inline	inline		/* convert to C++ keyword */
-#else
-#ifndef __GNUC__
-#define	__inline			/* delete GCC keyword */
-#endif /* !__GNUC__ */
 #endif /* !__cplusplus */
 
-#else	/* !(__STDC__ || __cplusplus) */
-#define	__P(protos)	()		/* traditional C preprocessor */
-#define	__CONCAT(x,y)	x/**/y
-#define	__STRING(x)	"x"
-
-#ifndef __GNUC__
-#define	__const				/* delete pseudo-ANSI C keywords */
-#define	__inline
-#define	__signed
-#define	__volatile
-/*
- * In non-ANSI C environments, new programs will want ANSI-only C keywords
- * deleted from the program and old programs will want them left alone.
- * When using a compiler other than gcc, programs using the ANSI C keywords
- * const, inline etc. as normal identifiers should define -DNO_ANSI_KEYWORDS.
- * When using "gcc -traditional", we assume that this is the intent; if
- * __GNUC__ is defined but __STDC__ is not, we leave the new keywords alone.
- */
-#ifndef	NO_ANSI_KEYWORDS
-#define	const				/* delete ANSI C keywords */
-#define	inline
-#define	signed
-#define	volatile
-#endif
-#endif	/* !__GNUC__ */
-#endif	/* !(__STDC__ || __cplusplus) */
 
 /*
  * GCC1 and some versions of GCC2 declare dead (non-returning) and

--- a/src-lites-1.1-2025/xkernel/pi/include/x_stdio.h
+++ b/src-lites-1.1-2025/xkernel/pi/include/x_stdio.h
@@ -19,7 +19,6 @@
 
 #ifndef X_NETBSD
 
-#ifdef __STDC__
 
 int	fclose( FILE * );
 int	fflush( FILE * );
@@ -29,17 +28,6 @@ int	printf( char *, ... );
 int	sscanf( char *, char *, ... );
 void	setbuf( FILE *, char * );
 
-#else 
-
-int	fclose();
-int	fflush();
-int	fprintf();
-int	fscanf();
-int	printf();
-int	sscanf();
-void	setbuf();
-
-#endif
 #endif NETBSD
 int	_flsbuf();
 int	_filbuf();

--- a/src-lites-1.1-2025/xkernel/pi/prottbl_i.h
+++ b/src-lites-1.1-2025/xkernel/pi/prottbl_i.h
@@ -41,7 +41,6 @@ typedef struct {
 
 
 
-#ifdef __STDC__
 
 /* 
  * protTblAddProt -- Create an entry in the protocol map binding 'name'
@@ -82,7 +81,6 @@ void		protTblInitMaps( void );
 char *	protIdToStr( long );
 
 
-#endif __STDC__
 
 
 #endif !prottbl_i_h

--- a/src-lites-1.1-2025/xkernel/protocols/arp/arp_i.h
+++ b/src-lites-1.1-2025/xkernel/protocols/arp/arp_i.h
@@ -73,21 +73,12 @@ typedef struct ARPprotlstate {
 } PSTATE;
 
 
-#ifdef __STDC__
 
 void		arpPlatformInit( XObj );
 void		arpSendRequest( ArpWait * );
 void		newArpWait( ArpWait *, XObj, IPhost *, ArpStatus * );
 void		newRarpWait( ArpWait *, XObj, ETHhost *, ArpStatus * );
 
-#else
-
-void		arpPlatformInit();
-void		arpSendRequest();
-void		newArpWait();
-void		newRarpWait();
-
-#endif
 
 
 extern int	tracearpp;

--- a/src-lites-1.1-2025/xkernel/protocols/arp/arp_table.h
+++ b/src-lites-1.1-2025/xkernel/protocols/arp/arp_table.h
@@ -18,9 +18,7 @@ typedef struct arpent	*ArpTbl;
  * Returns 0 if the lookup was successful and -1 if it was not.
  */
 int	arpLookup(
-#ifdef __STDC__
 		  XObj, IPhost *, ETHhost *
-#endif
 		  );
 
 /*
@@ -29,9 +27,7 @@ int	arpLookup(
  * Returns 0 if the lookup was successful and -1 if it was not.
  */
 int	arpRevLookup(
-#ifdef __STDC__
 		     XObj, IPhost *, ETHhost *
-#endif
 		     );
 
 /*
@@ -40,18 +36,14 @@ int	arpRevLookup(
  * Returns 0 if the lookup was successful and -1 if it was not.
  */
 int	arpRevLookupTable(
-#ifdef __STDC__
 			  XObj, IPhost *, ETHhost *
-#endif
 			  );
 
 /*
  * Initialize the arp table.
  */
 ArpTbl	arpTableInit(
-#ifdef __STDC__
 		     void
-#endif
 		     );
 
 /*
@@ -62,9 +54,7 @@ ArpTbl	arpTableInit(
  * the address could not be resolved
  */
 void 	arpSaveBinding(
-#ifdef __STDC__
 		       ArpTbl, IPhost *ip, ETHhost *eth
-#endif
 		       );
 
 
@@ -75,9 +65,7 @@ void 	arpSaveBinding(
  */
 void
 arpTblPurge(
-#ifdef __STDC__
 	    ArpTbl, IPhost *
-#endif
 	    );
 
 
@@ -86,9 +74,7 @@ arpTblPurge(
  * remains in the cache.
  */
 void	arpLock(
-#ifdef __STDC__
 		ArpTbl, IPhost *h
-#endif
 		);
 
 
@@ -98,7 +84,5 @@ void	arpLock(
  */
 void
 arpForEach( 
-#ifdef __STDC__
     ArpTbl, ArpForEach *
-#endif
 	   );

--- a/src-lites-1.1-2025/xkernel/protocols/bidctl/bidctl_i.h
+++ b/src-lites-1.1-2025/xkernel/protocols/bidctl/bidctl_i.h
@@ -115,7 +115,6 @@ extern int	tracebidctlp;
 #define BIDCTL_BCAST_QUERY_DELAY	3 * 1000	/* 3 seconds */
 
 
-#ifdef __STDC__
 
 void	bidctlBcastBoot( XObj );
 xkern_return_t	bidctlDestroy( BidctlState * );
@@ -134,24 +133,5 @@ void	bidctlTimer( Event, VOID * );
 void	bidctlTimeout( Event, VOID * );
 void	bidctlTransition( BidctlState *, BidctlHdr * );
 
-#else
-
-void	bidctlBcastBoot();
-xkern_return_t	bidctlDestroy();
-void	bidctlDispState();
-char *	bidctlFsmStr();
-void	bidctlHdrDump();
-void	bidctlHdrStore();
-BootId	bidctlNewId();
-void	bidctlOutput();
-void	bidctlReleaseWaiters();
-BootId	bidctlReqTag();
-void	bidctlSemWait();
-void	bidctlStartQuery();
-void	bidctlTimer();
-void	bidctlTimeout();
-void	bidctlTransition();
-
-#endif
 
 #endif  ! bootid_i_h

--- a/src-lites-1.1-2025/xkernel/protocols/blast/blast_internal.h
+++ b/src-lites-1.1-2025/xkernel/protocols/blast/blast_internal.h
@@ -126,7 +126,6 @@ typedef int PassiveID;
 extern BlastMask	blastFullMask[];
 extern int 		traceblastp;
 
-#ifdef __STDC__
 
 xmsg_handle_t	blastPush( XObj, Msg * );
 int		blastControlSessn( XObj, int, char *, int );
@@ -151,33 +150,7 @@ void	blastShowMstate( MSG_STATE *m, char *message );
 char *	blastShowMask( BLAST_MASK_PROTOTYPE );
 
 
-#else
 
-xmsg_handle_t	blastPush();
-int		blastControlSessn();
-int		blastControlProtl();
-void		blastDecIrc();
-xkern_return_t	blastPop();
-xkern_return_t	blastDemux();
-XObj		blastCreateSessn();
-void		blast_mapFlush();
-int		blast_freeSendSeq();
-int		blast_Retransmit();
-long		blastHdrLoad();
-void		blastHdrStore();
-MSG_STATE *	blastNewMstate();
-xkern_return_t	blastSenderPop();
-int		blast_mask_to_i();
-
-#ifdef XK_DEBUG
-void	blast_phdr();
-char *	blastOpStr();
-void	blastShowActiveKey();
-void	blastShowMstate();
-char *	blastShowMask();
-#endif XK_DEBUG
-
-#endif __STDC__
 
 #endif
 

--- a/src-lites-1.1-2025/xkernel/protocols/blast/blast_mask32.h
+++ b/src-lites-1.1-2025/xkernel/protocols/blast/blast_mask32.h
@@ -21,11 +21,7 @@
  * non-ANSI compilers gripe about the _n##U usage while GCC gives
  * warning messages about the u_long cast.
  */
-#ifdef __STDC__
 #   define UNSIGNED(_n)	_n##U
-#else
-#   define UNSIGNED(_n)	((u_long)(_n))
-#endif
 
 typedef u_long	BlastMask;
 #define BLAST_MASK_PROTOTYPE	BlastMask

--- a/src-lites-1.1-2025/xkernel/protocols/blast/blast_mask64.h
+++ b/src-lites-1.1-2025/xkernel/protocols/blast/blast_mask64.h
@@ -29,11 +29,7 @@ typedef struct {
  * non-ANSI compilers gripe about the _n##U usage while GCC gives
  * warning messages about the u_long cast.
  */
-#ifdef __STDC__
 #   define UNSIGNED(_n)	_n##U
-#else
-#   define UNSIGNED(_n)	((u_long)(_n))
-#endif
 
 #define BLAST_MAX_FRAGS	64
 #define BLAST_FULL_MASK(_m, _n)				\
@@ -86,12 +82,10 @@ extern int	abs();
 #      define FUNCTYPE	static 
 #  endif /* GNUC */
 
-#  ifdef __STDC__
 
 FUNCTYPE int	BLAST_MASK_IS_BIT_SET( BlastMask *, int );
 FUNCTYPE void	BLAST_MASK_SET_BIT( BlastMask *, int );
 
-#  endif __STDC__
 
 FUNCTYPE int
 BLAST_MASK_IS_BIT_SET( m, n )

--- a/src-lites-1.1-2025/xkernel/protocols/blast/blast_stack.h
+++ b/src-lites-1.1-2025/xkernel/protocols/blast/blast_stack.h
@@ -18,18 +18,9 @@ typedef struct stack {
 } *Stack;
 
 
-#ifdef __STDC__
 
 Stack	stackCreate( int size );
 VOID *	stackPop( Stack );
 int	stackPush( Stack, VOID *);
 void	stackDestroy( Stack );
 
-#else 
-
-Stack	stackCreate();
-VOID * 	stackPop();
-int	stackPush();
-void	stackDestroy();
-
-#endif

--- a/src-lites-1.1-2025/xkernel/protocols/chan/chan_internal.h
+++ b/src-lites-1.1-2025/xkernel/protocols/chan/chan_internal.h
@@ -146,12 +146,9 @@ typedef unsigned int PassiveID;
 
 
 typedef		int	(* MapChainForEachFun)(
-#ifdef __STDC__
 					       VOID *, VOID *
-#endif					       
 					       );
 
-#ifdef __STDC__
 
 typedef		XObj (ChanOpenFunc)( XObj, XObj, XObj, ActiveID *, int );
 
@@ -194,48 +191,6 @@ void		chanMapChainAddObject( VOID *, Map, IPhost *, long, int );
 int		chanMapChainApply( Map, IPhost *, MapChainForEachFun );
 Map		chanMapChainFollow( Map, IPhost *, long );
 
-#else
-
-typedef		XObj (ChanOpenFunc)();
-
-xkern_return_t	chanAddIdleSessn();
-xkern_return_t	chanBidctlRegister();
-int		chanCheckMsgLen();
-SEQ_STAT 	chanCheckSeq();
-void		chanClientIdleRespond();
-void		chanClientPeerRebooted();
-int		chanControlSessn();
-XObj 		chanCreateSessn();
-void		chanDestroy();
-void		chanDispKey();
-void		chanEventFlush();
-void		chanFreeResources();
-Map 		chanGetChanMap();
-Map 		chanGetMap();
-long		chanGetProtNum();
-void		chanHdrStore();
-void		chanInternalClose();
-int		chanMapRemove();
-xkern_return_t 	chanOpenEnable();
-xkern_return_t 	chanOpenDisable();
-xkern_return_t 	chanOpenDisableAll();
-void		chanRemoveActive();
-int		chanRemoveIdleSessns();
-xmsg_handle_t	chanReply();
-xmsg_handle_t	chanResend();
-char * 		chanStateStr();
-void		chanServerPeerRebooted();
-XObj		chanOpen();
-char * 		chanStatusStr();
-XObj		chanSvcOpen();
-void		chanTimeout();
-void 		pChanHdr();
-
-void		chanMapChainAddObject();
-int		chanMapChainApply();
-Map		chanMapChainFollow();
-
-#endif
 
 
 extern	int	tracechanp;

--- a/src-lites-1.1-2025/xkernel/protocols/eth/eth_i.h
+++ b/src-lites-1.1-2025/xkernel/protocols/eth/eth_i.h
@@ -56,36 +56,20 @@ typedef struct {
  */
 extern ETHhost ethBcastHost;
 
-#ifdef __STDC__
 
 void	ethCtlrInit( ETHhost host );
 void	getLocalEthHost( ETHhost *host );
 int	SetPromiscuous( void );
 void	ethCtlrXmit( Msg *msg, ETHhost *dst, int type );
 
-#else
-
-void	ethCtlrInit();
-void	getLocalEthHost();
-int	SetPromiscuous();
-void	ethCtlrXmit();
-
-#endif
 
 /*
  * Interface presented to driver from protocol
  */
 
-#ifdef __STDC__
 
 xkern_return_t	eth_demux( Msg, int, ETHhost, ETHhost );
 void		ethSendUp( Msg *, ETHhost *, int );
 
-#else
-
-xkern_return_t	eth_demux();
-void		ethSendUp();
-
-#endif
 
 #endif  ! eth_i_h

--- a/src-lites-1.1-2025/xkernel/protocols/icmp/icmp_internal.h
+++ b/src-lites-1.1-2025/xkernel/protocols/icmp/icmp_internal.h
@@ -88,7 +88,6 @@ typedef struct {
 } mapId;
 
 
-#ifdef __STDC__
 
 int 	icmpSendEchoReq(XObj s, int msgLength);
 void 	icmpPopEchoRep(XObj p, Msg *m);
@@ -96,15 +95,6 @@ void 	icmpHdrStore(void *hdr, char *netHdr, long len, void *);
 void 	icmpEchoStore(void *hdr, char *netHdr, long len, void *);
 long 	icmpEchoLoad(void *hdr, char *netHdr, long len, void *);
 
-#else
-
-int 	icmpSendEchoReq();
-void 	icmpPopEchoRep();
-void 	icmpHdrStore();
-void 	icmpEchoStore();
-long 	icmpEchoLoad();
-
-#endif
 
 
 extern int traceicmpp;

--- a/src-lites-1.1-2025/xkernel/protocols/ip/ip_i.h
+++ b/src-lites-1.1-2025/xkernel/protocols/ip/ip_i.h
@@ -157,7 +157,6 @@ typedef struct FragList {
 #define ERR_FRAG ((Fragtable *)-1)
 
 
-#ifdef __STDC__
 
 int		ipControlProtl( XObj, int, char *, int );
 int		ipControlSessn( XObj, int, char *, int );
@@ -184,31 +183,6 @@ xmsg_handle_t	ipSend( XObj s, XObj lls, Msg *msg, IPheader *hdr );
 xkern_return_t	ipStdPop( XObj, XObj, Msg *, VOID * );
 void		scheduleIpFragCollector( PState * );
 
-#else
-
-int		ipControlProtl();
-int		ipControlSessn();
-XObj		ipCreatePassiveSessn();
-xkern_return_t	ipDemux();
-Enable *	ipFindEnable();
-xkern_return_t 	ipForwardPop();
-void		ipFreeFragList();
-void		ipFreeFragtable();
-xkern_return_t 	ipFwdBcastPop();
-int		ipGetHdr();
-void		ipHdrStore();
-int		ipIsMyAddr();
-xkern_return_t	ipMsgComplete();
-void		ipProcessRomFile();
-xkern_return_t	ipReassemble();
-int		ipRemoteNet();
-void		ipRouteChanged();
-int		ipSameNet();
-xmsg_handle_t	ipSend();
-xkern_return_t	ipStdPop();
-void		scheduleIpFragCollector();
-
-#endif
 
 extern int 	traceipp;
 extern IPhost	ipSiteGateway;

--- a/src-lites-1.1-2025/xkernel/protocols/ip/route.h
+++ b/src-lites-1.1-2025/xkernel/protocols/ip/route.h
@@ -42,7 +42,6 @@ typedef struct {
 
 #include "ip_i.h"
 
-#ifdef __STDC__
 
 /* 
  * Initialize the routing tables and set the default router to be the
@@ -56,14 +55,5 @@ xkern_return_t	rt_add_def( PState *, IPhost * );
 xkern_return_t	rt_get( RouteTable *, IPhost *, route * );
 void		rt_delete( RouteTable *, IPhost *, IPhost * );
 
-#else
-
-xkern_return_t 	rt_init();
-xkern_return_t 	rt_add();
-xkern_return_t	rt_add_def();
-xkern_return_t	rt_get();
-void		rt_delete();
-
-#endif __STDC__
 
 #endif  ! route_h

--- a/src-lites-1.1-2025/xkernel/protocols/machnetipc/rrx.h
+++ b/src-lites-1.1-2025/xkernel/protocols/machnetipc/rrx.h
@@ -20,7 +20,6 @@
 #ifndef rrx_h
 #define rrx_h
 
-#ifdef __STDC__
 
 void		rrx_init( XObj );
 
@@ -38,13 +37,5 @@ xkern_return_t	rrxMoveReceiveRights( IPhost h, MsgId id, mnetport **np );
 void		rrxTransferComplete( IPhost , MsgId );
 
 
-#else
-
-void		rrx_init();
-xkern_return_t	rrxMoveReceiveRights();
-void		rrxTransferComplete();
-
-
-#endif __STDC__
 
 #endif  ! rrx_h

--- a/src-lites-1.1-2025/xkernel/protocols/machnetipc/rrx_i.h
+++ b/src-lites-1.1-2025/xkernel/protocols/machnetipc/rrx_i.h
@@ -124,7 +124,6 @@ typedef struct {
 
 
 
-#ifdef __STDC__
 
 
 long		rrxLoadReply( VOID *, char *, long, VOID * );
@@ -139,21 +138,6 @@ void		rrxStoreRequest( RrxReqOutgoing *, Msg * );
  */
 void		rrxReqDispose( RrxReqMsg * );
 
-#else
-
-long		rrxLoadReply();
-void		rrxStoreReply();
-xkern_return_t	rrxLoadRequest();
-void		rrxStoreRequest();
-
-/* 
- * Headers loaded with rrxLoadRequest include dynamically allocated
- * storage.  rrxReqDispose should be called for each of these
- * headers. 
- */
-void		rrxReqDispose();
-
-#endif
 
 
 #endif  ! rrx_i_h

--- a/src-lites-1.1-2025/xkernel/protocols/machnetipc/srx.h
+++ b/src-lites-1.1-2025/xkernel/protocols/machnetipc/srx.h
@@ -19,7 +19,6 @@
 #define srx_h
 
 
-#ifdef __STDC__
 
 /* 
  * Used to notify SRX that a message with ports transferred by SRX has
@@ -33,11 +32,5 @@ void		srxTransferComplete( IPhost , MsgId );
  */
 xkern_return_t	srxMoveSendRights( IPhost h, MsgId id, mnetport **np );
 
-#else
-
-void		srxTransferComplete();
-xkern_return_t	srxMoveSendRights();
-
-#endif __STDC__
 
 #endif  ! srx_h

--- a/src-lites-1.1-2025/xkernel/protocols/machnetipc/srx_i.h
+++ b/src-lites-1.1-2025/xkernel/protocols/machnetipc/srx_i.h
@@ -107,22 +107,12 @@ typedef enum {
 extern	XferHost	srxMyXferHost;
 extern	int		tracesrxp;
 
-#ifdef __STDC__
 
 xkern_return_t	srxLoadReply( SrxRepMsg *, Msg * );
 xkern_return_t	srxLoadRequest( SrxReqMsg *, Msg * );
 void		srxStoreReply( SrxRepMsg *, Msg * );
 void		srxStoreRequest( SrxReqOutgoing *, Msg * );
 
-#else
-
-xkern_return_t	srxLoadReply();
-xkern_return_t	srxLoadRequest();
-void		srxStoreReply();
-void		srxStoreRequest();
-
-
-#endif
 
 
 #endif  ! srx_i_h

--- a/src-lites-1.1-2025/xkernel/protocols/machnetipc/xfer.h
+++ b/src-lites-1.1-2025/xkernel/protocols/machnetipc/xfer.h
@@ -72,7 +72,6 @@ typedef int	SendCount;
 #define SENDCOUNT_NETLEN	4
 
 
-#ifdef __STDC__
 
 
 /* 
@@ -143,21 +142,5 @@ void		xferTransferMapRemove( Map, IPhost *h, MsgId id );
 char *		xferHostStr( XferHost * );
 
 
-#else
-
-typedef 	void	(* XferRemFunc)();
-typedef 	void	(* LockRemFunc)();
-
-XObj		xferOpen();
-int		xferConfirmBid();
-void		xferCreateMaps();
-char *		xferHostStr();
-void		xferLockedMapAdd();
-void		xferLockedMapRemove();
-void		xferPeerRebooted();
-void		xferTransferMapAdd();
-void		xferTransferMapRemove();
-
-#endif __STDC__
 
 #endif  ! xfer_h

--- a/src-lites-1.1-2025/xkernel/protocols/rat/rat.h
+++ b/src-lites-1.1-2025/xkernel/protocols/rat/rat.h
@@ -9,11 +9,9 @@
 #include "ip.h"
 #endif
 
-#  ifdef __STDC__
 
 void    rat_init( XObj );
 
-#  endif
 
 
 #endif

--- a/src-lites-1.1-2025/xkernel/protocols/select/select_i.h
+++ b/src-lites-1.1-2025/xkernel/protocols/select/select_i.h
@@ -41,7 +41,6 @@ typedef long PassiveKey;
 
 extern int	traceselectp;
 
-#ifdef __STDC__
 
 void		selectCommonInit( XObj );
 XObj		selectCommonOpen( XObj, XObj, XObj, Part *, long );
@@ -52,18 +51,6 @@ int		selectCommonControlSessn( XObj, int, char *, int );
 xkern_return_t	selectCallDemux( XObj, XObj, Msg *, Msg * );
 xkern_return_t	selectDemux( XObj, XObj, Msg * );
 
-#else
-
-void		selectCommonInit();
-XObj		selectCommonOpen();
-xkern_return_t	selectCommonOpenDisable();
-xkern_return_t 	selectCommonOpenEnable();
-int		selectControlProtl();
-int		selectCommonControlSessn();
-xkern_return_t	selectDemux();
-xkern_return_t	selectCallDemux();
-
-#endif __STDC__
 
 
 #endif	! select_i_h

--- a/src-lites-1.1-2025/xkernel/protocols/sunrpc/sunrpc_i.h
+++ b/src-lites-1.1-2025/xkernel/protocols/sunrpc/sunrpc_i.h
@@ -103,7 +103,6 @@ typedef struct pstate {
 extern int tracesunrpcp;
 extern struct opaque_auth sunrpcAuthDummy;
 
-#ifdef __STDC__
 
 long		sunrpcHdrLoad( void *, char *, long, void * );
 int		sunrpcEncodeHdr( Msg *, SunrpcHdr * );
@@ -119,22 +118,5 @@ xkern_return_t	sunrpcCall( XObj s, Msg *msg, Msg *reply_ptr );
 void		sunrpcGetProcServer( XObj );
 void		sunrpcSendError( int errorCode, XObj lls, int xid, void *arg );
 
-#else
-
-long		sunrpcHdrLoad();
-int		sunrpcEncodeHdr();
-int		sunrpcControlProtl();
-int 		sunrpcControlSessn();
-void		sunrpcAuthFree();
-u_short		sunrpcGetPort();
-xkern_return_t 	sunrpcClientDemux();
-xkern_return_t	sunrpcServerDemux();
-xkern_return_t	sunrpcPop();
-int		sunrpcPush();
-xkern_return_t	sunrpcCall();
-void		sunrpcGetProcServer();
-void		sunrpcSendError();
-
-#endif __STDC__
 
 #endif sunrpc_i_h

--- a/src-lites-1.1-2025/xkernel/protocols/tcp-tahoe/sb.h
+++ b/src-lites-1.1-2025/xkernel/protocols/tcp-tahoe/sb.h
@@ -46,7 +46,6 @@ extern struct sb_i *sbifreelist;
 #define sbinew(s) { if ((s) = sbifreelist) sbifreelist = (s)->next; else (s) = (struct sb_i *)xMalloc(sizeof(struct sb_i)); }
 #define sbifree(s) { (s)->next = sbifreelist; sbifreelist = (s); }
 
-#ifdef __STDC__
 
 extern void	sbappend( struct sb *, Msg * );
 extern void 	sbcollect( struct sb *, Msg *, int off, int len, int delete );
@@ -54,14 +53,5 @@ extern void 	sbflush( struct sb * );
 extern void 	sbdrop( struct sb * , int len );
 extern void 	sbdelete( struct sb * );
 
-#else
-
-extern void	sbappend();
-extern void 	sbcollect();
-extern void 	sbflush();
-extern void 	sbdrop();
-extern void 	sbdelete();
-
-#endif __STDC__
 
 #endif

--- a/src-lites-1.1-2025/xkernel/protocols/tcp-tahoe/tcp_internal.h
+++ b/src-lites-1.1-2025/xkernel/protocols/tcp-tahoe/tcp_internal.h
@@ -251,7 +251,6 @@ typedef struct {
 extern char *tcpstates[];
 extern long	tcpIpProtocolNum;
 
-#if defined(__STDC__) || defined(__GNUC__)
 
 /*
  * in_hacks.c
@@ -341,95 +340,5 @@ int	tcp_reass( struct tcpcb *, struct tcphdr *, XObj, Msg *, Msg * );
 void	tcp_trace(int, int, struct tcpcb *, struct tcpiphdr *, int );
 char *	tcpFlagStr( int );
 
-#else
-
-/*
- * in_hacks.c
- */
-int	in_pcballoc();
-void	in_pcbdisconnect();
-void 	in_pcbdetach();
-bool	in_broadcast();
-u_short	in_cksum();
-
-/*
- * tcp_subr.c
- */
-struct tcpiphdr *	tcp_template();
-struct tcpcb *	tcp_newtcpcb();
-struct tcpcb *	tcp_drop();
-struct tcpcb * 	tcp_destroy();
-void	tcp_notify();
-void	tcp_quench();
-void	tcp_respond();
- 
-/*
- * tcp_hdr.c
- */
-void 	tcpHdrStore();
-void 	tcpOptionsStore();
-long	tcpOptionsLoad();
-long 	tcpHdrLoad();
-
-/*
- * tcp_timer.c
- */
-void	tcp_fasttimo();
-void	tcp_slowtimo();
-void	tcp_canceltimers();
-struct tcpcb *	tcp_timers();
-
-/*
- * tcp_x.c
- */
-void	delete_tcpstate();
-struct tcpstate	*	new_tcpstate();
-void	sorwakeup();
-void	sowwakeup();
-void	soabort();
-void	socantsendmore();
-void	socantrcvmore();
-void	sohasoutofband();
-void	soisdisconnected();
-void	soisdisconnecting();
-void	soisconnected();
-void	soisconnecting();
-int	soreserve();
-XObj	sonewconn();
-void	tcpSemWait();
-void	tcpSemSignal();
-void	tcpSemInit();
-void	tcpVAll();
-
-/* 
- * tcp_output.c
- */
-int	tcp_output();
-void	tcp_setpersist();
-
-/* 
- * tcp_usrreq.c
- */
-int	tcp_attach();
-int	tcp_usrreq();
-struct tcpcb *tcp_disconnect();
-struct tcpcb *tcp_usrclosed();
-
-/* 
- * tcp_input.c
- */
-void	print_reass();
-xkern_return_t	tcp_input();
-int	tcp_mss();
-xkern_return_t	tcpPop();
-int	tcp_reass();
-
-/* 
- * tcp_debug.c
- */
-void	tcp_trace();
-char *	tcpFlagStr();
-
-#endif __STDC__
 
 #include "insque.h"

--- a/src-lites-1.1-2025/xkernel/protocols/tcp/sb.h
+++ b/src-lites-1.1-2025/xkernel/protocols/tcp/sb.h
@@ -46,7 +46,6 @@ extern struct sb_i *sbifreelist;
 #define sbinew(s) { if ((s) = sbifreelist) sbifreelist = (s)->next; else (s) = (struct sb_i *)xMalloc(sizeof(struct sb_i)); }
 #define sbifree(s) { (s)->next = sbifreelist; sbifreelist = (s); }
 
-#ifdef __STDC__
 
 extern void	sbappend( struct sb *, Msg * );
 extern void 	sbcollect( struct sb *, Msg *, int off, int len, int delete );
@@ -54,14 +53,5 @@ extern void 	sbflush( struct sb * );
 extern void 	sbdrop( struct sb * , int len );
 extern void 	sbdelete( struct sb * );
 
-#else
-
-extern void	sbappend();
-extern void 	sbcollect();
-extern void 	sbflush();
-extern void 	sbdrop();
-extern void 	sbdelete();
-
-#endif __STDC__
 
 #endif

--- a/src-lites-1.1-2025/xkernel/protocols/tcp/tcp_internal.h
+++ b/src-lites-1.1-2025/xkernel/protocols/tcp/tcp_internal.h
@@ -261,7 +261,6 @@ typedef struct {
 
 extern char *tcpstates[];
 
-#if defined(__STDC__) || defined(__GNUC__)
 
 /*
  * in_hacks.c
@@ -351,95 +350,5 @@ int	tcp_reass( struct tcpcb *, struct tcphdr *, XObj, Msg *, Msg * );
 void	tcp_trace(int, int, struct tcpcb *, struct tcpiphdr *, int );
 char *	tcpFlagStr( int );
 
-#else
-
-/*
- * in_hacks.c
- */
-int	in_pcballoc();
-void	in_pcbdisconnect();
-void 	in_pcbdetach();
-bool	in_broadcast();
-u_short	in_cksum();
-
-/*
- * tcp_subr.c
- */
-struct tcpiphdr *	tcp_template();
-struct tcpcb *	tcp_newtcpcb();
-struct tcpcb *	tcp_drop();
-struct tcpcb * 	tcp_destroy();
-void	tcp_notify();
-void	tcp_quench();
-void	tcp_respond();
- 
-/*
- * tcp_hdr.c
- */
-void 	tcpHdrStore();
-void 	tcpOptionsStore();
-long	tcpOptionsLoad();
-long 	tcpHdrLoad();
-
-/*
- * tcp_timer.c
- */
-void	tcp_fasttimo();
-void	tcp_slowtimo();
-void	tcp_canceltimers();
-struct tcpcb *	tcp_timers();
-
-/*
- * tcp_x.c
- */
-void	delete_tcpstate();
-struct tcpstate	*	new_tcpstate();
-void	sorwakeup();
-void	sowwakeup();
-void	soabort();
-void	socantsendmore();
-void	socantrcvmore();
-void	sohasoutofband();
-void	soisdisconnected();
-void	soisdisconnecting();
-void	soisconnected();
-void	soisconnecting();
-int	soreserve();
-XObj	sonewconn();
-void	tcpSemWait();
-void	tcpSemSignal();
-void	tcpSemInit();
-void	tcpVAll();
-
-/* 
- * tcp_output.c
- */
-int	tcp_output();
-void	tcp_setpersist();
-
-/* 
- * tcp_usrreq.c
- */
-int	tcp_attach();
-int	tcp_usrreq();
-struct tcpcb *tcp_disconnect();
-struct tcpcb *tcp_usrclosed();
-
-/* 
- * tcp_input.c
- */
-void	print_reass();
-xkern_return_t	tcp_input();
-int	tcp_mss();
-xkern_return_t	tcpPop();
-int	tcp_reass();
-
-/* 
- * tcp_debug.c
- */
-void	tcp_trace();
-char *	tcpFlagStr();
-
-#endif __STDC__
 
 #include "insque.h"

--- a/src-lites-1.1-2025/xkernel/protocols/util/port_mgr.h
+++ b/src-lites-1.1-2025/xkernel/protocols/util/port_mgr.h
@@ -18,7 +18,6 @@
  */
 
 
-#ifdef __STDC__
 #define XPASTE(X,Y) X##Y
 #define PASTE(X,Y) XPASTE(X,Y)
 
@@ -51,4 +50,3 @@ int	PASTE(NAME, DuplicatePort) ( void *, long );
  */
 void	PASTE(NAME, ReleasePort) ( void *, long );
 
-#endif

--- a/src-lites-1.1-2025/xkernel/sunos/include/assert.h
+++ b/src-lites-1.1-2025/xkernel/sunos/include/assert.h
@@ -15,17 +15,10 @@
 
 #include <stdio.h>
 
-#ifdef __STDC__
 
 extern int fprintf(FILE *, char *, ...);
 extern void abort(void);
 
-#else
-
-extern int fprintf();
-extern void abort();
-
-#endif
 
 #define PRINT(A,B,C) fprintf(stderr, (A), (B), (C))
 #define assertMessage "Assertion failed: file %s, line %d\n"

--- a/src-lites-1.1-2025/xkernel/sunos/include/event_i.h
+++ b/src-lites-1.1-2025/xkernel/sunos/include/event_i.h
@@ -35,7 +35,6 @@
 
 #ifdef XK_THREAD_TRACE
 
-#  ifdef __STDC__
 
 /* 
  * evMarkBlocked -- mark the current thread as blocked on the given
@@ -51,7 +50,6 @@ void	evMarkBlocked( Semaphore * );
  */
 void	evMarkRunning( void );
 
-#  endif
 
 /* 
  * localEventMap -- contains all x-kernel event structures.  Event
@@ -62,10 +60,8 @@ extern Map	localEventMap;
 
 #endif
 
-#ifdef __STDC__
 
 void	evInit( void );
 
-#endif
 
 #endif

--- a/src-lites-1.1-2025/xkernel/sunos/include/machine.h
+++ b/src-lites-1.1-2025/xkernel/sunos/include/machine.h
@@ -13,12 +13,10 @@
 #ifndef machine_h
 #define machine_h
 
-#ifdef __STDC__
 
 void	cancelSignalHandler( int );
 void	init_clock( Pfv, long );
 void	installSignalHandler( int, Pfi, VOID * );
 
-#endif
 
 #endif machine_h

--- a/src-lites-1.1-2025/xkernel/sunos/include/platform.h
+++ b/src-lites-1.1-2025/xkernel/sunos/include/platform.h
@@ -32,7 +32,6 @@
 #include "xtype.h"
 
 
-#ifdef __STDC__
 
 u_short ocsum( u_short *buf, int count );
 u_short ocsum_simple( u_short *buf, int count );
@@ -44,13 +43,6 @@ extern	char *	xMalloc( unsigned );
 extern	void	xFree( char * );
 extern	void	xMallocInit( void );
 
-#else
-
-extern	char *	xMalloc( );
-extern	void	xFree();
-extern	void	xMallocInit();
-
-#endif
 
 
 typedef long *Unspec;

--- a/src-lites-1.1-2025/xkernel/sunos/include/process.h
+++ b/src-lites-1.1-2025/xkernel/sunos/include/process.h
@@ -77,7 +77,6 @@ typedef struct sSemaphore {
 } Semaphore;
 
 
-#ifdef __STDC__
 
 extern void LWP_Init( void );
 
@@ -97,7 +96,6 @@ int	CreateProcess4( Pfi, short, int, int, int, int );
 int	CreateProcess5( Pfi, short, int, int, int, int, int );
 int	CreateProcess6( Pfi, short, int, int, int, int, int, int );
 
-#endif __STDC__
 
 #define semWait(S) { if (--(S)->count < 0) realP(S); }
 #define semSignal(S) { if (++(S)->count <= 0) realV(S); }

--- a/src-lites-1.1-2025/xkernel/sunos/include/x_libc.h
+++ b/src-lites-1.1-2025/xkernel/sunos/include/x_libc.h
@@ -19,7 +19,6 @@
 
 #include <string.h>
 
-#ifdef __STDC__
 
 extern void     bcopy( char *, char *, int );
 extern int	bcmp( char *, char *, int );
@@ -28,12 +27,5 @@ extern int	qsort( char *, int, int, int(*)());
 
 extern int	lwp_self();
 
-#else
-
-extern void     bcopy();
-extern int	bcmp();
-extern void     bzero();
-
-#endif  __STDC__
 
 #endif  ! x_libc_h

--- a/src-lites-1.1-2025/xkernel/util/compose/compose_intelx86.h
+++ b/src-lites-1.1-2025/xkernel/util/compose/compose_intelx86.h
@@ -18,7 +18,6 @@
 #define DIRENT direct
 #include <sys/stat.h>
 
-#ifdef __STDC__
 
 int	unlink( char * );
 int	access( char *, int );
@@ -35,4 +34,3 @@ void	exit( int );
 int	fclose( FILE * );
 int	fprintf( FILE *, char *, ... );
 
-#endif __STDC__

--- a/src-lites-1.1-2025/xkernel/util/compose/compose_mips.h
+++ b/src-lites-1.1-2025/xkernel/util/compose/compose_mips.h
@@ -18,7 +18,6 @@
 #include <sys/stat.h>
 #include <sys/file.h>
 
-#ifdef __STDC__
 
 int	unlink( char * );
 int	access( char *, int );
@@ -35,4 +34,3 @@ void	exit( int );
 int	fclose( FILE * );
 int	fprintf( FILE *, char *, ... );
 
-#endif __STDC__

--- a/src-lites-1.1-2025/xkernel/util/compose/compose_sparc.h
+++ b/src-lites-1.1-2025/xkernel/util/compose/compose_sparc.h
@@ -18,7 +18,6 @@
 #define DIRENT direct
 #include <sys/stat.h>
 
-#ifdef __STDC__
 
 int 	lstat( char *path, struct stat *buf );
 char	toupper( char );
@@ -36,5 +35,4 @@ void	exit( int );
 int	fclose( FILE * );
 int	fprintf( FILE *, char *, ... );
 
-#endif __STDC__
 

--- a/src-lites-1.1-2025/xkernel/util/compose/global.h
+++ b/src-lites-1.1-2025/xkernel/util/compose/global.h
@@ -48,7 +48,6 @@ typedef struct protocol {
 extern int	fileLine;
 extern int	filePosition;
 
-#ifdef __STDC__
 
 void	addInstance( PROTOCOL * );
 void	addProtTbl( char *name );
@@ -71,6 +70,5 @@ void	warnDefaultPtblNotSupported( void );
 void	warnProtNotFound( char * );
 void	warnReassignedTraceValue( char * );
 
-#endif __STDC__
 
 #include ARCH_INCLUDE

--- a/src-lites-1.1-2025/xkernel/util/make/gmake-3.66/getopt.h
+++ b/src-lites-1.1-2025/xkernel/util/make/gmake-3.66/getopt.h
@@ -76,11 +76,7 @@ extern int optopt;
 
 struct option
 {
-#if	__STDC__
   const char *name;
-#else
-  char *name;
-#endif
   /* has_arg can't be an enum because some compilers complain about
      type mismatches in all the code that assumes it is an int.  */
   int has_arg;
@@ -94,15 +90,11 @@ struct option
 #define required_argument	1
 #define optional_argument	2
 
-#if __STDC__
 #if defined(__GNU_LIBRARY__)
 /* Many other libraries have conflicting prototypes for getopt, with
    differences in the consts, in stdlib.h.  To avoid compilation
    errors, only prototype getopt for the GNU C library.  */
 extern int getopt (int argc, char *const *argv, const char *shortopts);
-#else /* not __GNU_LIBRARY__ */
-extern int getopt ();
-#endif /* not __GNU_LIBRARY__ */
 extern int getopt_long (int argc, char *const *argv, const char *shortopts,
 		        const struct option *longopts, int *longind);
 extern int getopt_long_only (int argc, char *const *argv,
@@ -114,13 +106,6 @@ extern int _getopt_internal (int argc, char *const *argv,
 			     const char *shortopts,
 		             const struct option *longopts, int *longind,
 			     int long_only);
-#else /* not __STDC__ */
-extern int getopt ();
-extern int getopt_long ();
-extern int getopt_long_only ();
-
-extern int _getopt_internal ();
-#endif /* not __STDC__ */
 
 #ifdef	__cplusplus
 }

--- a/src-lites-1.1-2025/xkernel/util/make/gmake-3.66/glob/fnmatch.h
+++ b/src-lites-1.1-2025/xkernel/util/make/gmake-3.66/glob/fnmatch.h
@@ -23,16 +23,8 @@ Cambridge, MA 02139, USA.  */
 extern "C" {
 #endif
 
-#if defined (__cplusplus) || (defined (__STDC__) && __STDC__)
 #undef	__P
 #define	__P(args)	args
-#else /* Not C++ or ANSI C.  */
-#undef	__P
-#define	__P(args)	()
-/* We can get away without defining `const' here only because in this file
-   it is used only inside the prototype for `fnmatch', which is elided in
-   non-ANSI C where `const' is problematical.  */
-#endif /* C++ or ANSI C.  */
 
 /* Bits set in the FLAGS argument to `fnmatch'.  */
 #define	FNM_PATHNAME	(1 << 0) /* No wildcard can ever match `/'.  */
@@ -51,7 +43,7 @@ extern "C" {
 /* Match STRING against the filename pattern PATTERN,
    returning zero if it matches, FNM_NOMATCH if not.  */
 extern int fnmatch __P ((const char *__pattern, const char *__string,
-			 int __flags));
+			 int __flags);
 
 #ifdef	__cplusplus
 }

--- a/src-lites-1.1-2025/xkernel/util/make/gmake-3.66/glob/glob.h
+++ b/src-lites-1.1-2025/xkernel/util/make/gmake-3.66/glob/glob.h
@@ -25,17 +25,9 @@ extern "C"
 #endif
 
 #undef	__ptr_t
-#if defined (__cplusplus) || (defined (__STDC__) && __STDC__)
 #undef	__P
 #define	__P(args)	args
 #define	__ptr_t	void *
-#else /* Not C++ or ANSI C.  */
-#undef	__P
-#define	__P(args)	()
-#undef	const
-#define	const
-#define	__ptr_t	char *
-#endif /* C++ or ANSI C.  */
 
 /* Bits set in the FLAGS argument to `glob'.  */
 #define	GLOB_ERR	(1 << 0)/* Return on read errors.  */
@@ -76,18 +68,18 @@ typedef struct
    If memory cannot be allocated for PGLOB, GLOB_NOSPACE is returned.
    Otherwise, `glob' returns zero.  */
 extern int glob __P ((const char *__pattern, int __flags,
-		      int (*__errfunc) __P ((const char *, int)),
-		      glob_t *__pglob));
+		      int (*__errfunc) __P ((const char *, int),
+		      glob_t *__pglob);
 
 /* Free storage allocated in PGLOB by a previous `glob' call.  */
-extern void globfree __P ((glob_t *__pglob));
+extern void globfree __P ((glob_t *__pglob);
 
 
 #if !defined (_POSIX_C_SOURCE) || _POSIX_C_SOURCE < 2 || defined (_GNU_SOURCE)
 /* If they are not NULL, `glob' uses these functions to read directories.  */
-extern __ptr_t (*__glob_opendir_hook) __P ((const char *__directory));
-extern const char *(*__glob_readdir_hook) __P ((__ptr_t __stream));
-extern void (*__glob_closedir_hook) __P ((__ptr_t __stream));
+extern __ptr_t (*__glob_opendir_hook) __P ((const char *__directory);
+extern const char *(*__glob_readdir_hook) __P ((__ptr_t __stream);
+extern void (*__glob_closedir_hook) __P ((__ptr_t __stream);
 #endif
 
 #ifdef	__cplusplus

--- a/src-lites-1.1-2025/xkernel/util/make/gmake-3.66/signame.h
+++ b/src-lites-1.1-2025/xkernel/util/make/gmake-3.66/signame.h
@@ -15,7 +15,6 @@ You should have received a copy of the GNU General Public License
 along with this program; see the file COPYING.  If not, write to
 the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.  */
 
-#if defined (__STDC__) && __STDC__
 
 /* Initialize `sys_siglist'.  */
 void signame_init (void);
@@ -35,7 +34,6 @@ int sig_number (const char *abbrev);
 /* Print to standard error the name of SIGNAL, preceded by MESSAGE and
    a colon, and followed by a newline.  */
 void psignal (int signal, const char *message);
-#endif
 
 #if !defined (HAVE_SYS_SIGLIST)
 /* Names for signals from 0 to NSIG-1.  */


### PR DESCRIPTION
## Summary
- drop `__STDC__` checks from all headers
- expand legacy `__P()` macros
- leave headers compiling under `-std=c23`

## Testing
- `make -f Makefile.new test` *(fails: Mach headers not found)*