### PR TITLE
Add minimal pthread wrappers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,8 @@ if(EXISTS "${LITES_SRC_DIR}")
         list(APPEND SERVER_SRC ${_dir_src})
     endforeach()
     file(GLOB _kern_src "${CMAKE_CURRENT_SOURCE_DIR}/kern/*.c")
-    list(APPEND SERVER_SRC ${_kern_src})
+    file(GLOB _posix_src "${CMAKE_CURRENT_SOURCE_DIR}/posix/*.c")
+    list(APPEND SERVER_SRC ${_kern_src} ${_posix_src})
     file(GLOB _iommu_src "${LITES_SRC_DIR}/iommu/*.c")
     list(APPEND SERVER_SRC ${_iommu_src})
 
@@ -150,7 +151,7 @@ if(EXISTS "${LITES_SRC_DIR}")
             file(GLOB_RECURSE _dir_src "${dir}/*.c" "${dir}/*.S")
             list(APPEND EMULATOR_SRC ${_dir_src})
         endforeach()
-        list(APPEND EMULATOR_SRC ${_kern_src} ${_iommu_src})
+        list(APPEND EMULATOR_SRC ${_kern_src} ${_iommu_src} ${_posix_src})
         if(BISON_FOUND)
             foreach(yfile ${_y_src})
                 get_filename_component(_y_name "${yfile}" NAME_WE)
@@ -166,6 +167,7 @@ if(EXISTS "${LITES_SRC_DIR}")
         "${LITES_SRC_DIR}/iommu"
         "${MACH_INCLUDE_DIR}"
         "${CMAKE_CURRENT_SOURCE_DIR}/kern"
+        "${CMAKE_CURRENT_SOURCE_DIR}/posix"
         "${CMAKE_CURRENT_SOURCE_DIR}/include")
     if(ARCH STREQUAL "x86_64")
         target_include_directories(lites_server PRIVATE
@@ -200,6 +202,7 @@ if(EXISTS "${LITES_SRC_DIR}")
             "${LITES_SRC_DIR}/emulator"
             "${MACH_INCLUDE_DIR}"
             "${CMAKE_CURRENT_SOURCE_DIR}/kern"
+            "${CMAKE_CURRENT_SOURCE_DIR}/posix"
             "${LITES_SRC_DIR}/iommu"
             "${CMAKE_CURRENT_SOURCE_DIR}/include")
 

--- a/Makefile.new
+++ b/Makefile.new
@@ -110,7 +110,9 @@ SERVER_DIRS := $(SRCDIR)/server/$(ARCH_DIR) $(SERVER_COMMON_DIRS)
 SERVER_SRC := $(foreach d,$(SERVER_DIRS),$(shell find $(d) -name \*.c -o -name \*.S))
 SERVER_INCDIRS := $(addprefix -I,$(SERVER_DIRS))
 KERN_SRC := $(wildcard kern/*.c) $(wildcard $(SRCDIR)/iommu/*.c)
-KERN_INCDIRS := -Ikern -I$(SRCDIR)/iommu
+POSIX_SRC := $(wildcard posix/*.c)
+KERN_SRC += $(POSIX_SRC)
+KERN_INCDIRS := -Ikern -I$(SRCDIR)/iommu -Iposix
 
 
 ifneq ($(wildcard $(SRCDIR)/emulator),)

--- a/docs/posix_compat.md
+++ b/docs/posix_compat.md
@@ -1,0 +1,7 @@
+# POSIX compatibility
+
+This tree provides a very small subset of POSIX threads.  Only thread
+creation, joining, detaching and basic mutex operations are available.
+The implementation wraps the Mach cthreads library and uses the simple
+spin locks from `kern/spinlock.h`.  Condition variables and other
+pthreads features are not implemented.

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <mach/cthreads.h>
+#include "../kern/spinlock.h"
+
+typedef cthread_t pthread_t;
+typedef void *pthread_attr_t;
+
+typedef spinlock_t pthread_mutex_t;
+typedef void *pthread_mutexattr_t;
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+                   void *(*start_routine)(void *), void *arg);
+int pthread_join(pthread_t thread, void **retval);
+int pthread_detach(pthread_t thread);
+pthread_t pthread_self(void);
+
+int pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr);
+int pthread_mutex_destroy(pthread_mutex_t *mutex);
+int pthread_mutex_lock(pthread_mutex_t *mutex);
+int pthread_mutex_unlock(pthread_mutex_t *mutex);

--- a/posix/pthread.c
+++ b/posix/pthread.c
@@ -1,0 +1,57 @@
+#include "pthread.h"
+#include <mach/cthreads.h>
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+                   void *(*start_routine)(void *), void *arg)
+{
+    (void)attr;
+    cthread_t t = cthread_fork((cthread_fn_t)start_routine, arg);
+    if (!t)
+        return -1;
+    *thread = (pthread_t)t;
+    return 0;
+}
+
+int pthread_join(pthread_t thread, void **retval)
+{
+    void *r = cthread_join((cthread_t)thread);
+    if (retval)
+        *retval = r;
+    return 0;
+}
+
+int pthread_detach(pthread_t thread)
+{
+    cthread_detach((cthread_t)thread);
+    return 0;
+}
+
+pthread_t pthread_self(void)
+{
+    return (pthread_t)cthread_self();
+}
+
+int pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr)
+{
+    (void)attr;
+    spin_lock_init(mutex);
+    return 0;
+}
+
+int pthread_mutex_destroy(pthread_mutex_t *mutex)
+{
+    (void)mutex;
+    return 0;
+}
+
+int pthread_mutex_lock(pthread_mutex_t *mutex)
+{
+    spin_lock(mutex);
+    return 0;
+}
+
+int pthread_mutex_unlock(pthread_mutex_t *mutex)
+{
+    spin_unlock(mutex);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add stubbed pthread header
- implement lightweight pthread functions
- compile pthread sources via CMake and Makefile
- document limited POSIX support

## Testing
- `make -f Makefile.new` *(fails: Mach headers not found)*