### PR TITLE
Update test build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
+
+if(NOT DEFINED ENV{CC})
+    find_program(_clang clang)
+    if(_clang)
+        set(CMAKE_C_COMPILER ${_clang} CACHE STRING "C compiler" FORCE)
+    endif()
+endif()
+
 project(lites LANGUAGES C)
 set(CMAKE_C_STANDARD 23)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,22 +4,22 @@ add_executable(test_cap
     ../kern/auth.c
     ../kern/audit.c)
 target_include_directories(test_cap PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_compile_options(test_cap PRIVATE -std=gnu2x -Wall -Wextra)
+target_compile_options(test_cap PRIVATE -std=c23 -Wall -Werror)
 
 add_executable(test_audit
     audit/test_audit.c
     ../kern/auth.c
     ../kern/audit.c)
 target_include_directories(test_audit PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_compile_options(test_audit PRIVATE -std=gnu2x -Wall -Wextra)
+target_compile_options(test_audit PRIVATE -std=c23 -Wall -Werror)
 
 add_executable(test_iommu
     iommu/test_iommu.c
     ../src-lites-1.1-2025/iommu/iommu.c)
-target_compile_options(test_iommu PRIVATE -std=c2x -Wall -Wextra)
+target_compile_options(test_iommu PRIVATE -std=c23 -Wall -Werror)
 
 add_executable(test_vm_fault
     vm_fault/test_vm_fault.c
     ../src-lites-1.1-2025/server/vm/vm_handlers.c)
-target_compile_options(test_vm_fault PRIVATE -std=c2x -Wall -Wextra)
+target_compile_options(test_vm_fault PRIVATE -std=c23 -Wall -Werror)
 

--- a/tests/audit/Makefile
+++ b/tests/audit/Makefile
@@ -1,5 +1,7 @@
-CC ?= gcc
-CFLAGS ?= -std=gnu2x -Wall -Wextra
+ifeq ($(origin CC),default)
+CC := $(shell command -v clang >/dev/null 2>&1 && echo clang || echo gcc)
+endif
+CFLAGS ?= -std=c23 -Wall -Werror
 
 all: test_audit
 

--- a/tests/cap/Makefile
+++ b/tests/cap/Makefile
@@ -1,5 +1,7 @@
-CC ?= gcc
-CFLAGS ?= -std=gnu2x -Wall -Wextra
+ifeq ($(origin CC),default)
+CC := $(shell command -v clang >/dev/null 2>&1 && echo clang || echo gcc)
+endif
+CFLAGS ?= -std=c23 -Wall -Werror
 
 all: test_cap
 

--- a/tests/iommu/Makefile
+++ b/tests/iommu/Makefile
@@ -1,5 +1,7 @@
-CC ?= gcc
-CFLAGS ?= -std=c2x -Wall -Wextra
+ifeq ($(origin CC),default)
+CC := $(shell command -v clang >/dev/null 2>&1 && echo clang || echo gcc)
+endif
+CFLAGS ?= -std=c23 -Wall -Werror
 
 all: test_iommu
 

--- a/tests/vm_fault/Makefile
+++ b/tests/vm_fault/Makefile
@@ -1,5 +1,7 @@
-CC ?= gcc
-CFLAGS ?= -std=c2x -Wall -Wextra
+ifeq ($(origin CC),default)
+CC := $(shell command -v clang >/dev/null 2>&1 && echo clang || echo gcc)
+endif
+CFLAGS ?= -std=c23 -Wall -Werror
 
 all: test_vm_fault
 


### PR DESCRIPTION
## Summary
- use clang when available by default
- build tests with -std=c23
- treat warnings as errors

## Testing
- `make -C tests/audit -n`
- `make -C tests/cap -n`
- `make -C tests/iommu -n`
- `make -C tests/vm_fault -n`
- `cmake -S tests -B tests/build`