### PR TITLE
Switch header guards to pragma once

### DIFF
--- a/include/audit.h
+++ b/include/audit.h
@@ -1,5 +1,4 @@
-#ifndef LITES_AUDIT_H
-#define LITES_AUDIT_H
+#pragma once
 
 #include <stdint.h>
 
@@ -15,4 +14,3 @@ extern audit_entry_t audit_log[AUDIT_LOG_SIZE];
 
 void audit_record(uint32_t op, uint64_t obj, int result);
 
-#endif /* LITES_AUDIT_H */

--- a/include/auth.h
+++ b/include/auth.h
@@ -1,5 +1,4 @@
-#ifndef LITES_AUTH_H
-#define LITES_AUTH_H
+#pragma once
 
 #include <stdint.h>
 #include "../src-lites-1.1-2025/include/cap.h"
@@ -18,4 +17,3 @@ int authorize(const cap_t *subject, uint32_t op, uint64_t obj);
 #define CAP_OP_REFINE 1
 #define CAP_OP_REVOKE 2
 
-#endif /* LITES_AUTH_H */

--- a/src-lites-1.1-2025/include/alpha/ansi.h
+++ b/src-lites-1.1-2025/include/alpha/ansi.h
@@ -35,8 +35,7 @@
 /*
  * Converted to alpha by Jukka Virtanen <jtv@hut.fi>
  */
-#ifndef	_ANSI_H_
-#define	_ANSI_H_
+#pragma once
 
 /*
  * Types which are fundamental to the implementation and may appear in
@@ -71,4 +70,3 @@
 #define	_BSD_WCHAR_T_	int			/* wchar_t */
 #define	_BSD_RUNE_T_	int			/* rune_t */
 
-#endif	/* _ANSI_H_ */

--- a/src-lites-1.1-2025/include/alpha/cpu.h
+++ b/src-lites-1.1-2025/include/alpha/cpu.h
@@ -39,8 +39,7 @@
 /* Cleaned up for Lites  -- jvh 5/94 */
 /* Polished up for Lites -- jtv 2/95 */
 
-#ifndef _CPU_H_
-#define _CPU_H_
+#pragma once
 
 /*
  * CTL_MACHDEP definitions.
@@ -53,4 +52,3 @@
 	{ "console_device", CTLTYPE_STRUCT }, \
 }
 
-#endif /* _CPU_H_ */

--- a/src-lites-1.1-2025/include/alpha/endian.h
+++ b/src-lites-1.1-2025/include/alpha/endian.h
@@ -35,8 +35,7 @@
 
 /* Modified for the Alpha AXP by Jukka Virtanen <jtv@hut.fi> 1995 */
 
-#ifndef _ENDIAN_H_
-#define	_ENDIAN_H_
+#pragma once
 
 /*
  * Define _NOQUAD if the compiler does NOT support 64-bit integers.
@@ -76,4 +75,3 @@ __END_DECLS
 #define	HTONL(x)	(x) = htonl((u_int)x)
 #define	HTONS(x)	(x) = htons((u_short)x)
 
-#endif /* !_ENDIAN_H_ */

--- a/src-lites-1.1-2025/include/alpha/param.h
+++ b/src-lites-1.1-2025/include/alpha/param.h
@@ -54,8 +54,7 @@
  * Machine dependent constants for Alpha AXP.
  */
 
-#ifndef _ALPHA_PARAM_H_
-#define _ALPHA_PARAM_H_
+#pragma once
 
 #define	MACHINE	"alpha"
 
@@ -173,4 +172,3 @@
 
 #define PAGE_SIZE ALPHA_PGBYTES
 
-#endif /* _ALPHA_PARAM_H_ */

--- a/src-lites-1.1-2025/include/alpha/signal.h
+++ b/src-lites-1.1-2025/include/alpha/signal.h
@@ -18,8 +18,7 @@
 /*
  * Machine-dependent signal definitions
  */
