### PR TITLE
Add capability checks to VFS

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,17 +1,17 @@
-# Security APIs
+#Security APIs
 
 This document describes the keystore and enclave interfaces added to the modernised source tree.
 
-## Keystore
+    ##Keystore
 
-The trivial keystore lives in `crypto/keystore.c`.
+        The trivial keystore lives in `crypto /
+    keystore.c`.
 
-```c
-int ks_generate_key(const char *path, size_t len);
-int ks_encrypt(const char *key_path, const unsigned char *in, size_t in_len,
-               unsigned char *out, size_t *out_len);
-int ks_decrypt(const char *key_path, const unsigned char *in, size_t in_len,
-               unsigned char *out, size_t *out_len);
+```c int ks_generate_key(const char *path, size_t len);
+int ks_encrypt(const char *key_path, const unsigned char *in, size_t in_len, unsigned char *out,
+               size_t *out_len);
+int ks_decrypt(const char *key_path, const unsigned char *in, size_t in_len, unsigned char *out,
+               size_t *out_len);
 ```
 
 `ks_generate_key` creates a random symmetric key and writes it to the specified
@@ -45,3 +45,12 @@ They can be compiled manually, for example:
 cc -I src-lites-1.1-2025/include crypto/keystore.c bin/keystore-demo.c -o keystore-demo
 cc -I src-lites-1.1-2025/include src-lites-1.1-2025/liblites/enclave.c bin/enclave-demo.c -o enclave-demo
 ```
+
+## Capability-aware VFS
+
+`src-lites-1.1-2025/liblites/posix.c` implements a very small VFS layer used by
+the regression tests.  Each file is opened with an associated capability and the
+allowed rights (read, write or execute) are stored per handle.  Subsequent calls
+to `vfs_read`, `vfs_write` or `vfs_close` verify that the caller's capability
+still grants the required permission via `authorize()`.  Operations fail with
+`EACCES` if the rights do not match.

--- a/headers_inventory.csv
+++ b/headers_inventory.csv
@@ -915,3 +915,4 @@ path
 ./src-lites-1.1-2025/xkernel/util/make/gmake-3.66/rule.h
 ./src-lites-1.1-2025/xkernel/util/make/gmake-3.66/signame.h
 ./src-lites-1.1-2025/xkernel/util/make/gmake-3.66/variable.h
+./src-lites-1.1-2025/include/posix_fs.h

--- a/include/auth.h
+++ b/include/auth.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <stdint.h>
 #include "../src-lites-1.1-2025/include/cap.h"
+#include <stdint.h>
 
 typedef struct cap cap_t;
 
@@ -16,4 +16,7 @@ int authorize(const cap_t *subject, uint32_t op, uint64_t obj);
 
 #define CAP_OP_REFINE 1
 #define CAP_OP_REVOKE 2
-
+#define CAP_OP_OPEN 3
+#define CAP_OP_READ 4
+#define CAP_OP_WRITE 5
+#define CAP_OP_CLOSE 6

--- a/src-lites-1.1-2025/include/cap.h
+++ b/src-lites-1.1-2025/include/cap.h
@@ -21,7 +21,11 @@ struct cap {
     unsigned int flags;
 };
 
+/* Rights bits for generic file objects */
+#define CAP_RIGHT_READ 0x1
+#define CAP_RIGHT_WRITE 0x2
+#define CAP_RIGHT_EXEC 0x4
+
 struct cap *cap_refine(struct cap *parent, unsigned long rights, unsigned int flags);
 void revoke_capability(struct cap *cap);
 int cap_check(const struct cap *cap);
-

