### PR TITLE
Add POSIX protection wrappers

### DIFF
--- a/bin/posix-demo.c
+++ b/bin/posix-demo.c
@@ -1,0 +1,37 @@
+/**
+ * Lites repository license applies to this file; see the LICENSE file
+ * in the project root for details.
+ */
+
+#include "posix_helpers.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+int main(void) {
+    size_t psz = (size_t)sysconf(_SC_PAGESIZE);
+    void *p = mmap(NULL, psz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+    if (p == MAP_FAILED) {
+        perror("mmap");
+        return 1;
+    }
+
+    lites_track_region(p, psz, PROT_READ | PROT_WRITE);
+    printf("initial prot: %d\n", lites_get_prot(p, psz));
+
+    if (lites_mprotect(p, psz, PROT_READ) != 0) {
+        perror("mprotect");
+        return 1;
+    }
+    printf("after mprotect: %d\n", lites_get_prot(p, psz));
+
+    if (lites_msync(p, psz) != 0) {
+        perror("msync");
+        return 1;
+    }
+
+    lites_untrack_region(p, psz);
+    munmap(p, psz);
+    return 0;
+}

--- a/docs/posix_helpers.md
+++ b/docs/posix_helpers.md
@@ -1,0 +1,23 @@
+# POSIX helpers
+
+`src-lites-1.1-2025/liblites/posix.c` implements a tiny tracking layer for page
+protections.  It exposes wrappers around `mprotect(2)` and `msync(2)` that keep
+an internal record of the current protection flags for each mapped region.
+
+```c
+void lites_track_region(void *addr, size_t len, int prot);
+void lites_untrack_region(void *addr, size_t len);
+int  lites_get_prot(void *addr, size_t len);
+int  lites_mprotect(void *addr, size_t len, int prot);
+int  lites_msync(void *addr, size_t len);
+```
+
+`lites_track_region` should be called after mapping a new region so that future
+protection changes can be queried via `lites_get_prot`.  The wrappers update the
+stored state on success.  `lites_msync` simply invokes `msync(MS_SYNC)` for
+convenience.
+
+## Example program
+
+`bin/posix-demo.c` demonstrates the helpers by mapping a single page,
+changing its protection and syncing it back to memory.

--- a/src-lites-1.1-2025/include/posix_helpers.h
+++ b/src-lites-1.1-2025/include/posix_helpers.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <sys/types.h>
+#include <sys/mman.h>
+
+/* Register a memory region with the initial protection flags. */
+void lites_track_region(void *addr, size_t len, int prot);
+
+/* Remove a previously tracked region. */
+void lites_untrack_region(void *addr, size_t len);
+
+/* Return the current protection flags for a tracked region or -1 if unknown. */
+int lites_get_prot(void *addr, size_t len);
+
+/* Wrapper around mprotect that keeps internal state in sync. */
+int lites_mprotect(void *addr, size_t len, int prot);
+
+/* Convenience wrapper for msync using MS_SYNC. */
+int lites_msync(void *addr, size_t len);
+

--- a/src-lites-1.1-2025/liblites/Makerules
+++ b/src-lites-1.1-2025/liblites/Makerules
@@ -47,7 +47,7 @@ ns532_OBJFILES = misc_asm.o memcmp.o in_cksum.o bcmp.o
 mips_OBJFILES = ntoh.o memcmp.o bcmp.o
 alpha_OBJFILES = ntoh.o bcmp.o memcmp.o
 
-OBJFILES = ${${TARGET_MACHINE}_OBJFILES} exec_file.o
+OBJFILES = ${${TARGET_MACHINE}_OBJFILES} exec_file.o posix.o
 OFILES_P = $(patsubst %.o,%_p.o,${OBJFILES})
 
 # XXX ar may require different flags on different platforms. Move to autoconf.

--- a/src-lites-1.1-2025/liblites/posix.c
+++ b/src-lites-1.1-2025/liblites/posix.c
@@ -1,0 +1,65 @@
+#include "../include/posix_helpers.h"
+#include <stdlib.h>
+#include <string.h>
+
+struct prot_entry {
+    void *addr;
+    size_t len;
+    int prot;
+    struct prot_entry *next;
+};
+
+static struct prot_entry *prot_list;
+
+static struct prot_entry *find_region(void *addr, size_t len) {
+    for (struct prot_entry *e = prot_list; e; e = e->next)
+        if (e->addr == addr && e->len == len)
+            return e;
+    return NULL;
+}
+
+void lites_track_region(void *addr, size_t len, int prot) {
+    struct prot_entry *e = find_region(addr, len);
+    if (e) {
+        e->prot = prot;
+        return;
+    }
+    e = malloc(sizeof(*e));
+    if (!e)
+        return;
+    e->addr = addr;
+    e->len = len;
+    e->prot = prot;
+    e->next = prot_list;
+    prot_list = e;
+}
+
+void lites_untrack_region(void *addr, size_t len) {
+    struct prot_entry **pp = &prot_list;
+    while (*pp) {
+        if ((*pp)->addr == addr && (*pp)->len == len) {
+            struct prot_entry *tmp = *pp;
+            *pp = tmp->next;
+            free(tmp);
+            return;
+        }
+        pp = &(*pp)->next;
+    }
+}
+
+int lites_get_prot(void *addr, size_t len) {
+    struct prot_entry *e = find_region(addr, len);
+    return e ? e->prot : -1;
+}
+
+int lites_mprotect(void *addr, size_t len, int prot) {
+    if (mprotect(addr, len, prot) == -1)
+        return -1;
+    lites_track_region(addr, len, prot);
+    return 0;
+}
+
+int lites_msync(void *addr, size_t len) {
+    return msync(addr, len, MS_SYNC);
+}
+

--- a/tests/vm_fault/Makefile
+++ b/tests/vm_fault/Makefile
@@ -6,7 +6,8 @@ all: test_vm_fault
 
 .PHONY: all clean
 
-test_vm_fault: test_vm_fault.c ../../src-lites-1.1-2025/server/vm/vm_handlers.c
+test_vm_fault: test_vm_fault.c ../../src-lites-1.1-2025/server/vm/vm_handlers.c \
+../../src-lites-1.1-2025/liblites/posix.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 clean:


### PR DESCRIPTION
## Summary
- extend liblites with a posix.c helper that tracks page protections
- wrap `mprotect` and `msync` in new functions
- export the API via `posix_helpers.h`
- document the helpers and provide a `posix-demo` example
- update VM fault test to use the new API

## Testing
- `make CC=gcc CFLAGS="-std=c2x -Wall -Wextra -Werror" -C tests/vm_fault`
- `make CC=gcc CFLAGS="-std=c2x -Wall -Wextra -Werror" -C src-lites-1.1-2025/bin/user_pager`
- `./tests/vm_fault/test_vm_fault`