### PR TITLE
Add basic POSIX IPC wrappers

### DIFF
--- a/bin/ipc-demo.c
+++ b/bin/ipc-demo.c
@@ -1,0 +1,55 @@
+/**
+ * Minimal demo exercising capability backed POSIX IPC wrappers.
+ */
+#include "posix_ipc.h"
+#include <stdio.h>
+#include <string.h>
+
+int main(void)
+{
+    cap_mq_t *mq = cap_mq_open("/ipc_demo_mq", O_CREAT | O_RDWR, 0600, 4);
+    if (!mq) {
+        perror("cap_mq_open");
+        return 1;
+    }
+    cap_sem_t *sem = cap_sem_open("/ipc_demo_sem", O_CREAT | O_RDWR, 0600, 0);
+    if (!sem) {
+        perror("cap_sem_open");
+        cap_mq_close(mq);
+        return 1;
+    }
+    cap_shm_t *shm = cap_shm_open("/ipc_demo_shm", O_CREAT | O_RDWR, 0600, 4096);
+    if (!shm) {
+        perror("cap_shm_open");
+        cap_sem_close(sem);
+        cap_mq_close(mq);
+        return 1;
+    }
+    void *addr = cap_shm_map(shm, 4096, PROT_READ | PROT_WRITE, MAP_SHARED, 0);
+    if (addr == MAP_FAILED) {
+        perror("cap_shm_map");
+        cap_shm_close(shm);
+        cap_sem_close(sem);
+        cap_mq_close(mq);
+        return 1;
+    }
+
+    const char *text = "hello";
+    if (cap_mq_send(mq, text, strlen(text) + 1, 0) < 0) {
+        perror("cap_mq_send");
+    }
+    char buf[32];
+    if (cap_mq_receive(mq, buf, sizeof(buf), NULL) >= 0)
+        printf("mq message: %s\n", buf);
+
+    strcpy((char *)addr, "shared memory");
+    cap_sem_post(sem);
+    cap_sem_wait(sem);
+    printf("shm contains: %s\n", (char *)addr);
+
+    cap_shm_unmap(addr, 4096);
+    cap_shm_close(shm);
+    cap_sem_close(sem);
+    cap_mq_close(mq);
+    return 0;
+}

--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -50,3 +50,41 @@ int exo_recv(exo_msg_t *out, unsigned int timeout_ms);
 ## Timeout semantics
 
 The timeout passed to `exo_recv` is interpreted in milliseconds.  A value of zero checks the mailbox without blocking.  Negative values block without a limit.  The function wakes as soon as a message is available or when the timeout expires.
+
+## POSIX IPC wrappers
+
+Capability backed wrappers expose POSIX message queues, semaphores and
+shared memory.  Each resource is associated with a capability object so
+rights can later be refined or revoked.
+
+### Message queues
+
+```c
+cap_mq_t *cap_mq_open(const char *name, int oflag, mode_t mode,
+                      unsigned int maxmsg);
+int cap_mq_send(cap_mq_t *q, const char *msg, size_t len, unsigned int prio);
+ssize_t cap_mq_receive(cap_mq_t *q, char *msg, size_t len, unsigned int *prio);
+int cap_mq_close(cap_mq_t *q);
+```
+
+### Semaphores
+
+```c
+cap_sem_t *cap_sem_open(const char *name, int oflag, mode_t mode,
+                        unsigned int value);
+int cap_sem_wait(cap_sem_t *s);
+int cap_sem_post(cap_sem_t *s);
+int cap_sem_close(cap_sem_t *s);
+```
+
+### Shared memory
+
+```c
+cap_shm_t *cap_shm_open(const char *name, int oflag, mode_t mode, size_t size);
+void *cap_shm_map(cap_shm_t *shm, size_t len, int prot, int flags, off_t off);
+int cap_shm_unmap(void *addr, size_t len);
+int cap_shm_close(cap_shm_t *shm);
+```
+
+The wrappers merely forward to the underlying POSIX functions while
+tracking the capability used to create the object.

