### PR TITLE
Add pragma once to headers

### DIFF
--- a/src-lites-1.1-2025/include/alpha/limits.h
+++ b/src-lites-1.1-2025/include/alpha/limits.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1988, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/alpha/ptrace.h
+++ b/src-lites-1.1-2025/include/alpha/ptrace.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * None for the alpha at this time.
  */

--- a/src-lites-1.1-2025/include/alpha/stdarg.h
+++ b/src-lites-1.1-2025/include/alpha/stdarg.h
@@ -1,3 +1,4 @@
+#pragma once
 /* stdarg.h for GNU.
    Note that the type used in va_arg is supposed to match the
    actual type **after default promotions**.

--- a/src-lites-1.1-2025/include/alpha/trap.h
+++ b/src-lites-1.1-2025/include/alpha/trap.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Mach Operating System
  * Copyright (c) 1992 Carnegie Mellon University

--- a/src-lites-1.1-2025/include/i386/cpu.h
+++ b/src-lites-1.1-2025/include/i386/cpu.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/i386/exec.h
+++ b/src-lites-1.1-2025/include/i386/exec.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/i386/limits.h
+++ b/src-lites-1.1-2025/include/i386/limits.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1988, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/i386/ptrace.h
+++ b/src-lites-1.1-2025/include/i386/ptrace.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/i386/signal.h
+++ b/src-lites-1.1-2025/include/i386/signal.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1986, 1989, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/i386/trap.h
+++ b/src-lites-1.1-2025/include/i386/trap.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -94,4 +95,3 @@
 
 /* Trap's coming from user mode */
 #define	T_USER	0x100
-

--- a/src-lites-1.1-2025/include/mips/SYS.h
+++ b/src-lites-1.1-2025/include/mips/SYS.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1991, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/mips/limits.h
+++ b/src-lites-1.1-2025/include/mips/limits.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1988, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/mips/param.h
+++ b/src-lites-1.1-2025/include/mips/param.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1988 University of Utah.
  * Copyright (c) 1992, 1993

--- a/src-lites-1.1-2025/include/mips/ptrace.h
+++ b/src-lites-1.1-2025/include/mips/ptrace.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/mips/signal.h
+++ b/src-lites-1.1-2025/include/mips/signal.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/mips/trap.h
+++ b/src-lites-1.1-2025/include/mips/trap.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1988 University of Utah.
  * Copyright (c) 1992, 1993

--- a/src-lites-1.1-2025/include/mips/vmparam.h
+++ b/src-lites-1.1-2025/include/mips/vmparam.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1988 University of Utah.
  * Copyright (c) 1992, 1993

