### PR TITLE
Add simple dir iteration helpers

### DIFF
--- a/include/dirent.h
+++ b/include/dirent.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <stddef.h>
+#include <stdint.h>
+
+struct dirent {
+    uint64_t d_fileno;
+    unsigned short d_reclen;
+    unsigned char d_type;
+    unsigned char d_namlen;
+    char d_name[255 + 1];
+};
+
+#define DT_UNKNOWN 0
+#define DT_FIFO 1
+#define DT_CHR 2
+#define DT_DIR 4
+#define DT_BLK 6
+#define DT_REG 8
+#define DT_LNK 10
+#define DT_SOCK 12
+
+struct memfs_node;
+
+typedef struct DIR {
+    const struct memfs_node *node;
+    size_t index;
+} DIR;
+
+DIR *opendir(const char *path);
+struct dirent *readdir(DIR *dirp);
+void rewinddir(DIR *dirp);
+int closedir(DIR *dirp);

--- a/src-lites-1.1-2025/liblites/memfs.c
+++ b/src-lites-1.1-2025/liblites/memfs.c
@@ -1,0 +1,65 @@
+#include "../../include/dirent.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+struct memfs_node {
+    const char *name;
+    unsigned char type;
+    const struct memfs_node *children;
+    size_t child_count;
+};
+
+static const struct memfs_node sub_nodes[] = {
+    {"nested.txt", DT_REG, NULL, 0},
+};
+
+static const struct memfs_node root_nodes[] = {
+    {"hello.txt", DT_REG, NULL, 0},
+    {"sub", DT_DIR, sub_nodes, 1},
+};
+
+static const struct memfs_node root_node = {"/", DT_DIR, root_nodes, 2};
+
+DIR *opendir(const char *path) {
+    if (!path || strcmp(path, "/") != 0) {
+        return NULL;
+    }
+    DIR *d = malloc(sizeof(DIR));
+    if (!d) {
+        return NULL;
+    }
+    d->node = &root_node;
+    d->index = 0;
+    return d;
+}
+
+static struct dirent d_buf;
+
+struct dirent *readdir(DIR *d) {
+    if (!d || d->index >= d->node->child_count) {
+        return NULL;
+    }
+    const struct memfs_node *ent = &d->node->children[d->index++];
+    d_buf.d_fileno = d->index;
+    d_buf.d_reclen = sizeof(struct dirent);
+    d_buf.d_type = ent->type;
+    d_buf.d_namlen = strlen(ent->name);
+    strncpy(d_buf.d_name, ent->name, sizeof(d_buf.d_name) - 1);
+    d_buf.d_name[sizeof(d_buf.d_name) - 1] = '\0';
+    return &d_buf;
+}
+
+void rewinddir(DIR *d) {
+    if (d) {
+        d->index = 0;
+    }
+}
+
+int closedir(DIR *d) {
+    if (!d) {
+        return -1;
+    }
+    free(d);
+    return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,3 +23,9 @@ add_executable(test_vm_fault
     ../src-lites-1.1-2025/server/vm/vm_handlers.c)
 target_compile_options(test_vm_fault PRIVATE -std=c23 -Wall -Wextra -Werror)
 
+add_executable(dirlist
+    posix/dirlist.c
+    ../src-lites-1.1-2025/liblites/memfs.c)
+target_include_directories(dirlist PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_compile_options(dirlist PRIVATE -std=c23 -Wall -Wextra -Werror)
+

--- a/tests/posix/Makefile
+++ b/tests/posix/Makefile
@@ -1,0 +1,13 @@
+CC ?= clang
+CFLAGS += -std=c2x -Wall -Wextra -Werror
+CPPFLAGS += -I../../include
+
+all: dirlist
+
+.PHONY: all clean
+
+dirlist: dirlist.c ../../src-lites-1.1-2025/liblites/memfs.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+clean:
+	rm -f dirlist

--- a/tests/posix/dirlist.c
+++ b/tests/posix/dirlist.c
@@ -1,0 +1,17 @@
+#include "../../include/dirent.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+    DIR *d = opendir("/");
+    if (!d) {
+        perror("opendir");
+        return 1;
+    }
+    struct dirent *ent;
+    while ((ent = readdir(d)) != NULL) {
+        printf("%s\n", ent->d_name);
+    }
+    closedir(d);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- wrap DIR operations for the toy in-memory filesystem
- implement a minimal filesystem in liblites
- add `dirlist` example to the POSIX tests

## Testing
- `make -C tests/posix`