### PR TITLE
Add header consolidation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,3 +197,10 @@ Build and run it with:
 make -f Makefile.new test
 ./tests/vm_fault/test_vm_fault
 ```
+
+## Header consolidation
+A helper script `scripts/move_all_headers.sh` is provided to move all `*.h` files
+from the repository into `src-lites-1.1-2025/include/all_headers` while
+preserving their original relative paths. This operation is destructive and
+should only be run for analysis purposes.
+

--- a/scripts/move_all_headers.sh
+++ b/scripts/move_all_headers.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Move all header files from the repository into the Lites source include
+# directory while preserving their relative paths. This script can be used to
+# consolidate headers for analysis purposes.
+
+set -euo pipefail
+
+TARGET_BASE="src-lites-1.1-2025/include/all_headers"
+
+# Create the destination base directory
+mkdir -p "$TARGET_BASE"
+
+# Find every .h file outside of the target directory and move it preserving
+# the original path structure under the target base.
+find . -path "./$TARGET_BASE/*" -prune -o -name '*.h' -print | while read -r file; do
+  relpath="${file#./}"
+  dest="$TARGET_BASE/$relpath"
+  mkdir -p "$(dirname "$dest")"
+  git mv "$file" "$dest"
+done


### PR DESCRIPTION
## Summary
- add `scripts/move_all_headers.sh` to relocate all headers under a single folder
- document the script in README

## Testing
- `bash -n scripts/move_all_headers.sh`
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`