--- a/src-lites-1.1-2025/include/ns532/cpu.h
+++ b/src-lites-1.1-2025/include/ns532/cpu.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/ns532/exec.h
+++ b/src-lites-1.1-2025/include/ns532/exec.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/ns532/limits.h
+++ b/src-lites-1.1-2025/include/ns532/limits.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1988, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/ns532/param.h
+++ b/src-lites-1.1-2025/include/ns532/param.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/ns532/ptrace.h
+++ b/src-lites-1.1-2025/include/ns532/ptrace.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/ns532/signal.h
+++ b/src-lites-1.1-2025/include/ns532/signal.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1986, 1989, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/parisc/cpu.h
+++ b/src-lites-1.1-2025/include/parisc/cpu.h
@@ -1,3 +1,4 @@
+#pragma once
 /* 
  * Copyright (c) 1994, The University of Utah and
  * the Computer Systems Laboratory at the University of Utah (CSL).

--- a/src-lites-1.1-2025/include/parisc/exec.h
+++ b/src-lites-1.1-2025/include/parisc/exec.h
@@ -1,3 +1,4 @@
+#pragma once
 /* 
  * Copyright (c) 1994, The University of Utah and
  * the Center for Software Science at the University of Utah (CSS).

--- a/src-lites-1.1-2025/include/parisc/limits.h
+++ b/src-lites-1.1-2025/include/parisc/limits.h
@@ -1,3 +1,4 @@
+#pragma once
 /* 
  * Copyright (c) 1994, The University of Utah and
  * the Computer Systems Laboratory at the University of Utah (CSL).

--- a/src-lites-1.1-2025/include/parisc/param.h
+++ b/src-lites-1.1-2025/include/parisc/param.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1994, The University of Utah and
  * the Computer Systems Laboratory at the University of Utah (CSL).

--- a/src-lites-1.1-2025/include/parisc/proc.h
+++ b/src-lites-1.1-2025/include/parisc/proc.h
@@ -1,3 +1,4 @@
+#pragma once
 /* 
  * Copyright (c) 1994, The University of Utah and
  * the Computer Systems Laboratory at the University of Utah (CSL).

--- a/src-lites-1.1-2025/include/parisc/ptrace.h
+++ b/src-lites-1.1-2025/include/parisc/ptrace.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/parisc/regalias.h
+++ b/src-lites-1.1-2025/include/parisc/regalias.h
@@ -1,3 +1,4 @@
+#pragma once
 /* 
  * Copyright (c) 1994, The University of Utah and
  * the Computer Systems Laboratory at the University of Utah (CSL).

--- a/src-lites-1.1-2025/include/parisc/signal.h
+++ b/src-lites-1.1-2025/include/parisc/signal.h
@@ -1,3 +1,4 @@
+#pragma once
 /* 
  * Copyright (c) 1994, The University of Utah and
  * the Computer Systems Laboratory at the University of Utah (CSL).

--- a/src-lites-1.1-2025/include/parisc/stdarg.h
+++ b/src-lites-1.1-2025/include/parisc/stdarg.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -33,8 +34,6 @@
  *	@(#)stdarg.h	8.1 (Berkeley) 6/10/93
  */
 
-#ifndef _STDARG_H_
-#define	_STDARG_H_
 
 typedef double *va_list;
 
@@ -53,5 +52,3 @@ typedef double *va_list;
 	     (*((type *) (void *) ((char *)ap + ((8 - sizeof(type)) % 4))))))
 
 #define	va_end(ap)
-
-#endif /* !_STDARG_H */