--- a/include/posix_ipc.h
+++ b/include/posix_ipc.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <mqueue.h>
+#include <semaphore.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include "../src-lites-1.1-2025/include/cap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Rights bitmasks */
+#define MQ_RIGHT_SEND  (1UL << 0)
+#define MQ_RIGHT_RECV  (1UL << 1)
+#define MQ_RIGHT_CLOSE (1UL << 2)
+
+#define SEM_RIGHT_WAIT  (1UL << 0)
+#define SEM_RIGHT_POST  (1UL << 1)
+#define SEM_RIGHT_CLOSE (1UL << 2)
+
+#define SHM_RIGHT_MAP    (1UL << 0)
+#define SHM_RIGHT_UNMAP  (1UL << 1)
+#define SHM_RIGHT_CLOSE  (1UL << 2)
+
+typedef struct {
+    mqd_t mq;
+    struct cap *cap;
+} cap_mq_t;
+
+cap_mq_t *cap_mq_open(const char *name, int oflag, mode_t mode,
+                      unsigned int maxmsg);
+int cap_mq_send(cap_mq_t *q, const char *msg, size_t len, unsigned int prio);
+ssize_t cap_mq_receive(cap_mq_t *q, char *msg, size_t len, unsigned int *prio);
+int cap_mq_close(cap_mq_t *q);
+
+typedef struct {
+    sem_t *sem;
+    struct cap *cap;
+} cap_sem_t;
+
+cap_sem_t *cap_sem_open(const char *name, int oflag, mode_t mode,
+                        unsigned int value);
+int cap_sem_wait(cap_sem_t *s);
+int cap_sem_post(cap_sem_t *s);
+int cap_sem_close(cap_sem_t *s);
+
+typedef struct {
+    int fd;
+    struct cap *cap;
+} cap_shm_t;
+
+cap_shm_t *cap_shm_open(const char *name, int oflag, mode_t mode, size_t size);
+void *cap_shm_map(cap_shm_t *shm, size_t len, int prot, int flags, off_t off);
+int cap_shm_unmap(void *addr, size_t len);
+int cap_shm_close(cap_shm_t *shm);
+
+#ifdef __cplusplus
+}
+#endif

