### PR TITLE
Update test Makefiles to honour compiler settings

### DIFF
--- a/tests/audit/Makefile
+++ b/tests/audit/Makefile
@@ -1,5 +1,7 @@
 CC ?= gcc
-CFLAGS ?= -std=gnu2x -Wall -Wextra
+# Additional compile flags from the top-level build system are appended.
+CFLAGS += -std=c23 -Wall -Wextra -Werror
+CPPFLAGS += -I../../include
 
 all: test_audit
 
@@ -7,7 +9,7 @@ all: test_audit
 .PHONY: all clean
 
 test_audit: test_audit.c ../../kern/auth.c ../../kern/audit.c
-	$(CC) $(CFLAGS) -I../../include $^ -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 clean:
-		rm -f test_audit
+	rm -f test_audit

--- a/tests/cap/Makefile
+++ b/tests/cap/Makefile
@@ -1,5 +1,7 @@
 CC ?= gcc
-CFLAGS ?= -std=gnu2x -Wall -Wextra
+# Additional compile flags from the top-level build system are appended.
+CFLAGS += -std=c23 -Wall -Wextra -Werror
+CPPFLAGS += -I../../include
 
 all: test_cap
 
@@ -7,7 +9,7 @@ all: test_cap
 .PHONY: all clean
 
 test_cap: test_cap.c ../../src-lites-1.1-2025/server/kern/cap.c ../../kern/auth.c ../../kern/audit.c
-	$(CC) $(CFLAGS) -I../../include $^ -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 clean:
-		rm -f test_cap
+	rm -f test_cap

--- a/tests/iommu/Makefile
+++ b/tests/iommu/Makefile
@@ -1,12 +1,13 @@
 CC ?= gcc
-CFLAGS ?= -std=c2x -Wall -Wextra
+# Additional compile flags from the top-level build system are appended.
+CFLAGS += -std=c23 -Wall -Wextra -Werror
 
 all: test_iommu
 
 .PHONY: all clean
 
 test_iommu: test_iommu.c ../../src-lites-1.1-2025/iommu/iommu.c
-	$(CC) $(CFLAGS) $^ -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 clean:
 	rm -f test_iommu

--- a/tests/vm_fault/Makefile
+++ b/tests/vm_fault/Makefile
@@ -1,12 +1,13 @@
 CC ?= gcc
-CFLAGS ?= -std=c2x -Wall -Wextra
+# Additional compile flags from the top-level build system are appended.
+CFLAGS += -std=c23 -Wall -Wextra -Werror
 
 all: test_vm_fault
 
 .PHONY: all clean
 
 test_vm_fault: test_vm_fault.c ../../src-lites-1.1-2025/server/vm/vm_handlers.c
-	$(CC) $(CFLAGS) $^ -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 clean:
-	 rm -f test_vm_fault
+	rm -f test_vm_fault


### PR DESCRIPTION
## Summary
- ensure each test Makefile picks up `CC` and extra flags
- build tests with `-std=c23 -Wall -Wextra -Werror`

## Testing
- `make -C tests/audit CC=clang`
- `make -C tests/cap CC=clang`
- `make -C tests/iommu CC=clang`
- `make -C tests/vm_fault CC=clang`
