### PR TITLE
Add POSIX helper wrappers and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,9 @@ The helpers expect the binaries produced by `Makefile.new` in the repository
 root and require the corresponding `qemu-system` binary in `PATH`.
 
 Additional notes are kept in [`docs/`](docs/).  The mailbox-based IPC
-wrappers are described in [docs/IPC.md](docs/IPC.md).
+wrappers are described in [docs/IPC.md](docs/IPC.md).  Helper wrappers
+for common POSIX operations are documented in
+[docs/POSIX.md](docs/POSIX.md).
 
 ## Tests
 

--- a/bin/posix-demo.c
+++ b/bin/posix-demo.c
@@ -1,0 +1,47 @@
+/**
+ * Lites repository license applies to this file; see the LICENSE file
+ * in the project root for details.
+ */
+
+#include "posix_wrap.h"
+
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+
+int main(void) {
+    char cwd[256];
+    lx_getcwd(cwd, sizeof(cwd));
+    printf("cwd: %s\n", cwd);
+
+    int fd = open("demo.tmp", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        perror("open");
+        return 1;
+    }
+    write(fd, "hello", 5);
+    close(fd);
+
+    if (lx_link("demo.tmp", "demo.lnk") != 0) {
+        perror("link");
+    }
+
+    if (lx_unlink("demo.tmp") != 0) {
+        perror("unlink");
+    }
+
+    char *args[] = {"echo", "done", NULL};
+    char *env[] = {"PATH=/bin:/usr/bin", NULL};
+    pid_t pid = fork();
+    if (pid == 0) {
+        lx_execvep("echo", args, env);
+        _exit(1);
+    }
+    lx_waitpid(pid, NULL, 0);
+
+    lx_unlink("demo.lnk");
+    return 0;
+}

--- a/docs/POSIX.md
+++ b/docs/POSIX.md
@@ -1,0 +1,55 @@
+# POSIX helpers
+
+A small collection of convenience wrappers lives in
+`src-lites-1.1-2025/liblites/posix_wrap.c` and the associated header
+`src-lites-1.1-2025/include/posix_wrap.h`.
+
+```c
+int lx_link(const char *oldpath, const char *newpath);
+int lx_unlink(const char *path);
+char *lx_getcwd(char *buf, size_t size);
+int lx_chdir(const char *path);
+int lx_execvep(const char *file, char *const argv[], char *const envp[]);
+
+pid_t lx_waitpid(pid_t pid, int *status, int options);
+pid_t lx_wait(int *status);
+
+int lx_socket_cloexec(int domain, int type, int protocol);
+int lx_accept_cloexec(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
+int lx_send_fd(int sockfd, int fd);
+int lx_recv_fd(int sockfd);
+```
+
+`lx_link`, `lx_unlink`, `lx_getcwd` and `lx_chdir` simply retry the
+underlying system call when it fails with `EINTR`.
+
+`lx_execvep` behaves like `execvpe`: when the file name does not contain a
+slash it searches the `PATH` environment variable (either from `envp` or
+from the current process) for an executable and then calls `execve`.
+
+`lx_waitpid` and `lx_wait` wrap the standard waiting functions and ignore
+`EINTR` interruptions.
+
+The socket helpers create or accept descriptors with the close-on-exec
+flag and provide a simple way to send and receive file descriptors over a
+UNIX domain socket.
+
+## Example
+
+```c
+#include "posix_wrap.h"
+
+int main(void) {
+    char *args[] = {"echo", "hi", NULL};
+    char *env[] = {"PATH=/bin:/usr/bin", NULL};
+    lx_execvep("echo", args, env);
+    return 0; /* only reached on error */
+}
+```
+
+Compile manually with:
+
+```sh
+cc -I src-lites-1.1-2025/include \
+    src-lites-1.1-2025/liblites/posix_wrap.c bin/posix-demo.c -o posix-demo
+```

--- a/headers_inventory.csv
+++ b/headers_inventory.csv
@@ -915,3 +915,4 @@ path
 ./src-lites-1.1-2025/xkernel/util/make/gmake-3.66/rule.h
 ./src-lites-1.1-2025/xkernel/util/make/gmake-3.66/signame.h
 ./src-lites-1.1-2025/xkernel/util/make/gmake-3.66/variable.h
+./src-lites-1.1-2025/include/posix_wrap.h

