### PR TITLE
Remove deprecated BSD integer aliases

### DIFF
--- a/src-lites-1.1-2025/include/alpha/types.h
+++ b/src-lites-1.1-2025/include/alpha/types.h
@@ -41,17 +41,5 @@
 #pragma once
 
 #include <mach/alpha/vm_types.h>
-
-/*
- * Basic integral types.  Omit the typedef if
- * not possible for a machine/compiler combination.
- */
-typedef	signed char		   int8_t;
-typedef	unsigned char		 u_int8_t;
-typedef	short			  int16_t;
-typedef	unsigned short		u_int16_t;
-typedef	int			  int32_t;
-typedef	unsigned int		u_int32_t;
-typedef	long			  int64_t;
-typedef	unsigned long		u_int64_t;
+#include <stdint.h>
 

--- a/src-lites-1.1-2025/include/i386/types.h
+++ b/src-lites-1.1-2025/include/i386/types.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <mach/machine/vm_types.h>
+#include <stdint.h>
 
 #if !defined(_ANSI_SOURCE) && !defined(_POSIX_SOURCE)
 typedef struct _physadr {
@@ -46,17 +47,4 @@ typedef struct label_t {
 	int val[6];
 } label_t;
 #endif
-
-/*
- * Basic integral types.  Omit the typedef if
- * not possible for a machine/compiler combination.
- */
-typedef	signed char		   int8_t;
-typedef	unsigned char		 u_int8_t;
-typedef	short			  int16_t;
-typedef	unsigned short		u_int16_t;
-typedef	int			  int32_t;
-typedef	unsigned int		u_int32_t;
-typedef	long long		  int64_t;
-typedef	unsigned long long	u_int64_t;
 

--- a/src-lites-1.1-2025/include/mips/cpu.h
+++ b/src-lites-1.1-2025/include/mips/cpu.h
@@ -1,3 +1,4 @@
+#include <stdint.h>
 /*-
  * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.

--- a/src-lites-1.1-2025/include/mips/param.h
+++ b/src-lites-1.1-2025/include/mips/param.h
@@ -1,3 +1,4 @@
+#include <stdint.h>
 /*
  * Copyright (c) 1988 University of Utah.
  * Copyright (c) 1992, 1993

--- a/src-lites-1.1-2025/include/mips/types.h
+++ b/src-lites-1.1-2025/include/mips/types.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <mach/machine/vm_types.h>
+#include <stdint.h>
 
 #if !defined(_ANSI_SOURCE) && !defined(_POSIX_SOURCE)
 typedef struct _physadr {
@@ -46,17 +47,4 @@ typedef struct label_t {
 	int val[6];
 } label_t;
 #endif
-
-/*
- * Basic integral types.  Omit the typedef if
- * not possible for a machine/compiler combination.
- */
-typedef	signed char		   int8_t;
-typedef	unsigned char		 u_int8_t;
-typedef	short			  int16_t;
-typedef	unsigned short		u_int16_t;
-typedef	int			  int32_t;
-typedef	unsigned int		u_int32_t;
-typedef	long long		  int64_t;
-typedef	unsigned long long	u_int64_t;
 

--- a/src-lites-1.1-2025/include/mips/vmparam.h
+++ b/src-lites-1.1-2025/include/mips/vmparam.h
@@ -1,3 +1,4 @@
+#include <stdint.h>
 /*
  * Copyright (c) 1988 University of Utah.
  * Copyright (c) 1992, 1993

--- a/src-lites-1.1-2025/include/ns532/types.h
+++ b/src-lites-1.1-2025/include/ns532/types.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <mach/machine/vm_types.h>
+#include <stdint.h>
 
 #if !defined(_ANSI_SOURCE) && !defined(_POSIX_SOURCE)
 typedef struct _physadr {
@@ -46,17 +47,4 @@ typedef struct label_t {
 	int val[6];
 } label_t;
 #endif
-
-/*
- * Basic integral types.  Omit the typedef if
- * not possible for a machine/compiler combination.
- */
-typedef	signed char		   int8_t;
-typedef	unsigned char		 u_int8_t;
-typedef	short			  int16_t;
-typedef	unsigned short		u_int16_t;
-typedef	int			  int32_t;
-typedef	unsigned int		u_int32_t;
-typedef	long long		  int64_t;
-typedef	unsigned long long	u_int64_t;
 

--- a/src-lites-1.1-2025/include/parisc/types.h
+++ b/src-lites-1.1-2025/include/parisc/types.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <mach/machine/vm_types.h>
+#include <stdint.h>
 
 #if !defined(_ANSI_SOURCE) && !defined(_POSIX_SOURCE)
 typedef struct _physadr {
@@ -66,18 +67,4 @@ typedef	float			f4byte_t;
 typedef	double			f8byte_t;
 #endif
 
-/*
- * Basic integral types.  Omit the typedef if
- * not possible for a machine/compiler combination.
- */
-typedef	signed char		   int8_t;
-typedef	unsigned char		 u_int8_t;
-typedef	short			  int16_t;
-typedef	unsigned short		u_int16_t;
-typedef	int			  int32_t;
-typedef	unsigned int		u_int32_t;
-#ifdef __GNUC__
-typedef	long long		  int64_t;
-typedef	unsigned long long	u_int64_t;
-#endif
 

--- a/src-lites-1.1-2025/include/sys/types.h
+++ b/src-lites-1.1-2025/include/sys/types.h
@@ -44,26 +44,21 @@
 #include <machine/endian.h>
 #include <machine/ansi.h>
 #include <machine/types.h>
+#include <stdint.h>
 
 #ifndef _POSIX_SOURCE
-typedef	unsigned char	u_char;
-typedef	unsigned short	u_short;
-typedef	unsigned int	u_int;
-typedef	unsigned long	u_long;
-typedef	unsigned short	ushort;		/* Sys V compatibility */
-typedef	unsigned int	uint;		/* Sys V compatibility */
 #endif
 
-typedef	u_int64_t	u_quad_t;	/* quads */
+typedef	uint64_t	u_quad_t;	/* quads */
 typedef	int64_t		quad_t;
 typedef	quad_t *	qaddr_t;
 
 typedef	char *		caddr_t;	/* core address */
 typedef	int32_t		daddr_t;	/* disk address */
-typedef	u_int32_t	dev_t;		/* device number */
+typedef	uint32_t	dev_t;		/* device number */
 typedef unsigned long	fixpt_t;	/* fixed point number */
-typedef	u_int32_t	gid_t;		/* group id */
-typedef	u_int32_t	ino_t;		/* inode number */
+typedef	uint32_t	gid_t;		/* group id */
+typedef	uint32_t	ino_t;		/* inode number */
 #ifdef alpha
 typedef	unsigned int	mode_t;		/* permissions */
 #else
@@ -74,7 +69,7 @@ typedef	quad_t		off_t;		/* file offset */
 typedef	int32_t		pid_t;		/* process id */
 typedef	long		segsz_t;	/* segment size */
 typedef	long		swblk_t;	/* swap offset */
-typedef	u_int32_t	uid_t;		/* user id */
+typedef	uint32_t	uid_t;		/* user id */
 
 /*
  * This belongs in unistd.h, but is placed here to ensure that programs
@@ -91,11 +86,11 @@ __END_DECLS
 
 #ifndef _POSIX_SOURCE
 #ifdef alpha
-#define major(x)	((u_int)(((dev_t)(x) >> 20)&0xfff))
-#define minor(x)	((u_int)((x)&0xfffff))
+#define major(x)	((uint32_t)(((dev_t)(x) >> 20)&0xfff))
+#define minor(x)	((uint32_t)((x)&0xfffff))
 #define makedev(x,y)	((dev_t)(((x)<<20) | (y)))
 #else
-#define	major(x)	((int)(((u_int)(x) >> 8)&0xff))	/* major number */
+#define	major(x)	((int)(((uint32_t)(x) >> 8)&0xff))	/* major number */
 #ifdef 	DISKSLICE
 /*
  * minor() gives a cookie instead of an index since we don't want to

--- a/src-lites-1.1-2025/include/x86_64/types.h
+++ b/src-lites-1.1-2025/include/x86_64/types.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <mach/machine/vm_types.h>
+#include <stdint.h>
 
 #if !defined(_ANSI_SOURCE) && !defined(_POSIX_SOURCE)
 typedef struct _physadr {
@@ -46,17 +47,4 @@ typedef struct label_t {
 	int val[6];
 } label_t;
 #endif
-
-/*
- * Basic integral types.  Omit the typedef if
- * not possible for a machine/compiler combination.
- */
-typedef	signed char		   int8_t;
-typedef	unsigned char		 u_int8_t;
-typedef	short			  int16_t;
-typedef	unsigned short		u_int16_t;
-typedef	int			  int32_t;
-typedef	unsigned int		u_int32_t;
-typedef	long long		  int64_t;
-typedef	unsigned long long	u_int64_t;
 


### PR DESCRIPTION
## Summary
- drop old BSD typedefs from `sys/types.h`
- include `<stdint.h>` in architecture-specific headers
- remove BSD integer typedefs from architecture `types.h` files

## Testing
- `make -f Makefile.new -n` *(fails: Mach headers not found)*