--- a/src-lites-1.1-2025/include/posix_fs.h
+++ b/src-lites-1.1-2025/include/posix_fs.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "../../include/auth.h"
+#include "cap.h"
+#include <stddef.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct file_handle {
+    int fd;
+    unsigned long rights;
+    const cap_t *owner;
+    struct file_handle *next;
+} file_handle_t;
+
+file_handle_t *vfs_open(const cap_t *cap, const char *path, int flags);
+ssize_t vfs_read(file_handle_t *h, void *buf, size_t len);
+ssize_t vfs_write(file_handle_t *h, const void *buf, size_t len);
+int vfs_close(file_handle_t *h);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src-lites-1.1-2025/liblites/posix.c
+++ b/src-lites-1.1-2025/liblites/posix.c
@@ -1,0 +1,68 @@
+#include "../include/posix_fs.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static file_handle_t *open_files;
+
+file_handle_t *vfs_open(const cap_t *cap, const char *path, int flags) {
+    unsigned long req = 0;
+    if ((flags & O_WRONLY) || (flags & O_RDWR))
+        req |= CAP_RIGHT_WRITE;
+    if (!(flags & O_WRONLY))
+        req |= CAP_RIGHT_READ;
+
+    if ((cap->rights & req) != req || !authorize(cap, CAP_OP_OPEN, req)) {
+        errno = EACCES;
+        return NULL;
+    }
+
+    int fd = open(path, flags, 0644);
+    if (fd < 0)
+        return NULL;
+
+    file_handle_t *h = malloc(sizeof(*h));
+    if (!h) {
+        close(fd);
+        errno = ENOMEM;
+        return NULL;
+    }
+    h->fd = fd;
+    h->rights = req;
+    h->owner = cap;
+    h->next = open_files;
+    open_files = h;
+    return h;
+}
+
+ssize_t vfs_read(file_handle_t *h, void *buf, size_t len) {
+    if (!h || !(h->rights & CAP_RIGHT_READ) || !authorize(h->owner, CAP_OP_READ, 0)) {
+        errno = EACCES;
+        return -1;
+    }
+    return read(h->fd, buf, len);
+}
+
+ssize_t vfs_write(file_handle_t *h, const void *buf, size_t len) {
+    if (!h || !(h->rights & CAP_RIGHT_WRITE) || !authorize(h->owner, CAP_OP_WRITE, 0)) {
+        errno = EACCES;
+        return -1;
+    }
+    return write(h->fd, buf, len);
+}
+
+int vfs_close(file_handle_t *h) {
+    if (!h || !authorize(h->owner, CAP_OP_CLOSE, 0)) {
+        errno = EACCES;
+        return -1;
+    }
+    file_handle_t **p = &open_files;
+    while (*p && *p != h)
+        p = &(*p)->next;
+    if (*p)
+        *p = h->next;
+    int r = close(h->fd);
+    free(h);
+    return r;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,25 +1,31 @@
-add_executable(test_cap
-    cap/test_cap.c
-    ../src-lites-1.1-2025/server/kern/cap.c
-    ../kern/auth.c
-    ../kern/audit.c)
-target_include_directories(test_cap PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_compile_options(test_cap PRIVATE -std=c23 -Wall -Wextra -Werror)
+add_executable(test_cap cap / test_cap.c../ src - lites - 1.1 -
+               2025 / server / kern / cap.c../ kern / auth.c../ kern / audit.c)
+    target_include_directories(test_cap PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} /../ include)
+        target_compile_options(test_cap PRIVATE - std = c23 - Wall - Wextra - Werror)
 
-add_executable(test_audit
-    audit/test_audit.c
-    ../kern/auth.c
-    ../kern/audit.c)
-target_include_directories(test_audit PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_compile_options(test_audit PRIVATE -std=c23 -Wall -Wextra -Werror)
+            add_executable(test_audit audit / test_audit.c../ kern / auth.c../ kern / audit.c)
+                target_include_directories(test_audit PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} /../
+                                           include)
+                    target_compile_options(test_audit PRIVATE - std = c23 - Wall - Wextra - Werror)
 
-add_executable(test_iommu
-    iommu/test_iommu.c
-    ../src-lites-1.1-2025/iommu/iommu.c)
-target_compile_options(test_iommu PRIVATE -std=c23 -Wall -Wextra -Werror)
+                        add_executable(test_iommu iommu / test_iommu.c../ src - lites - 1.1 -
+                                       2025 / iommu / iommu.c)
+                            target_compile_options(test_iommu PRIVATE - std = c23 - Wall - Wextra -
+                                                                              Werror)
 
-add_executable(test_vm_fault
-    vm_fault/test_vm_fault.c
-    ../src-lites-1.1-2025/server/vm/vm_handlers.c)
-target_compile_options(test_vm_fault PRIVATE -std=c23 -Wall -Wextra -Werror)
+                                add_executable(test_vm_fault vm_fault / test_vm_fault.c../ src -
+                                               lites - 1.1 - 2025 / server / vm / vm_handlers.c)
+                                    target_compile_options(test_vm_fault PRIVATE -
+                                                               std = c23 - Wall - Wextra - Werror)
 
+                                        add_executable(test_vfs vfs / test_vfs.c../ src - lites -
+                                                       1.1 -
+                                                       2025 / liblites / posix.c../ kern / auth.c../
+                                                           kern / audit.c../ src -
+                                                       lites - 1.1 - 2025 / server / kern / cap.c)
+                                            target_include_directories(
+                                                test_vfs PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} /../
+                                                include)
+                                                target_compile_options(test_vfs PRIVATE -
+                                                                           std = c23 - Wall -
+                                                                                 Wextra - Werror)