--- a/ipc.c
+++ b/ipc.c
@@ -1,0 +1,180 @@
+#include "posix_ipc.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static struct cap *cap_alloc(unsigned long rights)
+{
+    struct cap *c = malloc(sizeof(*c));
+    if (!c)
+        return NULL;
+    c->parent = NULL;
+    c->children = NULL;
+    c->next_sibling = NULL;
+    c->epoch = 0;
+    c->rights = rights;
+    c->flags = 0;
+    return c;
+}
+
+/* ------------------------ Message queues ------------------------ */
+cap_mq_t *cap_mq_open(const char *name, int oflag, mode_t mode,
+                      unsigned int maxmsg)
+{
+    cap_mq_t *q = malloc(sizeof(*q));
+    if (!q)
+        return NULL;
+    struct mq_attr attr = {0};
+    if (maxmsg)
+        attr.mq_maxmsg = maxmsg;
+    if (attr.mq_maxmsg == 0)
+        attr.mq_maxmsg = 8;
+    attr.mq_msgsize = 128;
+    q->mq = mq_open(name, oflag, mode, &attr);
+    if (q->mq == (mqd_t)-1) {
+        free(q);
+        return NULL;
+    }
+    q->cap = cap_alloc(MQ_RIGHT_SEND | MQ_RIGHT_RECV | MQ_RIGHT_CLOSE);
+    if (!q->cap) {
+        mq_close(q->mq);
+        free(q);
+        return NULL;
+    }
+    return q;
+}
+
+int cap_mq_send(cap_mq_t *q, const char *msg, size_t len, unsigned int prio)
+{
+    if (!q || !q->cap || !(q->cap->rights & MQ_RIGHT_SEND)) {
+        errno = EPERM;
+        return -1;
+    }
+    return mq_send(q->mq, msg, len, prio);
+}
+
+ssize_t cap_mq_receive(cap_mq_t *q, char *msg, size_t len, unsigned int *prio)
+{
+    if (!q || !q->cap || !(q->cap->rights & MQ_RIGHT_RECV)) {
+        errno = EPERM;
+        return -1;
+    }
+    return mq_receive(q->mq, msg, len, prio);
+}
+
+int cap_mq_close(cap_mq_t *q)
+{
+    if (!q)
+        return -1;
+    if (q->cap && (q->cap->rights & MQ_RIGHT_CLOSE))
+        mq_close(q->mq);
+    free(q->cap);
+    free(q);
+    return 0;
+}
+
+/* ------------------------ Semaphores ------------------------ */
+cap_sem_t *cap_sem_open(const char *name, int oflag, mode_t mode,
+                        unsigned int value)
+{
+    cap_sem_t *s = malloc(sizeof(*s));
+    if (!s)
+        return NULL;
+    s->sem = sem_open(name, oflag, mode, value);
+    if (s->sem == SEM_FAILED) {
+        free(s);
+        return NULL;
+    }
+    s->cap = cap_alloc(SEM_RIGHT_WAIT | SEM_RIGHT_POST | SEM_RIGHT_CLOSE);
+    if (!s->cap) {
+        sem_close(s->sem);
+        free(s);
+        return NULL;
+    }
+    return s;
+}
+
+int cap_sem_wait(cap_sem_t *s)
+{
+    if (!s || !s->cap || !(s->cap->rights & SEM_RIGHT_WAIT)) {
+        errno = EPERM;
+        return -1;
+    }
+    return sem_wait(s->sem);
+}
+
+int cap_sem_post(cap_sem_t *s)
+{
+    if (!s || !s->cap || !(s->cap->rights & SEM_RIGHT_POST)) {
+        errno = EPERM;
+        return -1;
+    }
+    return sem_post(s->sem);
+}
+
+int cap_sem_close(cap_sem_t *s)
+{
+    if (!s)
+        return -1;
+    if (s->cap && (s->cap->rights & SEM_RIGHT_CLOSE))
+        sem_close(s->sem);
+    free(s->cap);
+    free(s);
+    return 0;
+}
+
+/* ------------------------ Shared memory ------------------------ */
+cap_shm_t *cap_shm_open(const char *name, int oflag, mode_t mode, size_t size)
+{
+    cap_shm_t *shm = malloc(sizeof(*shm));
+    if (!shm)
+        return NULL;
+    shm->fd = shm_open(name, oflag, mode);
+    if (shm->fd < 0) {
+        free(shm);
+        return NULL;
+    }
+    if ((oflag & O_CREAT) && size > 0) {
+        if (ftruncate(shm->fd, (off_t)size) < 0) {
+            close(shm->fd);
+            free(shm);
+            return NULL;
+        }
+    }
+    shm->cap = cap_alloc(SHM_RIGHT_MAP | SHM_RIGHT_UNMAP | SHM_RIGHT_CLOSE);
+    if (!shm->cap) {
+        close(shm->fd);
+        free(shm);
+        return NULL;
+    }
+    return shm;
+}
+
+void *cap_shm_map(cap_shm_t *shm, size_t len, int prot, int flags, off_t off)
+{
+    if (!shm || !shm->cap || !(shm->cap->rights & SHM_RIGHT_MAP)) {
+        errno = EPERM;
+        return MAP_FAILED;
+    }
+    return mmap(NULL, len, prot, flags, shm->fd, off);
+}
+
+int cap_shm_unmap(void *addr, size_t len)
+{
+    return munmap(addr, len);
+}
+
+int cap_shm_close(cap_shm_t *shm)
+{
+    if (!shm)
+        return -1;
+    if (shm->cap && (shm->cap->rights & SHM_RIGHT_CLOSE))
+        close(shm->fd);
+    free(shm->cap);
+    free(shm);
+    return 0;
+}
+

--- a/meson.build
+++ b/meson.build
@@ -2,4 +2,10 @@ project('lites', 'c')
 
 bison = find_program('bison', required : false)
 
-# Placeholder for future Bison based sources
+# Build the IPC demo
+rt = cc.find_library('rt', required : false)
+inc = include_directories('.', 'src-lites-1.1-2025/include')
+executable('ipc-demo',
+           ['ipc.c', 'bin/ipc-demo.c'],
+           include_directories : inc,
+           dependencies : rt)


### PR DESCRIPTION
## Summary
- add capability-backed POSIX IPC wrappers
- document the new IPC helpers
- build a small demo using Meson

## Testing
- `gcc -Iinclude -Isrc-lites-1.1-2025/include -c ipc.c` *(fails: machine/endian.h missing)*
- `meson setup build` *(fails: meson not found)*