### PR TITLE
Introduce spin locks for scheduler

### DIFF
--- a/kern/sched.h
+++ b/kern/sched.h
@@ -2,6 +2,7 @@
 #define LITES_SCHED_H
 
 #include <cthreads.h>
+#include "spinlock.h"
 
 /* Simple MCS lock implementation used by the scheduler. */
 typedef struct mcs_lock_node {
@@ -21,5 +22,7 @@ void schedule_enqueue(cthread_t thread);
 void schedule_dequeue(cthread_t thread);
 void *scheduler_loop(void *arg);
 void scheduler_init(int num_cores);
+
+extern spinlock_t sched_lock;
 
 #endif /* LITES_SCHED_H */

--- a/kern/spinlock.h
+++ b/kern/spinlock.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <stdint.h>
+
+/* Basic spin lock used inside the kernel scheduler. */
+
+typedef struct {
+#ifdef CONFIG_TICKET_LOCK
+    volatile uint32_t next;
+    volatile uint32_t owner;
+#else
+    volatile int locked;
+#endif
+} spinlock_t;
+
+static inline void spin_lock_init(spinlock_t *l)
+{
+#ifdef CONFIG_TICKET_LOCK
+    l->next = 0;
+    l->owner = 0;
+#else
+    l->locked = 0;
+#endif
+}
+
+static inline void spin_lock(spinlock_t *l)
+{
+#ifdef CONFIG_TICKET_LOCK
+    uint32_t ticket = __sync_fetch_and_add(&l->next, 1);
+    while (__sync_val_compare_and_swap(&l->owner, ticket, ticket) != ticket)
+        ;
+#else
+    while (__sync_lock_test_and_set(&l->locked, 1))
+        ;
+#endif
+}
+
+static inline void spin_unlock(spinlock_t *l)
+{
+#ifdef CONFIG_TICKET_LOCK
+    __sync_fetch_and_add(&l->owner, 1);
+#else
+    __sync_lock_release(&l->locked);
+#endif
+}
+


### PR DESCRIPTION
## Summary
- add a simple spinlock implementation
- use the new spinlock in the scheduler
- export a global `sched_lock` for future use

## Testing
- `make -f Makefile.new test` *(fails: Mach headers not found)*