### PR TITLE
Replace bzero/bcopy/bcmp usage

### DIFF
--- a/src-lites-1.1-2025/include/sys/buf.h
+++ b/src-lites-1.1-2025/include/sys/buf.h
@@ -45,6 +45,7 @@
 #include <serv/import_mach.h>
 #endif
 #include <sys/queue.h>
+#include <string.h>
 
 #define NOLIST ((struct buf *)0x87654321)
 
@@ -181,7 +182,7 @@ TAILQ_HEAD(bqueues, buf) bufqueues[BUFFER_QUEUES];	  /* XXX extern! */
  * Zero out the buffer's data area.
  */
 #define	clrbuf(bp) {							\
-	bzero((bp)->b_data, (u_int)(bp)->b_bcount);			\
+	memset((bp)->b_data, 0, (u_int)(bp)->b_bcount);			\
 	(bp)->b_resid = 0;						\
 }
 

--- a/src-lites-1.1-2025/include/sys/systm.h
+++ b/src-lites-1.1-2025/include/sys/systm.h
@@ -159,3 +159,4 @@ void	stopprofclock (struct proc *);
 void	setstatclockrate (int hzrate);
 
 #include <libkern/libkern.h>
+#include <string.h>

--- a/src-lites-1.1-2025/include/sys/types.h
+++ b/src-lites-1.1-2025/include/sys/types.h
@@ -84,6 +84,7 @@ typedef	u_int32_t	uid_t;		/* user id */
  */
 #ifndef KERNEL
 #include <sys/cdefs.h>
+#include <string.h>
 __BEGIN_DECLS
 off_t	 lseek (int, off_t, int);
 __END_DECLS
