### PR TITLE
Add signal helper wrappers and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ The helpers expect the binaries produced by `Makefile.new` in the repository
 root and require the corresponding `qemu-system` binary in `PATH`.
 
 Additional notes are kept in [`docs/`](docs/).  The mailbox-based IPC
-wrappers are described in [docs/IPC.md](docs/IPC.md).
+wrappers are described in [docs/IPC.md](docs/IPC.md).  Signal helper
+functions are documented in [docs/signals.md](docs/signals.md).
 
 ## Tests
 

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -1,0 +1,17 @@
+# Signal helpers
+
+The modernized tree provides thin wrappers around common signal calls.
+They behave like their POSIX counterparts but are grouped under a
+single header for convenience.
+
+```c
+int lites_sigaction(int signum, const struct sigaction *act,
+                    struct sigaction *oldact);
+int lites_sigprocmask(int how, const sigset_t *set, sigset_t *oldset);
+int lites_killpg(pid_t pgid, int sig);
+```
+
+`lites_sigaction` installs a handler for `signum` and optionally returns the
+previous action. `lites_sigprocmask` adjusts the calling thread's blocked
+signals. `lites_killpg` sends `sig` to every process in the specified group
+and falls back to `kill(-pgid, sig)` when `killpg` is unavailable.

--- a/src-lites-1.1-2025/include/signal_helpers.h
+++ b/src-lites-1.1-2025/include/signal_helpers.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <signal.h>
+#include <sys/types.h>
+
+int lites_sigaction(int signum, const struct sigaction *act,
+                    struct sigaction *oldact);
+int lites_sigprocmask(int how, const sigset_t *set, sigset_t *oldset);
+int lites_killpg(pid_t pgid, int sig);
+

--- a/src-lites-1.1-2025/liblites/signal_helpers.c
+++ b/src-lites-1.1-2025/liblites/signal_helpers.c
@@ -1,0 +1,25 @@
+#include "signal_helpers.h"
+
+#include <signal.h>
+#include <unistd.h>
+
+int lites_sigaction(int signum, const struct sigaction *act,
+                    struct sigaction *oldact)
+{
+    return sigaction(signum, act, oldact);
+}
+
+int lites_sigprocmask(int how, const sigset_t *set, sigset_t *oldset)
+{
+    return sigprocmask(how, set, oldset);
+}
+
+int lites_killpg(pid_t pgid, int sig)
+{
+#ifdef HAVE_KILLPG
+    return killpg(pgid, sig);
+#else
+    return kill(-pgid, sig);
+#endif
+}
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,3 +23,8 @@ add_executable(test_vm_fault
     ../src-lites-1.1-2025/server/vm/vm_handlers.c)
 target_compile_options(test_vm_fault PRIVATE -std=c23 -Wall -Wextra -Werror)
 
+add_executable(test_signal
+    signal/test_signal.c
+    ../src-lites-1.1-2025/liblites/signal_helpers.c)
+target_compile_options(test_signal PRIVATE -std=c23 -Wall -Wextra -Werror)
+

--- a/tests/signal/Makefile
+++ b/tests/signal/Makefile
@@ -1,0 +1,13 @@
+CC ?= gcc
+CFLAGS += -std=c23 -Wall -Wextra -Werror
+CPPFLAGS += -I../../src-lites-1.1-2025/include
+
+all: test_signal
+
+.PHONY: all clean
+
+test_signal: test_signal.c ../../src-lites-1.1-2025/liblites/signal_helpers.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+clean:
+	rm -f test_signal

--- a/tests/signal/test_signal.c
+++ b/tests/signal/test_signal.c
@@ -1,0 +1,28 @@
+#include "../../src-lites-1.1-2025/include/signal_helpers.h"
+#include <assert.h>
+#include <signal.h>
+#include <unistd.h>
+
+static volatile sig_atomic_t got;
+
+static void handler(int sig) { got = sig; }
+
+int main(void) {
+    struct sigaction sa = {0};
+    sa.sa_handler = handler;
+    sigemptyset(&sa.sa_mask);
+    assert(lites_sigaction(SIGUSR1, &sa, NULL) == 0);
+
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGUSR1);
+    assert(lites_sigprocmask(SIG_BLOCK, &mask, NULL) == 0);
+
+    assert(lites_killpg(getpgrp(), SIGUSR1) == 0);
+    assert(got == 0);
+
+    assert(lites_sigprocmask(SIG_UNBLOCK, &mask, NULL) == 0);
+    assert(got == SIGUSR1);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement lightweight signal helper wrappers
- document signal helper usage
- add unit test covering handler registration
- reference new docs from README

## Testing
- `make -C tests/signal` *(fails: unrecognized command-line option ‘-std=c23’)*