### PR TITLE
Add timer tracking with nanosleep wrapper

### DIFF
--- a/docs/technical_notes.md
+++ b/docs/technical_notes.md
@@ -27,3 +27,11 @@ A repository-wide `.editorconfig` enforces UTF‑8 encoding, LF line endings and
 tests.  It reads `pf_info_t` structures from a UNIX domain socket and simply
 acknowledges each request, leaving the kernel side to map zero-filled pages.
 The VM tests spawn the pager automatically.
+
+## Timer tracking
+
+`kern/timer.c` implements a simple wrapper around `nanosleep(2)` that
+records how long each process has slept. Include `timer.h` and call
+`timer_init()` once before using `k_nanosleep()`. The accumulated
+sleep time for a process can be queried with `timer_get_total_ns()` and
+reset with `timer_reset()`.

--- a/include/timer.h
+++ b/include/timer.h
@@ -1,0 +1,20 @@
+#define _POSIX_C_SOURCE 200809L
+#pragma once
+
+#include <stdint.h>
+#include <time.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/* Initialize timer tracking. Call once at startup. */
+void timer_init(void);
+
+/* Sleep for the requested interval, tracking per-process usage. */
+int k_nanosleep(const struct timespec *req, struct timespec *rem);
+
+/* Return total nanoseconds slept by the given process. */
+uint64_t timer_get_total_ns(pid_t pid);
+
+/* Reset the accumulated sleep time for the given process. */
+void timer_reset(pid_t pid);
+

--- a/kern/timer.c
+++ b/kern/timer.c
@@ -1,0 +1,81 @@
+#define _POSIX_C_SOURCE 200809L
+#include "timer.h"
+#include "spinlock.h"
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+struct proc_timer {
+    pid_t pid;
+    uint64_t total_ns;
+    struct proc_timer *next;
+};
+
+static struct proc_timer *timers;
+static spinlock_t timer_lock;
+
+static struct proc_timer *find_timer(pid_t pid)
+{
+    for (struct proc_timer *it = timers; it; it = it->next) {
+        if (it->pid == pid)
+            return it;
+    }
+    return NULL;
+}
+
+static struct proc_timer *ensure_timer(pid_t pid)
+{
+    struct proc_timer *pt = find_timer(pid);
+    if (!pt) {
+        pt = malloc(sizeof(*pt));
+        if (!pt)
+            return NULL;
+        pt->pid = pid;
+        pt->total_ns = 0;
+        pt->next = timers;
+        timers = pt;
+    }
+    return pt;
+}
+
+void timer_init(void)
+{
+    spin_lock_init(&timer_lock);
+}
+
+void timer_reset(pid_t pid)
+{
+    spin_lock(&timer_lock);
+    struct proc_timer *pt = ensure_timer(pid);
+    if (pt)
+        pt->total_ns = 0;
+    spin_unlock(&timer_lock);
+}
+
+uint64_t timer_get_total_ns(pid_t pid)
+{
+    spin_lock(&timer_lock);
+    struct proc_timer *pt = find_timer(pid);
+    uint64_t ns = pt ? pt->total_ns : 0;
+    spin_unlock(&timer_lock);
+    return ns;
+}
+
+int k_nanosleep(const struct timespec *req, struct timespec *rem)
+{
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    int ret = nanosleep(req, rem);
+    clock_gettime(CLOCK_MONOTONIC, &end);
+
+    uint64_t delta = (uint64_t)(end.tv_sec - start.tv_sec) * 1000000000ULL +
+                     (uint64_t)(end.tv_nsec - start.tv_nsec);
+    pid_t pid = getpid();
+    spin_lock(&timer_lock);
+    struct proc_timer *pt = ensure_timer(pid);
+    if (pt)
+        pt->total_ns += delta;
+    spin_unlock(&timer_lock);
+    return ret;
+}
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,3 +23,9 @@ add_executable(test_vm_fault
     ../src-lites-1.1-2025/server/vm/vm_handlers.c)
 target_compile_options(test_vm_fault PRIVATE -std=c23 -Wall -Wextra -Werror)
 
+
+add_executable(test_timer
+    timer/test_timer.c
+    ../kern/timer.c)
+target_include_directories(test_timer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_compile_options(test_timer PRIVATE -std=c23 -Wall -Wextra -Werror)

--- a/tests/timer/Makefile
+++ b/tests/timer/Makefile
@@ -1,0 +1,14 @@
+CC ?= gcc
+# Additional compile flags from the top-level build system are appended.
+CFLAGS += -std=c23 -Wall -Wextra -Werror
+CPPFLAGS += -I../../include
+
+all: test_timer
+
+.PHONY: all clean
+
+test_timer: test_timer.c ../../kern/timer.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+clean:
+	rm -f test_timer

--- a/tests/timer/test_timer.c
+++ b/tests/timer/test_timer.c
@@ -1,0 +1,23 @@
+#include "../../include/timer.h"
+#include <assert.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main(void)
+{
+    timer_init();
+    pid_t pid = getpid();
+    timer_reset(pid);
+
+    struct timespec ts = {0, 5000000};
+    uint64_t before = timer_get_total_ns(pid);
+    k_nanosleep(&ts, NULL);
+    uint64_t after = timer_get_total_ns(pid);
+    assert(after >= before + 1000000);
+
+    timer_reset(pid);
+    assert(timer_get_total_ns(pid) == 0);
+    (void)after;
+    printf("timer test passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a tiny timer subsystem with `k_nanosleep`
- expose timer APIs via new header
- document usage in Technical Notes
- create timer regression test and build rule

## Testing
- `make CC=clang -C tests/timer`