--- a/src-lites-1.1-2025/include/posix_wrap.h
+++ b/src-lites-1.1-2025/include/posix_wrap.h
@@ -1,0 +1,22 @@
+#ifndef POSIX_WRAP_H
+#define POSIX_WRAP_H
+
+#include <stddef.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+
+int lx_link(const char *oldpath, const char *newpath);
+int lx_unlink(const char *path);
+char *lx_getcwd(char *buf, size_t size);
+int lx_chdir(const char *path);
+int lx_execvep(const char *file, char *const argv[], char *const envp[]);
+
+pid_t lx_waitpid(pid_t pid, int *status, int options);
+pid_t lx_wait(int *status);
+
+int lx_socket_cloexec(int domain, int type, int protocol);
+int lx_accept_cloexec(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
+int lx_send_fd(int sockfd, int fd);
+int lx_recv_fd(int sockfd);
+
+#endif /* POSIX_WRAP_H */

--- a/src-lites-1.1-2025/liblites/posix_wrap.c
+++ b/src-lites-1.1-2025/liblites/posix_wrap.c
@@ -1,0 +1,204 @@
+#include "posix_wrap.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <limits.h>
+#include <sys/wait.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+
+int lx_link(const char *oldpath, const char *newpath)
+{
+    int r;
+    do {
+        r = link(oldpath, newpath);
+    } while (r < 0 && errno == EINTR);
+    return r;
+}
+
+int lx_unlink(const char *path)
+{
+    int r;
+    do {
+        r = unlink(path);
+    } while (r < 0 && errno == EINTR);
+    return r;
+}
+
+char *lx_getcwd(char *buf, size_t size)
+{
+    char *r;
+    do {
+        r = getcwd(buf, size);
+    } while (!r && errno == EINTR);
+    return r;
+}
+
+int lx_chdir(const char *path)
+{
+    int r;
+    do {
+        r = chdir(path);
+    } while (r < 0 && errno == EINTR);
+    return r;
+}
+
+static const char *find_in_path(const char *file, char *buf, size_t buflen, const char *path)
+{
+    const char *start = path;
+    while (start && *start) {
+        const char *colon = strchr(start, ':');
+        size_t len = colon ? (size_t)(colon - start) : strlen(start);
+        if (len + 1 + strlen(file) + 1 < buflen) {
+            memcpy(buf, start, len);
+            buf[len] = '/';
+            strcpy(buf + len + 1, file);
+            if (access(buf, X_OK) == 0)
+                return buf;
+        }
+        if (!colon)
+            break;
+        start = colon + 1;
+    }
+    return NULL;
+}
+
+static const char *env_lookup(char *const envp[], const char *name)
+{
+    size_t nlen = strlen(name);
+    if (envp) {
+        for (char *const *p = envp; *p; ++p) {
+            if (strncmp(*p, name, nlen) == 0 && (*p)[nlen] == '=')
+                return *p + nlen + 1;
+        }
+    }
+    const char *val = getenv(name);
+    return val;
+}
+
+int lx_execvep(const char *file, char *const argv[], char *const envp[])
+{
+    if (strchr(file, '/'))
+        return execve(file, argv, envp);
+
+    const char *path = env_lookup(envp, "PATH");
+    if (!path)
+        path = "/bin:/usr/bin";
+
+    char buf[PATH_MAX];
+    const char *full = find_in_path(file, buf, sizeof(buf), path);
+    if (full)
+        return execve(full, argv, envp);
+    errno = ENOENT;
+    return -1;
+}
+
+pid_t lx_waitpid(pid_t pid, int *status, int options)
+{
+    pid_t r;
+    do {
+        r = waitpid(pid, status, options);
+    } while (r < 0 && errno == EINTR);
+    return r;
+}
+
+pid_t lx_wait(int *status)
+{
+    return lx_waitpid(-1, status, 0);
+}
+
+static int set_cloexec(int fd)
+{
+    int flags = fcntl(fd, F_GETFD);
+    if (flags < 0)
+        return -1;
+    return fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+}
+
+int lx_socket_cloexec(int domain, int type, int protocol)
+{
+#ifdef SOCK_CLOEXEC
+    int fd;
+    do {
+        fd = socket(domain, type | SOCK_CLOEXEC, protocol);
+    } while (fd < 0 && errno == EINTR);
+    if (fd >= 0 || errno != EINVAL)
+        return fd;
+#endif
+    int fd;
+    do {
+        fd = socket(domain, type, protocol);
+    } while (fd < 0 && errno == EINTR);
+    if (fd >= 0)
+        set_cloexec(fd);
+    return fd;
+}
+
+int lx_accept_cloexec(int sockfd, struct sockaddr *addr, socklen_t *len)
+{
+#ifdef SOCK_CLOEXEC
+    int fd;
+    do {
+        fd = accept4(sockfd, addr, len, SOCK_CLOEXEC);
+    } while (fd < 0 && errno == EINTR);
+    if (fd >= 0 || errno != ENOSYS)
+        return fd;
+#endif
+    int fd;
+    do {
+        fd = accept(sockfd, addr, len);
+    } while (fd < 0 && errno == EINTR);
+    if (fd >= 0)
+        set_cloexec(fd);
+    return fd;
+}
+
+int lx_send_fd(int sockfd, int fd)
+{
+    struct msghdr msg = {0};
+    char buf = 'x';
+    struct iovec io = {&buf, 1};
+    msg.msg_iov = &io;
+    msg.msg_iovlen = 1;
+    char cbuf[CMSG_SPACE(sizeof(int))];
+    msg.msg_control = cbuf;
+    msg.msg_controllen = sizeof(cbuf);
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type = SCM_RIGHTS;
+    cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+    memcpy(CMSG_DATA(cmsg), &fd, sizeof(int));
+    ssize_t n;
+    do {
+        n = sendmsg(sockfd, &msg, 0);
+    } while (n < 0 && errno == EINTR);
+    return n == 1 ? 0 : -1;
+}
+
+int lx_recv_fd(int sockfd)
+{
+    struct msghdr msg = {0};
+    char buf;
+    struct iovec io = {&buf, 1};
+    msg.msg_iov = &io;
+    msg.msg_iovlen = 1;
+    char cbuf[CMSG_SPACE(sizeof(int))];
+    msg.msg_control = cbuf;
+    msg.msg_controllen = sizeof(cbuf);
+    ssize_t n;
+    do {
+        n = recvmsg(sockfd, &msg, 0);
+    } while (n < 0 && errno == EINTR);
+    if (n <= 0)
+        return -1;
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+    if (!cmsg || cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_RIGHTS)
+        return -1;
+    int fd;
+    memcpy(&fd, CMSG_DATA(cmsg), sizeof(int));
+    return fd;
+}
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,3 +23,10 @@ add_executable(test_vm_fault
     ../src-lites-1.1-2025/server/vm/vm_handlers.c)
 target_compile_options(test_vm_fault PRIVATE -std=c23 -Wall -Wextra -Werror)
 
+add_executable(test_posix
+    posix/test_posix.c
+    ../src-lites-1.1-2025/liblites/posix_wrap.c)
+target_include_directories(test_posix PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src-lites-1.1-2025/include)
+target_compile_options(test_posix PRIVATE -std=c23 -Wall -Wextra -Werror)
+

--- a/tests/posix/Makefile
+++ b/tests/posix/Makefile
@@ -1,0 +1,14 @@
+CC ?= gcc
+CFLAGS += -std=c23 -Wall -Wextra -Werror
+CPPFLAGS += -I../../src-lites-1.1-2025/include
+
+all: test_posix
+
+.PHONY: all clean
+
+test_posix: test_posix.c ../../src-lites-1.1-2025/liblites/posix_wrap.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+
+clean:
+	rm -f test_posix

--- a/tests/posix/test_posix.c
+++ b/tests/posix/test_posix.c
@@ -1,0 +1,48 @@
+#include "../../src-lites-1.1-2025/include/posix_wrap.h"
+#include <assert.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+
+int main(void) {
+    char file[] = "tfileXXXXXX";
+    int fd = mkstemp(file);
+    assert(fd >= 0);
+    close(fd);
+
+    assert(lx_link(file, "tlink") == 0);
+    assert(lx_unlink(file) == 0);
+    assert(access("tlink", F_OK) == 0);
+
+    char buf[256];
+    assert(lx_getcwd(buf, sizeof(buf)));
+    assert(lx_chdir(".") == 0);
+
+    pid_t pid = fork();
+    assert(pid >= 0);
+    if (pid == 0) {
+        char *args[] = {"true", NULL};
+        char *env[] = {"PATH=/bin:/usr/bin", NULL};
+        lx_execvep("true", args, env);
+        _exit(1);
+    }
+    assert(lx_waitpid(pid, NULL, 0) == pid);
+
+    assert(lx_unlink("tlink") == 0);
+
+    int sv[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
+    int dupfd = dup(sv[0]);
+    assert(dupfd >= 0);
+    assert(lx_send_fd(sv[0], dupfd) == 0);
+    close(dupfd);
+    int recvfd = lx_recv_fd(sv[1]);
+    assert(recvfd >= 0);
+    close(recvfd);
+    close(sv[0]);
+    close(sv[1]);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement wrappers for link/unlink/getcwd/chdir/execve with PATH search
- add waiting helpers and socket utilities
- document the new POSIX helper API
- provide a demo program and unit test exercising the wrappers

## Testing
- `make -f Makefile.new test` *(fails: Mach headers not found)*
- `make -C tests/posix` *(fails: missing separator earlier; fixed, but build requires headers)*