--- a/src-lites-1.1-2025/include/parisc/trap.h
+++ b/src-lites-1.1-2025/include/parisc/trap.h
@@ -1,3 +1,4 @@
+#pragma once
 /* 
  * Copyright (c) 1994, The University of Utah and
  * the Computer Systems Laboratory at the University of Utah (CSL).

--- a/src-lites-1.1-2025/include/sys/acct.h
+++ b/src-lites-1.1-2025/include/sys/acct.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/aout.h
+++ b/src-lites-1.1-2025/include/sys/aout.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/clist.h
+++ b/src-lites-1.1-2025/include/sys/clist.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/dirent.h
+++ b/src-lites-1.1-2025/include/sys/dirent.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1989, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/disk.h
+++ b/src-lites-1.1-2025/include/sys/disk.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/dkbad.h
+++ b/src-lites-1.1-2025/include/sys/dkbad.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1982, 1986, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/dkstat.h
+++ b/src-lites-1.1-2025/include/sys/dkstat.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/domain.h
+++ b/src-lites-1.1-2025/include/sys/domain.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1982, 1986, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/exec_file.h
+++ b/src-lites-1.1-2025/include/sys/exec_file.h
@@ -1,3 +1,4 @@
+#pragma once
 /* 
  * Mach Operating System
  * Copyright (c) 1994 Johannes Helander

--- a/src-lites-1.1-2025/include/sys/fbio.h
+++ b/src-lites-1.1-2025/include/sys/fbio.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/file.h
+++ b/src-lites-1.1-2025/include/sys/file.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1982, 1986, 1989, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/filedesc.h
+++ b/src-lites-1.1-2025/include/sys/filedesc.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/ktrace.h
+++ b/src-lites-1.1-2025/include/sys/ktrace.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1988, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/map.h
+++ b/src-lites-1.1-2025/include/sys/map.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1982, 1986, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/mbuf.h
+++ b/src-lites-1.1-2025/include/sys/mbuf.h
@@ -1,3 +1,4 @@
+#pragma once
 /* 
  * Mach Operating System
  * Copyright (c) 1994 Johannes Helander

--- a/src-lites-1.1-2025/include/sys/mman.h
+++ b/src-lites-1.1-2025/include/sys/mman.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1982, 1986, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/msgbuf.h
+++ b/src-lites-1.1-2025/include/sys/msgbuf.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1981, 1984, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/mtio.h
+++ b/src-lites-1.1-2025/include/sys/mtio.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1982, 1986, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/param.h
+++ b/src-lites-1.1-2025/include/sys/param.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1982, 1986, 1989, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/protosw.h
+++ b/src-lites-1.1-2025/include/sys/protosw.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1982, 1986, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/socketvar.h
+++ b/src-lites-1.1-2025/include/sys/socketvar.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1982, 1986, 1990, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/synch.h
+++ b/src-lites-1.1-2025/include/sys/synch.h
@@ -1,3 +1,4 @@
+#pragma once
 /* 
  * Mach Operating System
  * Copyright (c) 1992 Carnegie Mellon University

--- a/src-lites-1.1-2025/include/sys/syslimits.h
+++ b/src-lites-1.1-2025/include/sys/syslimits.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1988, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/syslog.h
+++ b/src-lites-1.1-2025/include/sys/syslog.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1982, 1986, 1988, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/systm.h
+++ b/src-lites-1.1-2025/include/sys/systm.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1982, 1988, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/timeb.h
+++ b/src-lites-1.1-2025/include/sys/timeb.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1991, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/tprintf.h
+++ b/src-lites-1.1-2025/include/sys/tprintf.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/trace.h
+++ b/src-lites-1.1-2025/include/sys/trace.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1982, 1986, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/un.h
+++ b/src-lites-1.1-2025/include/sys/un.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1982, 1986, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/unpcb.h
+++ b/src-lites-1.1-2025/include/sys/unpcb.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1982, 1986, 1989, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/user.h
+++ b/src-lites-1.1-2025/include/sys/user.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1982, 1986, 1989, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/vadvise.h
+++ b/src-lites-1.1-2025/include/sys/vadvise.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1982, 1986, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/vcmd.h
+++ b/src-lites-1.1-2025/include/sys/vcmd.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1982, 1986, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/vlimit.h
+++ b/src-lites-1.1-2025/include/sys/vlimit.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1982, 1986, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/vmmeter.h
+++ b/src-lites-1.1-2025/include/sys/vmmeter.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1982, 1986, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/vsio.h
+++ b/src-lites-1.1-2025/include/sys/vsio.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1987, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/sys/wait.h
+++ b/src-lites-1.1-2025/include/sys/wait.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1982, 1986, 1989, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/x86_64/cpu.h
+++ b/src-lites-1.1-2025/include/x86_64/cpu.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/x86_64/exec.h
+++ b/src-lites-1.1-2025/include/x86_64/exec.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/x86_64/limits.h
+++ b/src-lites-1.1-2025/include/x86_64/limits.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1988, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/x86_64/ptrace.h
+++ b/src-lites-1.1-2025/include/x86_64/ptrace.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/x86_64/signal.h
+++ b/src-lites-1.1-2025/include/x86_64/signal.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright (c) 1986, 1989, 1991, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/x86_64/trap.h
+++ b/src-lites-1.1-2025/include/x86_64/trap.h
@@ -1,3 +1,4 @@
+#pragma once
 /*-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.
@@ -94,4 +95,3 @@
 
 /* Trap's coming from user mode */
 #define	T_USER	0x100
-


### PR DESCRIPTION
## Summary
- modernize headers with `#pragma once`
- drop obsolete include guards

## Testing
- `cmake -S . -B build` *(fails: Mach headers not found)*