--- a/tests/vfs/Makefile
+++ b/tests/vfs/Makefile
@@ -1,0 +1,15 @@
+CC ?= gcc
+CFLAGS += -std=c23 -Wall -Wextra -Werror
+CPPFLAGS += -I../../include
+
+all: test_vfs
+
+.PHONY: all clean
+
+test_vfs: test_vfs.c ../../src-lites-1.1-2025/liblites/posix.c \
+../../kern/auth.c ../../kern/audit.c \
+../../src-lites-1.1-2025/server/kern/cap.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+clean:
+	rm -f test_vfs

--- a/tests/vfs/test_vfs.c
+++ b/tests/vfs/test_vfs.c
@@ -1,0 +1,47 @@
+#include "../../include/auth.h"
+#include "../../src-lites-1.1-2025/include/posix_fs.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(void) {
+    struct cap root = {0};
+    root.rights = CAP_RIGHT_READ | CAP_RIGHT_WRITE;
+    root.epoch = 1;
+
+    acl_add(&root, CAP_OP_OPEN, CAP_RIGHT_READ | CAP_RIGHT_WRITE);
+    acl_add(&root, CAP_OP_READ, 0);
+    acl_add(&root, CAP_OP_WRITE, 0);
+    acl_add(&root, CAP_OP_CLOSE, 0);
+
+    const char *tmp = "vfs_test.tmp";
+    FILE *f = fopen(tmp, "w");
+    assert(f);
+    fclose(f);
+
+    file_handle_t *h = vfs_open(&root, tmp, O_RDWR);
+    assert(h);
+    assert(vfs_write(h, "hi", 2) == 2);
+    assert(vfs_close(h) == 0);
+
+    h = vfs_open(&root, tmp, O_RDONLY);
+    assert(h);
+    char buf[3];
+    assert(vfs_read(h, buf, 2) == 2);
+    buf[2] = '\0';
+    assert(strcmp(buf, "hi") == 0);
+    assert(vfs_close(h) == 0);
+
+    struct cap read_only = {0};
+    read_only.rights = CAP_RIGHT_READ;
+    read_only.epoch = 1;
+    acl_add(&read_only, CAP_OP_OPEN, CAP_RIGHT_READ);
+    acl_add(&read_only, CAP_OP_READ, 0);
+    acl_add(&read_only, CAP_OP_CLOSE, 0);
+
+    assert(vfs_open(&read_only, tmp, O_WRONLY) == NULL);
+
+    unlink(tmp);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- introduce CAP_RIGHT_* definitions
- expand `auth.h` with capability opcodes
- implement simple capability-aware VFS in `posix.c`
- document VFS permission checks in `security.md`
- add regression test for the VFS capability logic

## Testing
- `make -C tests/vfs` *(fails: unrecognized command-line option '-std=c23')*