@@ -157,8 +158,8 @@ typedef	struct fd_set {
 #define	FD_SET(n, p)	((p)->fds_bits[(n)/NFDBITS] |= (1 << ((n) % NFDBITS)))
 #define	FD_CLR(n, p)	((p)->fds_bits[(n)/NFDBITS] &= ~(1 << ((n) % NFDBITS)))
 #define	FD_ISSET(n, p)	((p)->fds_bits[(n)/NFDBITS] & (1 << ((n) % NFDBITS)))
-#define	FD_COPY(f, t)	bcopy(f, t, sizeof(*(f)))
-#define	FD_ZERO(p)	bzero(p, sizeof(*(p)))
+#define FD_COPY(f, t)   memcpy(t, f, sizeof(*(f)))
+#define	FD_ZERO(p)      memset(p, 0, sizeof(*(p)))
 
 #if defined(KERNEL)
 /*

--- a/src-lites-1.1-2025/liblites/bcmp.c
+++ b/src-lites-1.1-2025/liblites/bcmp.c
@@ -42,24 +42,13 @@ static char sccsid[] = "@(#)bcmp.c	8.1 (Berkeley) 6/4/93";
 #endif /* LIBC_SCCS and not lint */
 
 #include <libkern/libkern.h>
+#include <string.h>
 
 /*
  * bcmp -- vax cmpc3 instruction
  */
 int
-bcmp(b1, b2, length)
-	const void *b1, *b2;
-	register size_t length;
+bcmp(const void *b1, const void *b2, size_t length)
 {
-	register char *p1, *p2;
-
-	if (length == 0)
-		return(0);
-	p1 = (char *)b1;
-	p2 = (char *)b2;
-	do
-		if (*p1++ != *p2++)
-			break;
-	while (--length);
-	return(length);
+       return memcmp(b1, b2, length);
 }

--- a/src-lites-1.1-2025/liblites/exec_file.c
+++ b/src-lites-1.1-2025/liblites/exec_file.c
@@ -43,6 +43,7 @@
 #include <sys/types.h>
 #include <sys/exec_file.h>
 #include <sys/errno.h>
+#include <string.h>
 
 #define CPU_TYPE_UNKNOWN ((cpu_type_t) 0)
 
@@ -327,7 +328,7 @@ mach_error_t parse_exec_file(
 /* Initialize a section to reasonable defaults */
 void exec_section_clear(struct exec_section *sec)
 {
-	bzero((void *) sec, sizeof(*sec));
+       memset((void *) sec, 0, sizeof(*sec));
 
 	sec->how = EXEC_M_MAP;
 	sec->prot = VM_PROT_ALL;
@@ -340,7 +341,7 @@ void exec_section_clear(struct exec_section *sec)
 
 void exec_load_info_clear(struct exec_load_info *li)
 {
-	bzero((void *) li, sizeof(*li));	
+       memset((void *) li, 0, sizeof(*li));
 }
 
 /* 

--- a/src-lites-1.1-2025/server/miscfs/procfs/procfs.h
+++ b/src-lites-1.1-2025/server/miscfs/procfs/procfs.h
@@ -1,3 +1,4 @@
+#include <string.h>
 /*
  * Copyright (c) 1993 Jan-Simon Pendry
  * Copyright (c) 1993
@@ -78,7 +79,7 @@ struct pfsnode {
 #ifdef KERNEL
 #define CNEQ(cnp, s, len) \
 	 ((cnp)->cn_namelen == (len) && \
-	  (bcmp((s), (cnp)->cn_nameptr, (len)) == 0))
+	  (memcmp((s), (cnp)->cn_nameptr, (len)) == 0))
 
 /*
  * Format of a directory entry in /proc, ...

--- a/src-lites-1.1-2025/server/net/radix.h
+++ b/src-lites-1.1-2025/server/net/radix.h
@@ -32,6 +32,7 @@
  *
  *	@(#)radix.h	8.1 (Berkeley) 6/10/93
  */
+#include <string.h>
 
 #ifndef _RADIX_H_
 #define	_RADIX_H_
@@ -122,14 +123,14 @@ struct radix_node_head {
 
 
 #ifndef KERNEL
-#define Bcmp(a, b, n) bcmp(((char *)(a)), ((char *)(b)), (n))
-#define Bzero(p, n) bzero((char *)(p), (int)(n));
+#define Bcmp(a, b, n) memcmp((char *)(a), (char *)(b), (n))
+#define Bzero(p, n) memset((char *)(p), 0, (int)(n));
 #define R_Malloc(p, t, n) (p = (t) malloc((unsigned int)(n)))
 #define Free(p) free((char *)p);
 #else
-#define Bcmp(a, b, n) bcmp(((caddr_t)(a)), ((caddr_t)(b)), (unsigned)(n))
-#define Bcopy(a, b, n) bcopy(((caddr_t)(a)), ((caddr_t)(b)), (unsigned)(n))
-#define Bzero(p, n) bzero((caddr_t)(p), (unsigned)(n));
+#define Bcmp(a, b, n) memcmp((caddr_t)(a), (caddr_t)(b), (unsigned)(n))
+#define Bcopy(a, b, n) memcpy((caddr_t)(b), (caddr_t)(a), (unsigned)(n))
+#define Bzero(p, n) memset((caddr_t)(p), 0, (unsigned)(n));
 #define R_Malloc(p, t, n) (p = (t) malloc((unsigned long)(n), M_RTABLE, M_DONTWAIT))
 #define Free(p) free((caddr_t)p, M_RTABLE);
 

--- a/src-lites-1.1-2025/server/netiso/clnp.h
+++ b/src-lites-1.1-2025/server/netiso/clnp.h
@@ -31,6 +31,7 @@
  * SUCH DAMAGE.
  *
  *	@(#)clnp.h	8.2 (Berkeley) 4/16/94
+#include <string.h>
  */
 
 /***********************************************************
@@ -412,7 +413,7 @@ extern float troll_random;
 			(isoa.isoa_len > 20) || (isoa.isoa_len == 0)) {\
 			hoff = (caddr_t)0;\
 		} else {\
-			(void) bcopy(hoff, (caddr_t)isoa.isoa_genaddr, isoa.isoa_len);\
+			(void) memcpy((caddr_t)isoa.isoa_genaddr, hoff, isoa.isoa_len);\
 			hoff += isoa.isoa_len;\
 		}\
 	}
@@ -422,7 +423,7 @@ extern float troll_random;
  */
 #define CLNP_INSERT_ADDR(hoff, isoa)\
 	*hoff++ = (isoa).isoa_len;\
-	(void) bcopy((caddr_t)((isoa).isoa_genaddr), hoff, (isoa).isoa_len);\
+	(void) memcpy(hoff, (caddr_t)((isoa).isoa_genaddr), (isoa).isoa_len);\
 	hoff += (isoa).isoa_len;
 
 /*

--- a/src-lites-1.1-2025/server/netiso/iso.h
+++ b/src-lites-1.1-2025/server/netiso/iso.h
@@ -132,6 +132,7 @@ SOFTWARE.
 #include <netinet/in.h>
 #endif /* IN_CLASSA_NET */
 
+#include <string.h>
 
 
 /* The following looks like a sockaddr
@@ -157,7 +158,7 @@ struct sockaddr_iso {
 #define TSEL(s) ((caddr_t)((s)->siso_data + (s)->siso_nlen))
 
 #define SAME_ISOADDR(a, b) \
-	(bcmp((a)->siso_data, (b)->siso_data, (unsigned)(a)->siso_nlen)==0)
+	(memcmp((a)->siso_data, (b)->siso_data, (unsigned)(a)->siso_nlen)==0)
 /*
  * The following are specific values for siso->siso_data[0],
  * otherwise known as the AFI:

--- a/src-lites-1.1-2025/server/netiso/iso_pcb.c
+++ b/src-lites-1.1-2025/server/netiso/iso_pcb.c
@@ -76,6 +76,7 @@ SOFTWARE.
 #include <sys/socket.h>
 #include <sys/socketvar.h>
 #include <sys/errno.h>
+#include <string.h>
 
 #include <netiso/argo_debug.h>
 #include <netiso/iso.h>
@@ -101,7 +102,7 @@ struct	iso_addr zeroiso_addr = {
 
 
 #ifdef LITES
-#define ovbcopy bcopy
+#define ovbcopy memmove
 #endif
 
 /*

--- a/src-lites-1.1-2025/server/netiso/tp_param.h
+++ b/src-lites-1.1-2025/server/netiso/tp_param.h
@@ -1,3 +1,4 @@
+#include <string.h>
 /*-
  * Copyright (c) 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -309,18 +310,18 @@ struct tp_vbp {
 #define vblen(x) (vbptr(x)->tpv_len)
 
 #define vb_putval(dst,type,src)\
-	bcopy((caddr_t)&(src),(caddr_t)&(((struct tp_vbp *)(dst))->tpv_val),\
-	sizeof(type))
+       memcpy((caddr_t)&(((struct tp_vbp *)(dst))->tpv_val), (caddr_t)&(src),\
+       sizeof(type))
 
 #define vb_getval(src,type,dst)\
-bcopy((caddr_t)&(((struct tp_vbp *)(src))->tpv_val),(caddr_t)&(dst),sizeof(type))
+memcpy((caddr_t)&(dst), (caddr_t)&(((struct tp_vbp *)(src))->tpv_val), sizeof(type))
 
 #define ADDOPTION(type, DU, len, src)\
 {	register caddr_t P;\
 	P = (caddr_t)(DU) + (int)((DU)->tpdu_li);\
 	vbptr(P)->tpv_code = type;\
 	vbptr(P)->tpv_len = len;\
-	bcopy((caddr_t)&src, (caddr_t)&(vbptr(P)->tpv_val), (unsigned)len);\
+       memcpy((caddr_t)&(vbptr(P)->tpv_val), (caddr_t)&src, (unsigned)len);\
 	DU->tpdu_li += len+2;/* 1 for code, 1 for length */\
 }
 /******************************************************

--- a/src-lites-1.1-2025/xkernel/mach4/api/proxy/uproxy.c
+++ b/src-lites-1.1-2025/xkernel/mach4/api/proxy/uproxy.c
@@ -44,6 +44,7 @@
 #include "xk_lproxy.h"
 #include "msg_internal.h"
 #include "proxy_util.h"
+#include <string.h>
 
 
 int	traceuproxyp;
@@ -244,7 +245,7 @@ findProxyXObj( lproxyPort, extXObj )
     xTrace2(uproxyp, TR_DETAILED,
 	    "uproxy findProxyXObj, port == %x, extXObj == %x",
 	    (int)lproxyPort, (int)extXObj);
-    bzero((char *)&key, sizeof(key));
+    memset((char *)&key, 0, sizeof(key));
     key.port = lproxyPort;
     key.xobjRef = extXObj;
     xAssert(proxyMap);
@@ -370,7 +371,7 @@ addProxyXObj( obj, port, extXObj )
     ProxyMapKey	key;
     Bind	b;
 
-    bzero((char *)&key, sizeof(key));
+    memset((char *)&key, 0, sizeof(key));
     key.port = port;
     key.xobjRef = extXObj;
     xAssert(proxyMap);

--- a/src-lites-1.1-2025/xkernel/sunos/drivers/simeth/sim_ether.c
+++ b/src-lites-1.1-2025/xkernel/sunos/drivers/simeth/sim_ether.c
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 #include <netinet/in.h>
 #include "x_stdio.h"
+#include <string.h>
 #include "xkernel.h"
 #include "eth.h"
 #include "eth_i.h"

--- a/src-lites-1.1-2025/xkernel/sunos/pxk/alloc_old.c
+++ b/src-lites-1.1-2025/xkernel/sunos/pxk/alloc_old.c
@@ -87,6 +87,7 @@ extern char *xsbrk();
 #ifdef GORP
 #include <stdio.h>
 #endif
+#include <string.h>
 
 /*  An implementation of malloc(3), free(3) using the QuickFit method.
  *  Guy Almes, May 1983.
@@ -646,7 +647,7 @@ int n, size;
   mp += (num + sizeof(long) - 1) / sizeof(long);
   for (i = 0; i < MALLOC_EXTRAS; i++) *mp++ = TAIL_MALLOC_TAG;
 #endif
-  bzero(answer, num);
+  memset(answer, 0, num);
   return answer;
 }
 


### PR DESCRIPTION
## Summary
- update FD macros to use `memcpy`/`memset`
- switch buffer clearing macro to `memset`
- add `<string.h>` where needed
- replace old BSD routines in various sources
- implement `bcmp` as a wrapper over `memcmp`

## Testing
- `true`