### PR TITLE
Switch to clang and update headers

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y clang lld llvm
+# set clang as default C compiler
+export CC=clang
+export CXX=clang++

--- a/src-lites-1.1-2025/include/alpha/types.h
+++ b/src-lites-1.1-2025/include/alpha/types.h
@@ -41,17 +41,10 @@
 #pragma once
 
 #include <mach/alpha/vm_types.h>
+#include <stdint.h>
 
 /*
  * Basic integral types.  Omit the typedef if
  * not possible for a machine/compiler combination.
  */
-typedef	signed char		   int8_t;
-typedef	unsigned char		 u_int8_t;
-typedef	short			  int16_t;
-typedef	unsigned short		u_int16_t;
-typedef	int			  int32_t;
-typedef	unsigned int		u_int32_t;
-typedef	long			  int64_t;
-typedef	unsigned long		u_int64_t;
 

--- a/src-lites-1.1-2025/include/i386/types.h
+++ b/src-lites-1.1-2025/include/i386/types.h
@@ -37,6 +37,7 @@
 
 #include <mach/machine/vm_types.h>
 
+#include <stdint.h>
 #if !defined(_ANSI_SOURCE) && !defined(_POSIX_SOURCE)
 typedef struct _physadr {
 	int r[1];
@@ -51,12 +52,4 @@ typedef struct label_t {
  * Basic integral types.  Omit the typedef if
  * not possible for a machine/compiler combination.
  */
-typedef	signed char		   int8_t;
-typedef	unsigned char		 u_int8_t;
-typedef	short			  int16_t;
-typedef	unsigned short		u_int16_t;
-typedef	int			  int32_t;
-typedef	unsigned int		u_int32_t;
-typedef	long long		  int64_t;
-typedef	unsigned long long	u_int64_t;
 

--- a/src-lites-1.1-2025/include/mips/types.h
+++ b/src-lites-1.1-2025/include/mips/types.h
@@ -37,6 +37,7 @@
 
 #include <mach/machine/vm_types.h>
 
+#include <stdint.h>
 #if !defined(_ANSI_SOURCE) && !defined(_POSIX_SOURCE)
 typedef struct _physadr {
 	int r[1];
@@ -51,12 +52,4 @@ typedef struct label_t {
  * Basic integral types.  Omit the typedef if
  * not possible for a machine/compiler combination.
  */
-typedef	signed char		   int8_t;
-typedef	unsigned char		 u_int8_t;
-typedef	short			  int16_t;
-typedef	unsigned short		u_int16_t;
-typedef	int			  int32_t;
-typedef	unsigned int		u_int32_t;
-typedef	long long		  int64_t;
-typedef	unsigned long long	u_int64_t;
 

--- a/src-lites-1.1-2025/include/ns532/types.h
+++ b/src-lites-1.1-2025/include/ns532/types.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <mach/machine/vm_types.h>
+#include <stdint.h>
 
 #if !defined(_ANSI_SOURCE) && !defined(_POSIX_SOURCE)
 typedef struct _physadr {
@@ -51,12 +52,4 @@ typedef struct label_t {
  * Basic integral types.  Omit the typedef if
  * not possible for a machine/compiler combination.
  */
-typedef	signed char		   int8_t;
-typedef	unsigned char		 u_int8_t;
-typedef	short			  int16_t;
-typedef	unsigned short		u_int16_t;
-typedef	int			  int32_t;
-typedef	unsigned int		u_int32_t;
-typedef	long long		  int64_t;
-typedef	unsigned long long	u_int64_t;
 

--- a/src-lites-1.1-2025/include/parisc/types.h
+++ b/src-lites-1.1-2025/include/parisc/types.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <mach/machine/vm_types.h>
+#include <stdint.h>
 
 #if !defined(_ANSI_SOURCE) && !defined(_POSIX_SOURCE)
 typedef struct _physadr {
@@ -70,14 +71,4 @@ typedef	double			f8byte_t;
  * Basic integral types.  Omit the typedef if
  * not possible for a machine/compiler combination.
  */
-typedef	signed char		   int8_t;
-typedef	unsigned char		 u_int8_t;
-typedef	short			  int16_t;
-typedef	unsigned short		u_int16_t;
-typedef	int			  int32_t;
-typedef	unsigned int		u_int32_t;
-#ifdef __GNUC__
-typedef	long long		  int64_t;
-typedef	unsigned long long	u_int64_t;
-#endif
 

--- a/src-lites-1.1-2025/include/sys/types.h
+++ b/src-lites-1.1-2025/include/sys/types.h
@@ -45,14 +45,6 @@
 #include <machine/ansi.h>
 #include <machine/types.h>
 
-#ifndef _POSIX_SOURCE
-typedef	unsigned char	u_char;
-typedef	unsigned short	u_short;
-typedef	unsigned int	u_int;
-typedef	unsigned long	u_long;
-typedef	unsigned short	ushort;		/* Sys V compatibility */
-typedef	unsigned int	uint;		/* Sys V compatibility */
-#endif
 
 typedef	u_int64_t	u_quad_t;	/* quads */
 typedef	int64_t		quad_t;
@@ -89,23 +81,6 @@ off_t	 lseek (int, off_t, int);
 __END_DECLS
 #endif
 
-#ifndef _POSIX_SOURCE
-#ifdef alpha
-#define major(x)	((u_int)(((dev_t)(x) >> 20)&0xfff))
-#define minor(x)	((u_int)((x)&0xfffff))
-#define makedev(x,y)	((dev_t)(((x)<<20) | (y)))
-#else
-#define	major(x)	((int)(((u_int)(x) >> 8)&0xff))	/* major number */
-#ifdef 	DISKSLICE
-/*
- * minor() gives a cookie instead of an index since we don't want to
- * change the meanings of bits 0-15 or waste time and space shifting
- * bits 16-31 for devices that don't use them.
- */
-#define	minor(x)	((int)((x)&0xffff00ff))		/* minor number */
-#else	/* !DISKSLICE */
-#define	minor(x)	((int)((x)&0xff))		/* minor number */
-#endif	/* !DISKSLICE */
 #define	makedev(x,y)	((dev_t)(((x)<<8) | (y)))	/* create dev_t */
 #endif
 #endif /* alpha */
@@ -130,18 +105,6 @@ typedef	_BSD_TIME_T_	time_t;
 #undef	_BSD_TIME_T_
 #endif
 
-#ifndef _POSIX_SOURCE
-#define	NBBY	8		/* number of bits in a byte */
-
-/*
- * Select uses bit masks of file descriptors in longs.  These macros
- * manipulate such bit fields (the filesystem macros use chars).
- * FD_SETSIZE may be defined by the user, but the default here should
- * be enough for most uses.
- */
-#ifndef	FD_SETSIZE
-#define	FD_SETSIZE	256
-#endif
 
 typedef long	fd_mask;
 #define NFDBITS	(sizeof(fd_mask) * NBBY)	/* bits per mask */

--- a/src-lites-1.1-2025/include/x86_64/types.h
+++ b/src-lites-1.1-2025/include/x86_64/types.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <mach/machine/vm_types.h>
+#include <stdint.h>
 
 #if !defined(_ANSI_SOURCE) && !defined(_POSIX_SOURCE)
 typedef struct _physadr {
@@ -51,12 +52,4 @@ typedef struct label_t {
  * Basic integral types.  Omit the typedef if
  * not possible for a machine/compiler combination.
  */
-typedef	signed char		   int8_t;
-typedef	unsigned char		 u_int8_t;
-typedef	short			  int16_t;
-typedef	unsigned short		u_int16_t;
-typedef	int			  int32_t;
-typedef	unsigned int		u_int32_t;
-typedef	long long		  int64_t;
-typedef	unsigned long long	u_int64_t;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,22 +4,22 @@ add_executable(test_cap
     ../kern/auth.c
     ../kern/audit.c)
 target_include_directories(test_cap PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_compile_options(test_cap PRIVATE -std=gnu2x -Wall -Wextra)
+target_compile_options(test_cap PRIVATE -std=c23 -Wall -Wextra -Werror)
 
 add_executable(test_audit
     audit/test_audit.c
     ../kern/auth.c
     ../kern/audit.c)
 target_include_directories(test_audit PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_compile_options(test_audit PRIVATE -std=gnu2x -Wall -Wextra)
+target_compile_options(test_audit PRIVATE -std=c23 -Wall -Wextra -Werror)
 
 add_executable(test_iommu
     iommu/test_iommu.c
     ../src-lites-1.1-2025/iommu/iommu.c)
-target_compile_options(test_iommu PRIVATE -std=c2x -Wall -Wextra)
+target_compile_options(test_iommu PRIVATE -std=c23 -Wall -Wextra -Werror)
 
 add_executable(test_vm_fault
     vm_fault/test_vm_fault.c
     ../src-lites-1.1-2025/server/vm/vm_handlers.c)
-target_compile_options(test_vm_fault PRIVATE -std=c2x -Wall -Wextra)
+target_compile_options(test_vm_fault PRIVATE -std=c23 -Wall -Wextra -Werror)
 


### PR DESCRIPTION
## Summary
- default to clang in setup
- build tests with `-std=c23` and `-Werror`
- drop legacy typedefs from `sys/types.h`
- rely on `<stdint.h>` in architecture headers

## Testing
- `pre-commit` *(fails: `pre-commit: command not found`)*
- `cmake -B build -DARCH=x86_64` *(fails: Mach headers not found)*
- `make -C tests/cap` *(fails: unrecognized command-line option `-std=c23`)*
