### PR TITLE
Add Codex automation scaffolding

### DIFF
--- a/.codex/config.yaml
+++ b/.codex/config.yaml
@@ -1,0 +1,1 @@
+approvalMode: full-auto

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "postCreateCommand": "npm i -g @openai/codex && codex -q 'doctor setup.sh'"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Codex project instructions
+
+- Whenever the repository is opened, ensure `setup.sh` matches `.codex/setup.sh`.
+- If differences exist, patch `setup.sh` in place and commit using the message `auto-heal setup.sh`.
+- Run `shellcheck setup.sh` and `bats tests/setup.bats` (if present) before committing.
+- Stop if either check fails.
+- Use `approvalMode: full-auto` so the agent may commit without prompting.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ so the remainder of the setup can continue.  The script normally requires
 root privileges and network access.  When invoked with `--offline` it
 installs all `.deb` files from the `offline_packages/` directory instead of
 using the network.
+Codex CLI can keep `setup.sh` in sync with `.codex/setup.sh` automatically. The `postCreateCommand` in `.devcontainer/devcontainer.json` installs Codex and runs `codex -q 'doctor setup.sh'` after container creation. A sample systemd unit `scripts/codex-setup.service` demonstrates how to do the same early in boot. The repository's `AGENTS.md` instructs Codex to update the script and verify it with shellcheck and BATS.
+
 
 You can also invoke `scripts/run-precommit.sh` which automatically installs
 `pre-commit` via pip when missing.

--- a/scripts/codex-setup.service
+++ b/scripts/codex-setup.service
@@ -1,0 +1,14 @@
+# codex-setup.service
+[Unit]
+Description=Heal and run setup.sh before networking
+DefaultDependencies=no
+Before=network-pre.target
+Wants=network-pre.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/codex -q -a full-auto "doctor setup.sh" && /usr/local/bin/setup.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add `AGENTS.md` rules for auto-healing `setup.sh`
- enable full-auto in `.codex/config.yaml`
- install Codex in devcontainers and run doctor
- provide example `codex-setup.service` for early boot
- document Codex integration in the README

## Testing
- `make -f Makefile.new test` *(fails: Mach headers not found)*