-#ifndef _ALPHA__SIGNAL_H_
-#define _ALPHA_SIGNAL_H_
+#pragma once
 
 struct  sigcontext {
   	integer_t sc_onstack;
@@ -90,4 +89,3 @@ struct  sigcontext {
 /* Stack must be allocated in 16 byte multiplies == rouding */
 #define	SC_ALLOC	(((SC_SIZE+6*8)+0xff) &~(0xff))
 
-#endif /* _ALPHA_SIGNAL_H_ */

--- a/src-lites-1.1-2025/include/alpha/types.h
+++ b/src-lites-1.1-2025/include/alpha/types.h
@@ -38,8 +38,7 @@
 /*
  * Modified for Alpha AXP by Jukka Virtanen <jtv@hut.fi> 1995
  */
-#ifndef	_MACHTYPES_H_
-#define	_MACHTYPES_H_
+#pragma once
 
 #include <mach/alpha/vm_types.h>
 
@@ -56,4 +55,3 @@ typedef	unsigned int		u_int32_t;
 typedef	long			  int64_t;
 typedef	unsigned long		u_int64_t;
 
-#endif	/* _MACHTYPES_H_ */

--- a/src-lites-1.1-2025/include/alpha/va-alpha.h
+++ b/src-lites-1.1-2025/include/alpha/va-alpha.h
@@ -7,14 +7,12 @@
 
 /* Define __gnuc_va_list.  */
 
-#ifndef __GNUC_VA_LIST
-#define __GNUC_VA_LIST
+#pragma once
 
 typedef struct {
   char *__base;			/* Pointer to first integer register. */
   long __offset;		/* Byte offset of args so far. */
 } __gnuc_va_list;
-#endif /* not __GNUC_VA_LIST */
 
 /* If this is for internal libc use, don't define anything but
    __gnuc_va_list.  */

--- a/src-lites-1.1-2025/include/alpha/vmparam.h
+++ b/src-lites-1.1-2025/include/alpha/vmparam.h
@@ -68,8 +68,7 @@
  * 
  */ 
 
-#ifndef	_ALPHA_VMPARAM_H_
-#define	_ALPHA_VMPARAM_H_
+#pragma once
 
 /*
  * Machine dependent constants for ALPHA
@@ -266,4 +265,3 @@
 #define VM_MIN_ADDRESS	((vm_offset_t) 0x0)
 #define VM_MAX_ADDRESS	((vm_offset_t) 0x000003fe00000000)
 
-#endif	_ALPHA_VMPARAM_H_

--- a/src-lites-1.1-2025/include/c23_arch.h
+++ b/src-lites-1.1-2025/include/c23_arch.h
@@ -1,5 +1,4 @@
-#ifndef LITES_C23_ARCH_H
-#define LITES_C23_ARCH_H
+#pragma once
 
 #if defined(__x86_64__) || defined(_M_X64)
 #  define LITES_ARCH_X86_64 1
@@ -12,4 +11,3 @@
 static_assert(sizeof(void*) == 8 || sizeof(void*) == 4,
               "Pointer size must be 32 or 64 bits");
 
-#endif /* LITES_C23_ARCH_H */

--- a/src-lites-1.1-2025/include/cap.h
+++ b/src-lites-1.1-2025/include/cap.h
@@ -1,5 +1,4 @@
-#ifndef _CAP_H_
-#define _CAP_H_
+#pragma once
 
 /*
  * Basic capability descriptor.  Capabilities form a tree where each child
@@ -26,4 +25,3 @@ struct cap *cap_refine(struct cap *parent, unsigned long rights, unsigned int fl
 void revoke_capability(struct cap *cap);
 int cap_check(const struct cap *cap);
 
-#endif /* _CAP_H_ */

--- a/src-lites-1.1-2025/include/diagnostic.h
+++ b/src-lites-1.1-2025/include/diagnostic.h
@@ -1,4 +1,2 @@
-#ifndef _DIAGNOSTIC_H_
-#define _DIAGNOSTIC_H_
+#pragma once
 #define DIAGNOSTIC 0
-#endif

--- a/src-lites-1.1-2025/include/dirent.h
+++ b/src-lites-1.1-2025/include/dirent.h
@@ -33,8 +33,7 @@
  *	@(#)dirent.h	8.1 (Berkeley) 6/8/93
  */
 
-#ifndef _DIRENT_H_
-#define _DIRENT_H_
+#pragma once
 
 /*
  * The kernel defines the format of directory entries returned by 
@@ -91,4 +90,3 @@ __END_DECLS
 
 #endif /* !KERNEL */
 
-#endif /* !_DIRENT_H_ */

--- a/src-lites-1.1-2025/include/enclave.h
+++ b/src-lites-1.1-2025/include/enclave.h
@@ -1,7 +1,5 @@
-#ifndef ENCLAVE_H
-#define ENCLAVE_H
+#pragma once
 
 int enclave_create(const char *name);
 int enclave_attest(int handle);
 
-#endif /* ENCLAVE_H */

--- a/src-lites-1.1-2025/include/eon.h
+++ b/src-lites-1.1-2025/include/eon.h
@@ -1,4 +1,2 @@
-#ifndef _EON_H_
-#define _EON_H_
+#pragma once
 #include <netiso/eonvar.h>
-#endif

--- a/src-lites-1.1-2025/include/gateway.h
+++ b/src-lites-1.1-2025/include/gateway.h
@@ -1,4 +1,2 @@
-#ifndef _GATEWAY_H_
-#define _GATEWAY_H_
+#pragma once
 /* Stub gateway header */
-#endif

--- a/src-lites-1.1-2025/include/i386/ansi.h
+++ b/src-lites-1.1-2025/include/i386/ansi.h
@@ -33,8 +33,7 @@
  *	@(#)ansi.h	8.2 (Berkeley) 1/4/94
  */
 
-#ifndef	_ANSI_H_
-#define	_ANSI_H_
+#pragma once
 
 /*
  * Types which are fundamental to the implementation and may appear in
@@ -69,4 +68,3 @@
 #define	_BSD_WCHAR_T_	int			/* wchar_t */
 #define	_BSD_RUNE_T_	int			/* rune_t */
 
-#endif	/* _ANSI_H_ */

--- a/src-lites-1.1-2025/include/i386/asm.h
+++ b/src-lites-1.1-2025/include/i386/asm.h
@@ -1,5 +1,4 @@
-#ifndef _I386_ASM_H_
-#define _I386_ASM_H_
+#pragma once
 
 /* Generic assembly macros modelled after the 4.4BSD i386 header. */
 
@@ -18,4 +17,3 @@
 /* System call instruction */
 #define SVC             int $0x80
 
-#endif /* _I386_ASM_H_ */

--- a/src-lites-1.1-2025/include/i386/endian.h
+++ b/src-lites-1.1-2025/include/i386/endian.h
@@ -33,8 +33,7 @@
  *	@(#)endian.h	8.1 (Berkeley) 6/11/93
  */
 
-#ifndef _ENDIAN_H_
-#define	_ENDIAN_H_
+#pragma once
 
 /*
  * Define _NOQUAD if the compiler does NOT support 64-bit integers.
@@ -89,4 +88,3 @@ __END_DECLS
 #define	HTONS(x)	(x) = htons((u_short)x)
 #endif
 #endif /* ! _POSIX_SOURCE */
-#endif /* !_ENDIAN_H_ */

--- a/src-lites-1.1-2025/include/i386/param.h
+++ b/src-lites-1.1-2025/include/i386/param.h
@@ -40,8 +40,7 @@
  * Machine dependent constants for Intel 386.
  */
 
-#ifndef _I386_PARAM_H_
-#define _I386_PARAM_H_
+#pragma once
 
 #define MACHINE "i386"
 
@@ -177,4 +176,3 @@
 #define PAGE_SIZE 4096
 #endif
 
-#endif /* _I386_PARAM_H_ */

--- a/src-lites-1.1-2025/include/i386/stdarg.h
+++ b/src-lites-1.1-2025/include/i386/stdarg.h
@@ -33,8 +33,7 @@
  *	@(#)stdarg.h	8.1 (Berkeley) 6/10/93
  */
 
-#ifndef _STDARG_H_
-#define	_STDARG_H_
+#pragma once
 
 typedef char *va_list;
 
@@ -55,4 +54,3 @@ typedef char *va_list;
 
 #define	va_end(ap)
 
-#endif /* !_STDARG_H_ */

--- a/src-lites-1.1-2025/include/i386/svr4_machdep.h
+++ b/src-lites-1.1-2025/include/i386/svr4_machdep.h
@@ -29,8 +29,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _I386_SVR4_MACHDEP_H_
-#define _I386_SVR4_MACHDEP_H_
+#pragma once
 
 #include <compat/svr4/svr4_types.h>
 
@@ -123,4 +122,3 @@ struct svr4_ssd {
 
 void svr4_syscall_intern(struct proc *);
 
-#endif /* !_I386_SVR4_MACHDEP_H_ */

--- a/src-lites-1.1-2025/include/i386/types.h
+++ b/src-lites-1.1-2025/include/i386/types.h
@@ -33,8 +33,7 @@
  *	@(#)types.h	8.3 (Berkeley) 1/5/94
  */
 
-#ifndef	_MACHTYPES_H_
-#define	_MACHTYPES_H_
+#pragma once
 
 #include <mach/machine/vm_types.h>
 
@@ -61,4 +60,3 @@ typedef	unsigned int		u_int32_t;
 typedef	long long		  int64_t;
 typedef	unsigned long long	u_int64_t;
 
-#endif	/* _MACHTYPES_H_ */

--- a/src-lites-1.1-2025/include/i386/varargs.h
+++ b/src-lites-1.1-2025/include/i386/varargs.h
@@ -38,8 +38,7 @@
  *	@(#)varargs.h	8.2 (Berkeley) 3/22/94
  */
 
-#ifndef _VARARGS_H_
-#define	_VARARGS_H_
+#pragma once
 
 typedef char *va_list;
 
@@ -59,4 +58,3 @@ typedef char *va_list;
 
 #define	va_end(ap)
 
-#endif /* !_VARARGS_H_ */

--- a/src-lites-1.1-2025/include/i386/vmparam.h
+++ b/src-lites-1.1-2025/include/i386/vmparam.h
@@ -36,8 +36,7 @@
  *	@(#)vmparam.h	8.2 (Berkeley) 4/22/94
  */
 
-#ifndef _I386_BSD_VMPARAM_H_
-#define _I386_BSD_VMPARAM_H_
+#pragma once
 /*
  * Machine dependent constants for 386.
  */
@@ -202,4 +201,3 @@
 #define VM_KMEM_SIZE		(NKMEMCLUSTERS*CLBYTES)
 #define VM_PHYS_SIZE		(USRIOSIZE*CLBYTES)
 
-#endif /* _I386_BSD_VMPARAM_H_ */

--- a/src-lites-1.1-2025/include/inet.h
+++ b/src-lites-1.1-2025/include/inet.h
@@ -1,4 +1,2 @@
-#ifndef _INET_H_
-#define _INET_H_
+#pragma once
 /* Basic network stubs */
-#endif

--- a/src-lites-1.1-2025/include/keystore.h
+++ b/src-lites-1.1-2025/include/keystore.h
@@ -1,5 +1,4 @@
-#ifndef KEYSTORE_H
-#define KEYSTORE_H
+#pragma once
 
 #include <stddef.h>
 
@@ -9,4 +8,3 @@ int ks_encrypt(const char *key_path, const unsigned char *in, size_t in_len, uns
 int ks_decrypt(const char *key_path, const unsigned char *in, size_t in_len, unsigned char *out,
                size_t *out_len);
 
-#endif /* KEYSTORE_H */

--- a/src-lites-1.1-2025/include/llc.h
+++ b/src-lites-1.1-2025/include/llc.h
@@ -1,4 +1,2 @@
-#ifndef _LLC_H_
-#define _LLC_H_
+#pragma once
 /* Stub LLC header */
-#endif

--- a/src-lites-1.1-2025/include/mach/cthread_internals.h
+++ b/src-lites-1.1-2025/include/mach/cthread_internals.h
@@ -1,5 +1,4 @@
-#ifndef MACH_CTHREAD_INTERNALS_H
-#define MACH_CTHREAD_INTERNALS_H
+#pragma once
 /*
  * Mach Operating System
  * Copyright (c) 1992,1991,1990,1989 Carnegie Mellon University
@@ -206,7 +205,6 @@ extern void cproc_prepare(cproc_t _child, natural_t *_child_context,
                           vm_offset_t _stackp);
 extern void cproc_setup(cproc_t _child, thread_t _mach_thread,
                         void (*_routine)(cproc_t));
-#endif /* MACH_CTHREAD_INTERNALS_H */
 
 #define yield()		\
 	(void) thread_switch(MACH_PORT_NULL, SWITCH_OPTION_DEPRESS, 10)

--- a/src-lites-1.1-2025/include/mach/options.h
+++ b/src-lites-1.1-2025/include/mach/options.h
@@ -1,5 +1,4 @@
-#ifndef MACH_OPTIONS_H
-#define MACH_OPTIONS_H
+#pragma once
 /*
  * Mach Operating System
  * Copyright (c) 1991,1990,1989 Carnegie Mellon University
@@ -95,4 +94,3 @@
 #define WAIT_DEBUG
 #define CTHREAD_SIGNAL
 
-#endif /* MACH_OPTIONS_H */

--- a/src-lites-1.1-2025/include/mips/ansi.h
+++ b/src-lites-1.1-2025/include/mips/ansi.h
@@ -33,8 +33,7 @@
  *	@(#)ansi.h	8.2 (Berkeley) 1/4/94
  */
 
-#ifndef	_ANSI_H_
-#define	_ANSI_H_
+#pragma once
 
 /*
  * Types which are fundamental to the implementation and may appear in
@@ -69,4 +68,3 @@
 #define	_BSD_WCHAR_T_	int			/* wchar_t */
 #define	_BSD_RUNE_T_	int			/* rune_t */
 
-#endif	/* _ANSI_H_ */

--- a/src-lites-1.1-2025/include/mips/cpu.h
+++ b/src-lites-1.1-2025/include/mips/cpu.h
@@ -38,8 +38,7 @@
 
 /* Cleaned up for LITES -- jvh 11/94 */
 
-#ifndef _CPU_H_
-#define _CPU_H_
+#pragma once
 
 /*
  * Exported definitions unique to pmax/mips cpu support.
@@ -94,4 +93,3 @@ union cpuprid {
 #define	MIPS_R6010	0x04
 #define	MIPS_R4010	0x05
 
-#endif /* _CPU_H_ */

--- a/src-lites-1.1-2025/include/mips/endian.h
+++ b/src-lites-1.1-2025/include/mips/endian.h
@@ -33,8 +33,7 @@
  *	@(#)endian.h	8.1 (Berkeley) 6/11/93
  */
 
-#ifndef _ENDIAN_H_
-#define	_ENDIAN_H_
+#pragma once
 
 /*
  * Define _NOQUAD if the compiler does NOT support 64-bit integers.
@@ -89,4 +88,3 @@ __END_DECLS
 #define	HTONS(x)	(x) = htons((u_short)x)
 #endif
 #endif /* ! _POSIX_SOURCE */
-#endif /* !_ENDIAN_H_ */

--- a/src-lites-1.1-2025/include/mips/stdarg.h
+++ b/src-lites-1.1-2025/include/mips/stdarg.h
@@ -33,8 +33,7 @@
  *	@(#)stdarg.h	8.1 (Berkeley) 6/10/93
  */
 
-#ifndef _STDARG_H_
-#define	_STDARG_H_
+#pragma once
 
 typedef char *va_list;
 
@@ -57,4 +56,3 @@ typedef char *va_list;
 
 #define	va_end(ap)
 
-#endif /* !_STDARG_H_ */

--- a/src-lites-1.1-2025/include/mips/types.h
+++ b/src-lites-1.1-2025/include/mips/types.h
@@ -33,8 +33,7 @@
  *	@(#)types.h	8.3 (Berkeley) 1/5/94
  */
 
-#ifndef	_MACHTYPES_H_
-#define	_MACHTYPES_H_
+#pragma once
 
 #include <mach/machine/vm_types.h>
 
@@ -61,4 +60,3 @@ typedef	unsigned int		u_int32_t;
 typedef	long long		  int64_t;
 typedef	unsigned long long	u_int64_t;
 
-#endif	/* _MACHTYPES_H_ */

--- a/src-lites-1.1-2025/include/mrouting.h
+++ b/src-lites-1.1-2025/include/mrouting.h
@@ -1,4 +1,2 @@
-#ifndef _MROUTING_H_
-#define _MROUTING_H_
+#pragma once
 /* Stub multicast routing header */
-#endif

--- a/src-lites-1.1-2025/include/ns532/ansi.h
+++ b/src-lites-1.1-2025/include/ns532/ansi.h
@@ -33,8 +33,7 @@
  *	@(#)ansi.h	8.2 (Berkeley) 1/4/94
  */
 
-#ifndef	_ANSI_H_
-#define	_ANSI_H_
+#pragma once
 
 /*
  * Types which are fundamental to the implementation and may appear in
@@ -69,4 +68,3 @@
 #define	_BSD_WCHAR_T_	int			/* wchar_t */
 #define	_BSD_RUNE_T_	int			/* rune_t */
 
-#endif	/* _ANSI_H_ */

--- a/src-lites-1.1-2025/include/ns532/endian.h
+++ b/src-lites-1.1-2025/include/ns532/endian.h
@@ -33,8 +33,7 @@
  *	@(#)endian.h	8.1 (Berkeley) 6/11/93
  */
 
-#ifndef _ENDIAN_H_
-#define	_ENDIAN_H_
+#pragma once
 
 /*
  * Define _NOQUAD if the compiler does NOT support 64-bit integers.
@@ -89,4 +88,3 @@ __END_DECLS
 #define	HTONS(x)	(x) = htons((u_short)x)
 #endif
 #endif /* ! _POSIX_SOURCE */
-#endif /* !_ENDIAN_H_ */

--- a/src-lites-1.1-2025/include/ns532/stdarg.h
+++ b/src-lites-1.1-2025/include/ns532/stdarg.h
@@ -33,8 +33,7 @@
  *	@(#)stdarg.h	8.1 (Berkeley) 6/10/93
  */
 
-#ifndef _STDARG_H_
-#define	_STDARG_H_
+#pragma once
 
 typedef char *va_list;
 
@@ -55,4 +54,3 @@ typedef char *va_list;
 
 #define	va_end(ap)
 
-#endif /* !_STDARG_H_ */

--- a/src-lites-1.1-2025/include/ns532/types.h
+++ b/src-lites-1.1-2025/include/ns532/types.h
@@ -33,8 +33,7 @@
  *	@(#)types.h	8.3 (Berkeley) 1/5/94
  */
 
-#ifndef	_MACHTYPES_H_
-#define	_MACHTYPES_H_
+#pragma once
 
 #include <mach/machine/vm_types.h>
 
@@ -61,4 +60,3 @@ typedef	unsigned int		u_int32_t;
 typedef	long long		  int64_t;
 typedef	unsigned long long	u_int64_t;
 
-#endif	/* _MACHTYPES_H_ */

--- a/src-lites-1.1-2025/include/ns532/varargs.h
+++ b/src-lites-1.1-2025/include/ns532/varargs.h
@@ -38,8 +38,7 @@
  *	@(#)varargs.h	8.2 (Berkeley) 3/22/94
  */
 
-#ifndef _VARARGS_H_
-#define	_VARARGS_H_
+#pragma once
 
 typedef char *va_list;
 
@@ -59,4 +58,3 @@ typedef char *va_list;
 
 #define	va_end(ap)
 
-#endif /* !_VARARGS_H_ */

--- a/src-lites-1.1-2025/include/ns532/vmparam.h
+++ b/src-lites-1.1-2025/include/ns532/vmparam.h
@@ -36,8 +36,7 @@
  *	@(#)vmparam.h	8.2 (Berkeley) 4/22/94
  */
 
-#ifndef _NS532_BSD_VMPARAM_H_
-#define _NS532_BSD_VMPARAM_H_
+#pragma once
 /*
  * Machine dependent constants for 532.
  */
@@ -202,4 +201,3 @@
 #define VM_KMEM_SIZE		(NKMEMCLUSTERS*CLBYTES)
 #define VM_PHYS_SIZE		(USRIOSIZE*CLBYTES)
 
-#endif /* _NS532_BSD_VMPARAM_H_ */

--- a/src-lites-1.1-2025/include/parisc/ansi.h
+++ b/src-lites-1.1-2025/include/parisc/ansi.h
@@ -33,8 +33,7 @@
  *	@(#)ansi.h	8.2 (Berkeley) 1/4/94
  */
 
-#ifndef	_ANSI_H_
-#define	_ANSI_H_
+#pragma once
 
 /*
  * Types which are fundamental to the implementation and may appear in
@@ -69,4 +68,3 @@
 #define	_BSD_WCHAR_T_	int			/* wchar_t */
 #define	_BSD_RUNE_T_	int			/* rune_t */
 
-#endif	/* _ANSI_H_ */

--- a/src-lites-1.1-2025/include/parisc/endian.h
+++ b/src-lites-1.1-2025/include/parisc/endian.h
@@ -33,8 +33,7 @@
  *	@(#)endian.h	7.10 (Berkeley) 5/7/93
  */
 
-#ifndef _ENDIAN_H_
-#define	_ENDIAN_H_
+#pragma once
 
 /*
  * Define _NOQUAD if the compiler does NOT support 64-bit integers.
@@ -91,4 +90,3 @@ __END_DECLS
 #define	HTONS(x)	(x) = htons((u_short)x)
 #endif
 #endif /* !_POSIX_SOURCE */
-#endif /* !_ENDIAN_H_ */

--- a/src-lites-1.1-2025/include/parisc/types.h
+++ b/src-lites-1.1-2025/include/parisc/types.h
@@ -33,8 +33,7 @@
  *	@(#)types.h	8.3 (Berkeley) 1/5/94
  */
 
-#ifndef	_MACHTYPES_H_
-#define	_MACHTYPES_H_
+#pragma once
 
 #include <mach/machine/vm_types.h>
 
@@ -82,4 +81,3 @@ typedef	long long		  int64_t;
 typedef	unsigned long long	u_int64_t;
 #endif
 
-#endif	/* _MACHTYPES_H_ */

--- a/src-lites-1.1-2025/include/parisc/vmparam.h
+++ b/src-lites-1.1-2025/include/parisc/vmparam.h
@@ -25,8 +25,7 @@
  *
  */
 
-#ifndef _PARISC_BSD_VMPARAM_H_
-#define _PARISC_BSD_VMPARAM_H_
+#pragma once
 
 /*
  * Machine dependent constants for HP800
@@ -202,4 +201,3 @@
  */
 #define	GWPGADDR	0xC0000000
 
-#endif	/* _PARISC_BSD_VMPARAM_H_ */

--- a/src-lites-1.1-2025/include/string.h
+++ b/src-lites-1.1-2025/include/string.h
@@ -33,8 +33,7 @@
  *	@(#)string.h	8.1 (Berkeley) 6/2/93
  */
 
-#ifndef _STRING_H_
-#define	_STRING_H_
+#pragma once
 #include <machine/ansi.h>
 
 #ifdef	_BSD_SIZE_T_
@@ -90,4 +89,3 @@ void	 swab (const void *, void *, size_t);
 #endif 
 __END_DECLS
 
-#endif /* _STRING_H_ */

--- a/src-lites-1.1-2025/include/sys/assert.h
+++ b/src-lites-1.1-2025/include/sys/assert.h
@@ -28,8 +28,7 @@
  *	assert macro for the Lites server
  */
 
-#ifndef _SYS_ASSERT_H_
-#define _SYS_ASSERT_H_
+#pragma once
 
 #include "assertions.h"
 
@@ -43,4 +42,3 @@
 #define assert(expr)
 #endif /* ASSERTIONS */
 
-#endif /* !_SYS_ASSERT_H_ */

--- a/src-lites-1.1-2025/include/sys/audit.h
+++ b/src-lites-1.1-2025/include/sys/audit.h
@@ -1,9 +1,7 @@
-#ifndef _SYS_AUDIT_H_
-#define _SYS_AUDIT_H_
+#pragma once
 
 #include <sys/proc.h>
 
 void audit_record(struct proc *p, const char *op, int result);
 
-#endif /* _SYS_AUDIT_H_ */
 

--- a/src-lites-1.1-2025/include/sys/auth.h
+++ b/src-lites-1.1-2025/include/sys/auth.h
@@ -1,5 +1,4 @@
-#ifndef _SYS_AUTH_H_
-#define _SYS_AUTH_H_
+#pragma once
 
 #include <sys/types.h>
 #include <sys/proc.h>
@@ -13,5 +12,4 @@ struct acl_entry {
 void acl_add(uid_t uid, const char *op, int allow);
 int authorize(struct proc *p, const char *op);
 
-#endif /* _SYS_AUTH_H_ */
 

--- a/src-lites-1.1-2025/include/sys/buf.h
+++ b/src-lites-1.1-2025/include/sys/buf.h
@@ -39,8 +39,7 @@
  * $Id: buf.h,v 1.1.1.2 1995/03/23 01:15:54 law Exp $
  */
 
-#ifndef _SYS_BUF_H_
-#define	_SYS_BUF_H_
+#pragma once
 #ifdef LITES
 #include <serv/import_mach.h>
 #endif
@@ -232,4 +231,3 @@ void	bgetvp (struct vnode *, struct buf *);
 void	reassignbuf (struct buf *, struct vnode *);
 __END_DECLS
 #endif
-#endif /* !_SYS_BUF_H_ */

--- a/src-lites-1.1-2025/include/sys/cdefs.h
+++ b/src-lites-1.1-2025/include/sys/cdefs.h
@@ -1,5 +1,4 @@
-#ifndef _CDEFS_H_
-#define _CDEFS_H_
+#pragma once
 
 #if defined(__cplusplus)
 #define __BEGIN_DECLS   extern "C" {
@@ -23,4 +22,3 @@
 #define __dead
 #define __unused       __attribute__((__unused__))
 
-#endif /* _CDEFS_H_ */

--- a/src-lites-1.1-2025/include/sys/cmu_queue.h
+++ b/src-lites-1.1-2025/include/sys/cmu_queue.h
@@ -40,8 +40,7 @@
  *
  */
 
-#ifndef	_QUEUE_H_
-#define	_QUEUE_H_
+#pragma once
 
 #ifdef KERNEL
 #include "queue_assertions.h"
@@ -399,4 +398,3 @@ MACRO_END
 #define queue_assert_member(_head, _elem, _type, _chain)
 #endif /* QUEUE_ASSERTIONS */
 
-#endif	_QUEUE_H_

--- a/src-lites-1.1-2025/include/sys/coff.h
+++ b/src-lites-1.1-2025/include/sys/coff.h
@@ -65,8 +65,7 @@
  *	Structure definitions for COFF headers
  */
 
-#ifndef _SYS_COFF_H_
-#define _SYS_COFF_H_
+#pragma once
 
 struct filehdr {
 	unsigned short	f_magic;	/* magic number */
@@ -153,4 +152,3 @@ struct exechdr {
    ((sizeof(struct filehdr) + sizeof(struct aouthdr) + \
      (f).f_nscns * sizeof(struct scnhdr) + 15) & ~15)))
 
-#endif /* !_SYS_COFF_H_ */

--- a/src-lites-1.1-2025/include/sys/conf.h
+++ b/src-lites-1.1-2025/include/sys/conf.h
@@ -65,8 +65,7 @@
  *	@(#)conf.h	8.3 (Berkeley) 1/21/94
  */
 
-#ifndef _SYS_CONF_H_
-#define _SYS_CONF_H_
+#pragma once
 
 #ifdef LITES
 #include <serv/import_mach.h>
@@ -204,4 +203,3 @@ int nodev_start(struct tty *);
 int nodev_modem(struct tty *, int);
 #endif
 
-#endif /* !_SYS_CONF_H_ */

--- a/src-lites-1.1-2025/include/sys/device.h
+++ b/src-lites-1.1-2025/include/sys/device.h
@@ -42,8 +42,7 @@
  *	@(#)device.h	8.2 (Berkeley) 2/17/94
  */
 
-#ifndef _SYS_DEVICE_H_
-#define	_SYS_DEVICE_H_
+#pragma once
 
 /*
  * Minimal device structures.
@@ -140,4 +139,3 @@ int config_found (struct device *, void *, cfprint_t);
 int config_rootfound (char *, void *);
 void config_attach (struct device *, struct cfdata *, void *, cfprint_t);
 void evcnt_attach (struct device *, const char *, struct evcnt *);
-#endif /* !_SYS_DEVICE_H_ */

--- a/src-lites-1.1-2025/include/sys/dir.h
+++ b/src-lites-1.1-2025/include/sys/dir.h
@@ -38,8 +38,7 @@
  * and is provided solely (and temporarily) for backward compatibility.
  */
 
-#ifndef _SYS_DIR_H_
-#define	_SYS_DIR_H_
+#pragma once
 
 #include <dirent.h>
 
@@ -58,4 +57,3 @@
 #define DIRSIZ(dp) \
     ((sizeof (struct direct) - (MAXNAMLEN+1)) + (((dp)->d_namlen+1 + 3) &~ 3))
 
-#endif /* !_SYS_DIR_H_ */

--- a/src-lites-1.1-2025/include/sys/disklabel.h
+++ b/src-lites-1.1-2025/include/sys/disklabel.h
@@ -33,8 +33,7 @@
  *	@(#)disklabel.h	8.1 (Berkeley) 6/2/93
  */
 
-#ifndef _SYS_DISKLABEL_H_
-#define _SYS_DISKLABEL_H_
+#pragma once
 
 /*
  * Disk description table, see disktab(5)
@@ -334,4 +333,3 @@ __END_DECLS
 
 #endif
 
-#endif /* !_SYS_DISKLABEL_H_ */

--- a/src-lites-1.1-2025/include/sys/diskslice.h
+++ b/src-lites-1.1-2025/include/sys/diskslice.h
@@ -26,8 +26,7 @@
  *	$Id: diskslice.h,v 1.1 1996/02/17 01:07:01 sclawson Exp $
  */
 
-#ifndef _SYS_DISKSLICE_H_
-#define	_SYS_DISKSLICE_H_
+#pragma once
 
 #include <sys/ioccom.h>
 
@@ -189,4 +188,3 @@ int	dssize (dev_t dev, struct diskslices **sspp, d_open_t dopen,
 
 #endif /* 0 */
 
-#endif /* !_SYS_DISKSLICE_H_ */

--- a/src-lites-1.1-2025/include/sys/dmap.h
+++ b/src-lites-1.1-2025/include/sys/dmap.h
@@ -33,8 +33,7 @@
  *	@(#)dmap.h	8.2 (Berkeley) 1/4/94
  */
 
-#ifndef _SYS_DMAP_H_
-#define	_SYS_DMAP_H_
+#pragma once
 
 /*
  * Definitions for the mapping of vitual swap space to the physical swap
@@ -57,4 +56,3 @@ struct dblock {
 	swblk_t db_base;	/* base of physical contig drum block */
 	swblk_t db_size;	/* size of block */
 };
-#endif	/* !_SYS_DMAP_H_ */

--- a/src-lites-1.1-2025/include/sys/elf.h
+++ b/src-lites-1.1-2025/include/sys/elf.h
@@ -25,8 +25,7 @@
  *
  */
 
-#ifndef _SYS_ELF_H_
-#define _SYS_ELF_H_
+#pragma once
 
 /* Just enough ELF information so we can exec files.  */
 
@@ -86,4 +85,3 @@ typedef struct {
   Elf32_Phdr phdrs[MAX_PHDRS];
 } elf_exec;
 
-#endif /* !_SYS_ELF_H_ */

--- a/src-lites-1.1-2025/include/sys/errno.h
+++ b/src-lites-1.1-2025/include/sys/errno.h
@@ -67,8 +67,7 @@
  *	@(#)errno.h	8.5 (Berkeley) 1/21/94
  */
 
-#ifndef _SYS_ERRNO_H_
-#define _SYS_ERRNO_H_
+#pragma once
 
 #ifndef _POSIX_SOURCE
 typedef int errno_t;
@@ -476,4 +475,3 @@ extern int errno;			/* global error number */
 #endif /* _POSIX_SOURCE */
 #endif /* !defined(KERNEL) */
 
-#endif /* !_SYS_ERRNO_H_ */

--- a/src-lites-1.1-2025/include/sys/exec.h
+++ b/src-lites-1.1-2025/include/sys/exec.h
@@ -38,8 +38,7 @@
  *	@(#)exec.h	8.3 (Berkeley) 1/21/94
  */
 
-#ifndef _SYS_EXEC_H_
-#define _SYS_EXEC_H_
+#pragma once
 
 #include <machine/exec.h>
 
@@ -73,4 +72,3 @@ struct execve_args {
 	char	**envp;
 };
 
-#endif /* !_SYS_EXEC_H_ */

--- a/src-lites-1.1-2025/include/sys/fcntl.h
+++ b/src-lites-1.1-2025/include/sys/fcntl.h
@@ -38,8 +38,7 @@
  *	@(#)fcntl.h	8.3 (Berkeley) 1/21/94
  */
 
-#ifndef _SYS_FCNTL_H_
-#define	_SYS_FCNTL_H_
+#pragma once
 
 /*
  * This file includes the definitions for open and fcntl
@@ -192,4 +191,3 @@ int	flock (int, int);
 __END_DECLS
 #endif
 
-#endif /* !_SYS_FCNTL_H_ */

--- a/src-lites-1.1-2025/include/sys/filio.h
+++ b/src-lites-1.1-2025/include/sys/filio.h
@@ -38,8 +38,7 @@
  *	@(#)filio.h	8.1 (Berkeley) 3/28/94
  */
 
-#ifndef	_SYS_FILIO_H_
-#define	_SYS_FILIO_H_
+#pragma once
 
 #include <sys/ioccom.h>
 
@@ -52,4 +51,3 @@
 #define	FIOSETOWN	_IOW('f', 124, int)	/* set owner */
 #define	FIOGETOWN	_IOR('f', 123, int)	/* get owner */
 
-#endif /* !_SYS_FILIO_H_ */

--- a/src-lites-1.1-2025/include/sys/gmon.h
+++ b/src-lites-1.1-2025/include/sys/gmon.h
@@ -33,8 +33,7 @@
  *	@(#)gmon.h	8.2 (Berkeley) 1/4/94
  */
 
-#ifndef _SYS_GMON_H_
-#define _SYS_GMON_H_
+#pragma once
 
 #include <machine/profile.h>
 
@@ -156,4 +155,3 @@ extern struct gmonparam _gmonparam;
 #define	GPROF_FROMS	2	/* struct: from location hash bucket */
 #define	GPROF_TOS	3	/* struct: destination/count structure */
 #define	GPROF_GMONPARAM	4	/* struct: profiling parameters (see above) */
-#endif /* !_SYS_GMON_H_ */

--- a/src-lites-1.1-2025/include/sys/gprof.h
+++ b/src-lites-1.1-2025/include/sys/gprof.h
@@ -50,8 +50,7 @@
  *
  */
 
-#ifndef	_GPROF_H_
-#define _GPROF_H_
+#pragma once
 /*
  * The profiler keeps two datastructures, a pc histogram and a call graph.
  */
@@ -124,4 +123,3 @@ struct gprof_call {
 typedef char *char_array;
 
 
-#endif	/* _GPROF_H_ */

--- a/src-lites-1.1-2025/include/sys/ioccom.h
+++ b/src-lites-1.1-2025/include/sys/ioccom.h
@@ -33,8 +33,7 @@
  *	@(#)ioccom.h	8.2 (Berkeley) 3/28/94
  */
 
-#ifndef	_SYS_IOCCOM_H_
-#define	_SYS_IOCCOM_H_
+#pragma once
 
 /*
  * Ioctl's have the command encoded in the lower word, and the size of
@@ -61,4 +60,3 @@
 /* this should be _IORW, but stdio got there first */
 #define	_IOWR(g,n,t)	_IOC(IOC_INOUT,	(g), (n), sizeof(t))
 
-#endif /* !_SYS_IOCCOM_H_ */

--- a/src-lites-1.1-2025/include/sys/ioctl.h
+++ b/src-lites-1.1-2025/include/sys/ioctl.h
@@ -38,8 +38,7 @@
  *	@(#)ioctl.h	8.6 (Berkeley) 3/28/94
  */
 
-#ifndef	_SYS_IOCTL_H_
-#define	_SYS_IOCTL_H_
+#pragma once
 
 #include <sys/ttycom.h>
 
@@ -71,7 +70,6 @@ __BEGIN_DECLS
 int	ioctl (int, unsigned int, ...);
 __END_DECLS
 #endif /* KERNEL */
-#endif /* !_SYS_IOCTL_H_ */
 
 /*
  * Keep outside _SYS_IOCTL_H_

--- a/src-lites-1.1-2025/include/sys/ioctl_compat.h
+++ b/src-lites-1.1-2025/include/sys/ioctl_compat.h
@@ -38,8 +38,7 @@
  *	@(#)ioctl_compat.h	8.4 (Berkeley) 1/21/94
  */
 
-#ifndef _SYS_IOCTL_COMPAT_H_
-#define	_SYS_IOCTL_COMPAT_H_
+#pragma once
 
 #include <sys/ttychars.h>
 #include <sys/ttydev.h>
@@ -164,4 +163,3 @@ struct sgttyb {
 #define	NETLDISC	1
 #define	NTTYDISC	2
 
-#endif /* !_SYS_IOCTL_COMPAT_H_ */

--- a/src-lites-1.1-2025/include/sys/ipc.h
+++ b/src-lites-1.1-2025/include/sys/ipc.h
@@ -46,8 +46,7 @@
 /*
  * SVID compatible ipc.h file
  */
-#ifndef _SYS_IPC_H_
-#define _SYS_IPC_H_
+#pragma once
 
 typedef	int32_t	key_t;	/* XXX should be in types.h */
 
@@ -76,4 +75,3 @@ struct ipc_perm {
 #define	IPC_SET		1	/* set options */
 #define	IPC_STAT	2	/* get options */
 
-#endif /* !_SYS_IPC_H_ */

--- a/src-lites-1.1-2025/include/sys/kernel.h
+++ b/src-lites-1.1-2025/include/sys/kernel.h
@@ -64,8 +64,7 @@
  *	@(#)kernel.h	8.3 (Berkeley) 1/21/94
  */
 
-#ifndef _SYS_KERNEL_H_
-#define _SYS_KERNEL_H_
+#pragma once
 
 /* Global variables for the kernel. */
 
@@ -104,4 +103,3 @@ extern int stathz;			/* statistics clock's frequency */
 extern int profhz;			/* profiling clock's frequency */
 extern vm_offset_t lbolt;		/* once a second sleep address */
 
-#endif /* !_SYS_KERNEL_H_ */

--- a/src-lites-1.1-2025/include/sys/macro_help.h
+++ b/src-lites-1.1-2025/include/sys/macro_help.h
@@ -21,10 +21,8 @@
  *
  */
 
-#ifndef	_SYS_MACRO_HELP_H_
-#define _SYS_MACRO_HELP_H_
+#pragma once
 
 #define		MACRO_BEGIN	do {
 #define		MACRO_END	} while (0)
 
-#endif	/* !_SYS_MACRO_HELP_H_ */

--- a/src-lites-1.1-2025/include/sys/malloc.h
+++ b/src-lites-1.1-2025/include/sys/malloc.h
@@ -59,8 +59,7 @@
  *	@(#)malloc.h	8.3 (Berkeley) 1/12/94
  */
 
-#ifndef _SYS_MALLOC_H_
-#define	_SYS_MALLOC_H_
+#pragma once
 
 #include <sys/zalloc.h>
 
@@ -272,4 +271,3 @@ extern zone_t		zone_M_LAST;
 #define	bsd_malloc(size, type, flags) malloc(size)
 #define bsd_free(addr, type) free((void *)(addr))
 #endif
-#endif /* !_SYS_MALLOC_H_ */

--- a/src-lites-1.1-2025/include/sys/mount.h
+++ b/src-lites-1.1-2025/include/sys/mount.h
@@ -33,8 +33,7 @@
  *	@(#)mount.h	8.13 (Berkeley) 3/27/94
  */
 
-#ifndef _SYS_MOUNT_H_
-#define _SYS_MOUNT_H_
+#pragma once
 
 #ifdef KERNEL
 #include "nfs.h"
@@ -451,4 +450,3 @@ int	unmount (const char *, int);
 __END_DECLS
 
 #endif /* KERNEL */
-#endif /* !_SYS_MOUNT_H_ */

--- a/src-lites-1.1-2025/include/sys/namei.h
+++ b/src-lites-1.1-2025/include/sys/namei.h
@@ -33,8 +33,7 @@
  *	@(#)namei.h	8.2 (Berkeley) 1/4/94
  */
 
-#ifndef _SYS_NAMEI_H_
-#define	_SYS_NAMEI_H_
+#pragma once
 
 /*
  * Encapsulation of namei parameters.
@@ -185,4 +184,3 @@ struct	nchstats {
 	long	ncs_pass2;		/* names found with passes == 2 */
 	long	ncs_2passes;		/* number of times we attempt it */
 };
-#endif /* !_SYS_NAMEI_H_ */

--- a/src-lites-1.1-2025/include/sys/parallel.h
+++ b/src-lites-1.1-2025/include/sys/parallel.h
@@ -31,8 +31,7 @@
  *	Master lock serialization for threads within the server.
  */
 
-#ifndef SYS_PARALLEL_H
-#define SYS_PARALLEL_H
+#pragma once
 
 #include "data_synch.h"
 
@@ -77,4 +76,3 @@ MACRO_BEGIN \
 MACRO_END
 #endif /* DATA_SYNCH */
 
-#endif /* SYS_PARALLEL_H */

--- a/src-lites-1.1-2025/include/sys/proc.h
+++ b/src-lites-1.1-2025/include/sys/proc.h
@@ -64,8 +64,7 @@
  *	@(#)proc.h	8.8 (Berkeley) 1/21/94
  */
 
-#ifndef _SYS_PROC_H_
-#define	_SYS_PROC_H_
+#pragma once
 
 #ifdef KERNEL
 #include "map_uarea.h"
@@ -368,4 +367,3 @@ int	tsleep (void *chan, int pri, char *wmesg, int timo);
 void	unsleep (struct proc *);
 void	wakeup (void *chan);
 #endif	/* KERNEL */
-#endif	/* !_SYS_PROC_H_ */

--- a/src-lites-1.1-2025/include/sys/ptrace.h
+++ b/src-lites-1.1-2025/include/sys/ptrace.h
@@ -33,8 +33,7 @@
  *	@(#)ptrace.h	8.2 (Berkeley) 1/4/94
  */
 
-#ifndef	_SYS_PTRACE_H_
-#define	_SYS_PTRACE_H_
+#pragma once
 
 #define	PT_TRACE_ME	0	/* child declares it's being traced */
 #define	PT_READ_I	1	/* read word in child's I space */
@@ -64,4 +63,3 @@ __END_DECLS
 
 #endif /* !KERNEL */
 
-#endif	/* !_SYS_PTRACE_H_ */

--- a/src-lites-1.1-2025/include/sys/queue.h
+++ b/src-lites-1.1-2025/include/sys/queue.h
@@ -33,8 +33,7 @@
  *	@(#)queue.h	8.4 (Berkeley) 1/4/94
  */
 
-#ifndef	_SYS_QUEUE_H_
-#define	_SYS_QUEUE_H_
+#pragma once
 
 /*
  * This file defines three types of data structures: lists, tail queues,
@@ -242,4 +241,3 @@ struct {								\
 		(elm)->field.cqe_prev->field.cqe_next =			\
 		    (elm)->field.cqe_next;				\
 }
-#endif	/* !_SYS_QUEUE_H_ */

--- a/src-lites-1.1-2025/include/sys/reboot.h
+++ b/src-lites-1.1-2025/include/sys/reboot.h
@@ -33,8 +33,7 @@
  *	@(#)reboot.h	8.1 (Berkeley) 6/2/93
  */
 
-#ifndef _SYS_REBOOT_H_
-#define _SYS_REBOOT_H_
+#pragma once
 
 /*
  * Arguments to reboot system call.
@@ -95,4 +94,3 @@
 #ifdef KERNEL
 void boot (boolean_t, int);
 #endif
-#endif /* _SYS_REBOOT_H_ */

--- a/src-lites-1.1-2025/include/sys/resource.h
+++ b/src-lites-1.1-2025/include/sys/resource.h
@@ -33,8 +33,7 @@
  *	@(#)resource.h	8.2 (Berkeley) 1/4/94
  */
 
-#ifndef _SYS_RESOURCE_H_
-#define	_SYS_RESOURCE_H_
+#pragma once
 
 #include <sys/types.h>
 
@@ -124,4 +123,3 @@ int	setrlimit (int, const struct rlimit *);
 __END_DECLS
 
 #endif	/* KERNEL */
-#endif	/* !_SYS_RESOURCE_H_ */

--- a/src-lites-1.1-2025/include/sys/resourcevar.h
+++ b/src-lites-1.1-2025/include/sys/resourcevar.h
@@ -33,8 +33,7 @@
  *	@(#)resourcevar.h	8.3 (Berkeley) 2/22/94
  */
 
-#ifndef	_SYS_RESOURCEVAR_H_
-#define	_SYS_RESOURCEVAR_H_
+#pragma once
 
 /*
  * Kernel per-process accounting / statistics
@@ -87,4 +86,3 @@ void	 addupc_task (struct proc *p, u_long pc, u_int ticks);
 struct plimit
 	*limcopy (struct plimit *lim);
 #endif
-#endif	/* !_SYS_RESOURCEVAR_H_ */

--- a/src-lites-1.1-2025/include/sys/select.h
+++ b/src-lites-1.1-2025/include/sys/select.h
@@ -33,8 +33,7 @@
  *	@(#)select.h	8.2 (Berkeley) 1/4/94
  */
 
-#ifndef _SYS_SELECT_H_
-#define	_SYS_SELECT_H_
+#pragma once
 
 /*
  * Used to maintain information about processes that wish to be
@@ -55,4 +54,3 @@ void	selrecord (struct proc *selector, struct selinfo *);
 void	selwakeup (struct selinfo *);
 #endif
 
-#endif /* !_SYS_SELECT_H_ */

--- a/src-lites-1.1-2025/include/sys/shared_lock.h
+++ b/src-lites-1.1-2025/include/sys/shared_lock.h
@@ -37,8 +37,7 @@
  *
  */
 
-#ifndef	_SYS_SHARED_LOCK_H_
-#define	_SYS_SHARED_LOCK_H_
+#pragma once
 
 #include <sys/proc.h>		/* for struct proc */
 
@@ -60,4 +59,3 @@ extern int		share_lock_solid(struct shared_lock *, struct proc *);
 extern void		share_unlock(struct shared_lock *, struct proc *);
 extern boolean_t	share_try_lock(struct shared_lock *, struct proc *);
 
-#endif	_SYS_SHARED_LOCK_H_

--- a/src-lites-1.1-2025/include/sys/signal.h
+++ b/src-lites-1.1-2025/include/sys/signal.h
@@ -38,8 +38,7 @@
  *	@(#)signal.h	8.2 (Berkeley) 1/21/94
  */
 
-#ifndef	_SYS_SIGNAL_H_
-#define	_SYS_SIGNAL_H_
+#pragma once
 
 #define NSIG	32		/* counting 0; could be 33 (mask is 1-32) */
 
@@ -189,4 +188,3 @@ struct	sigstack {
 __BEGIN_DECLS
 void	(*signal(int, void (*)(int)))(int);
 __END_DECLS
-#endif	/* !_SYS_SIGNAL_H_ */

--- a/src-lites-1.1-2025/include/sys/signalvar.h
+++ b/src-lites-1.1-2025/include/sys/signalvar.h
@@ -39,8 +39,7 @@
  *
  */
 
-#ifndef	_SYS_SIGNALVAR_H_		/* tmp for user.h */
-#define	_SYS_SIGNALVAR_H_
+#pragma once
 
 /*
  * Kernel signal definitions and data structures,
@@ -178,4 +177,3 @@ void	trapsignal (struct proc *p, int sig, unsigned code);
  */
 boolean_t sendsig (struct proc *, thread_t thread, sig_t action, int sig, unsigned code, int returnmask);
 #endif	/* KERNEL */
-#endif	/* !_SYS_SIGNALVAR_H_ */

--- a/src-lites-1.1-2025/include/sys/socket.h
+++ b/src-lites-1.1-2025/include/sys/socket.h
@@ -33,8 +33,7 @@
  *	@(#)socket.h	8.4 (Berkeley) 2/21/94
  */
 
-#ifndef _SYS_SOCKET_H_
-#define	_SYS_SOCKET_H_
+#pragma once
 
 /*
  * Definitions related to sockets: types, address families, options.
@@ -336,4 +335,3 @@ int	socketpair (int, int, int, int *);
 __END_DECLS
 
 #endif /* !KERNEL */
-#endif /* !_SYS_SOCKET_H_ */

--- a/src-lites-1.1-2025/include/sys/sockio.h
+++ b/src-lites-1.1-2025/include/sys/sockio.h
@@ -33,8 +33,7 @@
  *	@(#)sockio.h	8.1 (Berkeley) 3/28/94
  */
 
-#ifndef	_SYS_SOCKIO_H_
-#define	_SYS_SOCKIO_H_
+#pragma once
 
 #include <sys/ioccom.h>
 
@@ -82,4 +81,3 @@
 #define	SIOCSIFASYNCMAP  _IOW('i', 125, struct ifreq)   /* set ppp asyncmap */
 #define	SIOCGIFASYNCMAP _IOWR('i', 124, struct ifreq)   /* get ppp asyncmap */
 
-#endif /* !_SYS_SOCKIO_H_ */

--- a/src-lites-1.1-2025/include/sys/som.h
+++ b/src-lites-1.1-2025/include/sys/som.h
@@ -25,8 +25,7 @@
  *
  */
 
-#ifndef	_SYS_SOM_H_
-#define	_SYS_SOM_H_
+#pragma once
 
 /*
  * Simplified SOM header structure for use by kern_exec code.
@@ -110,4 +109,3 @@ struct bsd_exechdr {
 #define	SOM_N_TXTOFF(x) \
 	((x).fhdr.tfile)
 
-#endif	/* _SYS_SOM_H_ */

--- a/src-lites-1.1-2025/include/sys/stat.h
+++ b/src-lites-1.1-2025/include/sys/stat.h
@@ -38,8 +38,7 @@
  *	@(#)stat.h	8.6 (Berkeley) 3/8/94
  */
 
-#ifndef _SYS_STAT_H_
-#define	_SYS_STAT_H_
+#pragma once
 
 #include <sys/time.h>
 
@@ -194,4 +193,3 @@ int	lstat (const char *, struct stat *);
 #endif
 __END_DECLS
 #endif
-#endif /* !_SYS_STAT_H_ */

--- a/src-lites-1.1-2025/include/sys/sysctl.h
+++ b/src-lites-1.1-2025/include/sys/sysctl.h
@@ -36,8 +36,7 @@
  *	@(#)sysctl.h	8.1 (Berkeley) 6/2/93
  */
 
-#ifndef _SYS_SYSCTL_H_
-#define	_SYS_SYSCTL_H_
+#pragma once
 
 /*
  * These are for the eproc structure defined below.
@@ -343,4 +342,3 @@ __BEGIN_DECLS
 int	sysctl (int *, u_int, void *, size_t *, void *, size_t);
 __END_DECLS
 #endif	/* KERNEL */
-#endif	/* !_SYS_SYSCTL_H_ */

--- a/src-lites-1.1-2025/include/sys/table.h
+++ b/src-lites-1.1-2025/include/sys/table.h
@@ -39,8 +39,7 @@
  *
  */
 
-#ifndef	_SYS_TABLE_H_
-#define _SYS_TABLE_H_
+#pragma once
 
 #define TBL_TTYLOC		0	/* index by device number */
 #define TBL_U_TTYD		1	/* index by process ID */
@@ -225,4 +224,3 @@ struct tbl_ttyinfo {
         long	ti_rawcc;
 };
 
-#endif	_SYS_TABLE_H_

--- a/src-lites-1.1-2025/include/sys/tablet.h
+++ b/src-lites-1.1-2025/include/sys/tablet.h
@@ -33,8 +33,7 @@
  *	@(#)tablet.h	8.3 (Berkeley) 1/4/94
  */
 
-#ifndef _SYS_TABLET_H_
-#define	_SYS_TABLET_H_
+#pragma once
 
 /*
  * Tablet line discipline.
@@ -91,4 +90,3 @@ struct	polpos {
 #define BIOSTYPE	_IOW('b', 3, int)	/* set tablet type */
 #define BIOGTYPE	_IOR('b', 4, int)	/* get tablet type*/
 
-#endif /* !_SYS_TABLET_H_ */

--- a/src-lites-1.1-2025/include/sys/termios.h
+++ b/src-lites-1.1-2025/include/sys/termios.h
@@ -33,8 +33,7 @@
  *	@(#)termios.h	8.3 (Berkeley) 3/28/94
  */
 
-#ifndef _SYS_TERMIOS_H_
-#define _SYS_TERMIOS_H_
+#pragma once
 
 /* 
  * Special Control Characters 
@@ -271,7 +270,6 @@ __END_DECLS
 /*
  * END OF PROTECTED INCLUDE.
  */
-#endif /* !_SYS_TERMIOS_H_ */
 
 #ifndef _POSIX_SOURCE
 #include <sys/ttydefaults.h>

--- a/src-lites-1.1-2025/include/sys/time.h
+++ b/src-lites-1.1-2025/include/sys/time.h
@@ -33,8 +33,7 @@
  *	@(#)time.h	8.1 (Berkeley) 6/2/93
  */
 
-#ifndef _SYS_TIME_H_
-#define _SYS_TIME_H_
+#pragma once
 
 #include <sys/types.h>
 
@@ -132,4 +131,3 @@ __END_DECLS
 
 #endif /* !KERNEL */
 
-#endif /* !_SYS_TIME_H_ */

--- a/src-lites-1.1-2025/include/sys/times.h
+++ b/src-lites-1.1-2025/include/sys/times.h
@@ -38,8 +38,7 @@
  *	@(#)times.h	8.4 (Berkeley) 1/21/94
  */
 
-#ifndef	_SYS_TIMES_H_
-#define	_SYS_TIMES_H_
+#pragma once
 
 #include <machine/ansi.h>
 
@@ -62,4 +61,3 @@ __BEGIN_DECLS
 clock_t	times (struct tms *);
 __END_DECLS
 #endif
-#endif /* !_SYS_TIMES_H_ */

--- a/src-lites-1.1-2025/include/sys/tty.h
+++ b/src-lites-1.1-2025/include/sys/tty.h
@@ -38,8 +38,7 @@
  *	@(#)tty.h	8.6 (Berkeley) 1/21/94
  */
 
-#ifndef _SYS_TTY_H_
-#define _SYS_TTY_H_
+#pragma once
 
 #ifdef LITES
 #include <serv/import_mach.h>
@@ -232,4 +231,3 @@ int	 ttywait (struct tty *tp);
 int	 ttywflush (struct tty *tp);
 #endif
 
-#endif /* !_SYS_TTY_H_ */

--- a/src-lites-1.1-2025/include/sys/ttychars.h
+++ b/src-lites-1.1-2025/include/sys/ttychars.h
@@ -38,8 +38,7 @@
  *
  * User visible structures and constants related to terminal handling.
  */
-#ifndef _SYS_TTYCHARS_H_
-#define	_SYS_TTYCHARS_H_
+#pragma once
 
 struct ttychars {
 	char	tc_erase;	/* erase last character */
@@ -60,4 +59,3 @@ struct ttychars {
 #ifdef USE_OLD_TTY
 #include <sys/ttydefaults.h>	/* to pick up character defaults */
 #endif
-#endif /* !_SYS_TTYCHARS_H_ */

--- a/src-lites-1.1-2025/include/sys/ttycom.h
+++ b/src-lites-1.1-2025/include/sys/ttycom.h
@@ -38,8 +38,7 @@
  *	@(#)ttycom.h	8.1 (Berkeley) 3/28/94
  */
 
-#ifndef	_SYS_TTYCOM_H_
-#define	_SYS_TTYCOM_H_
+#pragma once
 
 #include <sys/ioccom.h>
 
@@ -126,4 +125,3 @@ struct winsize {
 #define	SLIPDISC	4		/* serial IP discipline */
 #define	PPPDISC		5		/* ppp discipline */
 
-#endif /* !_SYS_TTYCOM_H_ */

--- a/src-lites-1.1-2025/include/sys/ttydefaults.h
+++ b/src-lites-1.1-2025/include/sys/ttydefaults.h
@@ -41,8 +41,7 @@
 /*
  * System wide defaults for terminal state.
  */
-#ifndef _SYS_TTYDEFAULTS_H_
-#define	_SYS_TTYDEFAULTS_H_
+#pragma once
 
 /*
  * Defaults on "first" open.
@@ -81,7 +80,6 @@
 #define	CFLUSH		CDISCARD
 
 /* PROTECTED INCLUSION ENDS HERE */
-#endif /* !_SYS_TTYDEFAULTS_H_ */
 
 /*
  * #define TTYDEFCHARS to include an array of default control characters.

--- a/src-lites-1.1-2025/include/sys/ttydev.h
+++ b/src-lites-1.1-2025/include/sys/ttydev.h
@@ -35,8 +35,7 @@
 
 /* COMPATABILITY HEADER FILE */
 
-#ifndef _SYS_TTYDEV_H_
-#define	_SYS_TTYDEV_H_
+#pragma once
 
 #ifdef USE_OLD_TTY
 #define B0	0
@@ -57,4 +56,3 @@
 #define EXTB	15
 #endif /* USE_OLD_TTY */
 
-#endif /* !_SYS_TTYDEV_H_ */

--- a/src-lites-1.1-2025/include/sys/types.h
+++ b/src-lites-1.1-2025/include/sys/types.h
@@ -38,8 +38,7 @@
  *	@(#)types.h	8.4 (Berkeley) 1/21/94
  */
 
-#ifndef _SYS_TYPES_H_
-#define	_SYS_TYPES_H_
+#pragma once
 
 /* Machine type dependent parameters. */
 #include <machine/endian.h>
@@ -180,4 +179,3 @@ typedef unsigned int ioctl_cmd_t;
 #endif
 
 #endif /* !_POSIX_SOURCE */
-#endif /* !_SYS_TYPES_H_ */

--- a/src-lites-1.1-2025/include/sys/ucred.h
+++ b/src-lites-1.1-2025/include/sys/ucred.h
@@ -33,8 +33,7 @@
  *	@(#)ucred.h	8.2 (Berkeley) 1/4/94
  */
 
-#ifndef _SYS_UCRED_H_
-#define	_SYS_UCRED_H_
+#pragma once
 
 /*
  * Credentials.
@@ -67,4 +66,3 @@ struct ucred *crcopy();
 struct ucred *crdup();
 #endif /* KERNEL */
 
-#endif /* !_SYS_UCRED_H_ */

--- a/src-lites-1.1-2025/include/sys/uio.h
+++ b/src-lites-1.1-2025/include/sys/uio.h
@@ -33,8 +33,7 @@
  *	@(#)uio.h	8.5 (Berkeley) 2/22/94
  */
 
-#ifndef _SYS_UIO_H_
-#define	_SYS_UIO_H_
+#pragma once
 
 /*
  * XXX
@@ -80,4 +79,3 @@ ssize_t	readv (int, const struct iovec *, int);
 ssize_t	writev (int, const struct iovec *, int);
 __END_DECLS
 #endif /* !KERNEL */
-#endif /* !_SYS_UIO_H_ */

--- a/src-lites-1.1-2025/include/sys/unistd.h
+++ b/src-lites-1.1-2025/include/sys/unistd.h
@@ -33,8 +33,7 @@
  *	@(#)unistd.h	8.2 (Berkeley) 1/7/94
  */
 
-#ifndef _SYS_UNISTD_H_
-#define	_SYS_UNISTD_H_
+#pragma once
 
 /* compile-time symbolic constants */
 #define	_POSIX_JOB_CONTROL	/* implementation supports job control */
@@ -121,4 +120,3 @@
 /* configurable system strings */
 #define	_CS_PATH		 1
 
-#endif /* !_SYS_UNISTD_H_ */

--- a/src-lites-1.1-2025/include/sys/ushared.h
+++ b/src-lites-1.1-2025/include/sys/ushared.h
@@ -24,8 +24,7 @@
  * the rights to redistribute these changes.
  */
 
-#ifndef	_SYS_USHARED_H_
-#define	_SYS_USHARED_H_
+#pragma once
 
 #ifdef	KERNEL
 #include <serv/import_mach.h>
@@ -59,4 +58,3 @@ struct ushared_rw {
 	int		us_sigignore;
 };
 
-#endif	_SYS_USHARED_H_

--- a/src-lites-1.1-2025/include/sys/utsname.h
+++ b/src-lites-1.1-2025/include/sys/utsname.h
@@ -36,8 +36,7 @@
  *	@(#)utsname.h	8.1 (Berkeley) 1/4/94
  */
 
-#ifndef	_SYS_UTSNAME_H
-#define	_SYS_UTSNAME_H
+#pragma once
 
 struct utsname {
 	char	sysname[256];	/* Name of this OS. */
@@ -53,4 +52,3 @@ __BEGIN_DECLS
 int	uname (struct utsname *);
 __END_DECLS
 
-#endif	/* !_SYS_UTSNAME_H */

--- a/src-lites-1.1-2025/include/sys/ux_exception.h
+++ b/src-lites-1.1-2025/include/sys/ux_exception.h
@@ -35,8 +35,7 @@
  *
  */
 
-#ifndef	_SYS_UX_EXCEPTION_H_
-#define	_SYS_UX_EXCEPTION_H_
+#pragma once
 
 /*
  *	Codes for Unix software exceptions under EXC_SOFTWARE.
@@ -60,4 +59,3 @@ struct mutex		ux_handler_init_lock;
 mach_port_t		ux_exception_port;
 
 #endif	KERNEL
-#endif	_SYS_UX_EXCEPTION_H_

--- a/src-lites-1.1-2025/include/sys/vnode.h
+++ b/src-lites-1.1-2025/include/sys/vnode.h
@@ -59,8 +59,7 @@
  *	@(#)vnode.h	8.7 (Berkeley) 2/4/94
  */
 
-#ifndef _SYS_VNODE_H_
-#define _SYS_VNODE_H_
+#pragma once
 
 #ifdef KERNEL
 #include "nfs.h"
@@ -453,4 +452,3 @@ void 	vref (struct vnode *vp);
 void 	vrele (struct vnode *vp);
 #endif /* KERNEL */
 
-#endif /* !_SYS_VNODE_H_ */

--- a/src-lites-1.1-2025/include/sys/zalloc.h
+++ b/src-lites-1.1-2025/include/sys/zalloc.h
@@ -38,8 +38,7 @@
  *
  */
 
-#ifndef	_ZALLOC_
-#define	_ZALLOC_
+#pragma once
 
 #include <serv/import_mach.h>
 
@@ -129,4 +128,3 @@ void		zchange(zone_t zone, boolean_t pageable, boolean_t sleepable,
 void		zcram(zone_t zone, vm_offset_t newmem, vm_size_t size);
 void		zone_init(void);
 
-#endif	_ZALLOC_

--- a/src-lites-1.1-2025/include/time.h
+++ b/src-lites-1.1-2025/include/time.h
@@ -38,8 +38,7 @@
  *	@(#)time.h	8.3 (Berkeley) 1/21/94
  */
 
-#ifndef _TIME_H_
-#define	_TIME_H_
+#pragma once
 
 #include <machine/ansi.h>
 
@@ -101,4 +100,3 @@ void tzsetwall (void);
 #endif /* neither ANSI nor POSIX */
 __END_DECLS
 
-#endif /* !_TIME_H_ */

--- a/src-lites-1.1-2025/include/vm.h
+++ b/src-lites-1.1-2025/include/vm.h
@@ -1,5 +1,4 @@
-#ifndef LITES_VM_H
-#define LITES_VM_H
+#pragma once
 
 #include <stdint.h>
 #include <sys/types.h>
@@ -43,4 +42,3 @@ typedef struct pf_info {
     int         flags; /* future use */
 } pf_info_t;
 
-#endif /* LITES_VM_H */

--- a/src-lites-1.1-2025/include/x86_64/ansi.h
+++ b/src-lites-1.1-2025/include/x86_64/ansi.h
@@ -33,8 +33,7 @@
  *	@(#)ansi.h	8.2 (Berkeley) 1/4/94
  */
 
-#ifndef	_ANSI_H_
-#define	_ANSI_H_
+#pragma once
 
 /*
  * Types which are fundamental to the implementation and may appear in
@@ -69,4 +68,3 @@
 #define	_BSD_WCHAR_T_	int			/* wchar_t */
 #define	_BSD_RUNE_T_	int			/* rune_t */
 
-#endif	/* _ANSI_H_ */

--- a/src-lites-1.1-2025/include/x86_64/asm.h
+++ b/src-lites-1.1-2025/include/x86_64/asm.h
@@ -1,5 +1,4 @@
-#ifndef _X86_64_ASM_H_
-#define _X86_64_ASM_H_
+#pragma once
 
 /* Generic assembly macros modelled after the 4.4BSD i386 header. */
 
@@ -18,4 +17,3 @@
 /* System call instruction */
 #define SVC             syscall
 
-#endif /* _X86_64_ASM_H_ */

--- a/src-lites-1.1-2025/include/x86_64/endian.h
+++ b/src-lites-1.1-2025/include/x86_64/endian.h
@@ -33,8 +33,7 @@
  *	@(#)endian.h	8.1 (Berkeley) 6/11/93
  */
 
-#ifndef _ENDIAN_H_
-#define	_ENDIAN_H_
+#pragma once
 
 /*
  * Define _NOQUAD if the compiler does NOT support 64-bit integers.
@@ -89,4 +88,3 @@ __END_DECLS
 #define	HTONS(x)	(x) = htons((u_short)x)
 #endif
 #endif /* ! _POSIX_SOURCE */
-#endif /* !_ENDIAN_H_ */

--- a/src-lites-1.1-2025/include/x86_64/param.h
+++ b/src-lites-1.1-2025/include/x86_64/param.h
@@ -40,8 +40,7 @@
  * Machine dependent constants for Intel 386.
  */
 
-#ifndef _X86_64_PARAM_H_
-#define _X86_64_PARAM_H_
+#pragma once
 
 #define MACHINE "x86_64"
 
@@ -177,4 +176,3 @@
 #define PAGE_SIZE 4096
 #endif
 
-#endif /* _X86_64_PARAM_H_ */

--- a/src-lites-1.1-2025/include/x86_64/stdarg.h
+++ b/src-lites-1.1-2025/include/x86_64/stdarg.h
@@ -33,8 +33,7 @@
  *	@(#)stdarg.h	8.1 (Berkeley) 6/10/93
  */
 
-#ifndef _STDARG_H_
-#define	_STDARG_H_
+#pragma once
 
 typedef char *va_list;
 
@@ -55,4 +54,3 @@ typedef char *va_list;
 
 #define	va_end(ap)
 
-#endif /* !_STDARG_H_ */

--- a/src-lites-1.1-2025/include/x86_64/types.h
+++ b/src-lites-1.1-2025/include/x86_64/types.h
@@ -33,8 +33,7 @@
  *	@(#)types.h	8.3 (Berkeley) 1/5/94
  */
 
-#ifndef	_MACHTYPES_H_
-#define	_MACHTYPES_H_
+#pragma once
 
 #include <mach/machine/vm_types.h>
 
@@ -61,4 +60,3 @@ typedef	unsigned int		u_int32_t;
 typedef	long long		  int64_t;
 typedef	unsigned long long	u_int64_t;
 
-#endif	/* _MACHTYPES_H_ */

--- a/src-lites-1.1-2025/include/x86_64/varargs.h
+++ b/src-lites-1.1-2025/include/x86_64/varargs.h
@@ -38,8 +38,7 @@
  *	@(#)varargs.h	8.2 (Berkeley) 3/22/94
  */
 
-#ifndef _VARARGS_H_
-#define	_VARARGS_H_
+#pragma once
 
 typedef char *va_list;
 
@@ -59,4 +58,3 @@ typedef char *va_list;
 
 #define	va_end(ap)
 
-#endif /* !_VARARGS_H_ */

--- a/src-lites-1.1-2025/include/x86_64/vmparam.h
+++ b/src-lites-1.1-2025/include/x86_64/vmparam.h
@@ -36,8 +36,7 @@
  *	@(#)vmparam.h	8.2 (Berkeley) 4/22/94
  */
 
-#ifndef _X86_64_BSD_VMPARAM_H_
-#define _X86_64_BSD_VMPARAM_H_
+#pragma once
 /*
  * Machine dependent constants for 386.
  */
@@ -202,4 +201,3 @@
 #define VM_KMEM_SIZE		(NKMEMCLUSTERS*CLBYTES)
 #define VM_PHYS_SIZE		(USRIOSIZE*CLBYTES)
 
-#endif /* _X86_64_BSD_VMPARAM_H_ */


### PR DESCRIPTION
## Summary
- modernize header style by replacing `#ifndef/#define` guards with `#pragma once`
- update all headers under `include/` and `src-lites-1.1-2025/include/`

## Testing
- `cmake ..` *(fails: Parse error due to missing variables)*
- `gcc -std=c2x tests/audit/test_audit.c kern/auth.c kern/audit.c src-lites-1.1-2025/server/kern/cap.c -Iinclude -I src-lites-1.1-2025/include -o /tmp/test_audit` *(fails: many errors)*