### PR TITLE
Improve setup script logging and fallback installers

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,32 +1,49 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 trap 'echo "Failure at line $LINENO: $BASH_COMMAND" >&2' ERR
-exec > >(tee -a setup.log) 2>&1
+
+# Log everything for troubleshooting. The log files help determine
+# which step failed during previous runs.
+LOG=/tmp/setup.log
+FAIL_LOG=/tmp/setup_failures.log
+exec > >(tee -a "$LOG") 2>&1
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get update -y
-apt-get dist-upgrade -y
+if ! apt-get update -y; then
+  echo "apt-get update failed" >> "$FAIL_LOG"
+fi
+if ! apt-get dist-upgrade -y; then
+  echo "apt-get dist-upgrade failed" >> "$FAIL_LOG"
+fi
 
 install_pkg() {
   local pkg="$1"
+  echo "\n===== Installing $pkg =====" | tee -a "$LOG"
+
   if apt-get install -y "$pkg"; then
+    echo "$pkg installed via apt" >> "$LOG"
     return 0
   fi
-  echo "apt-get failed for $pkg" >&2
+  echo "apt-get failed for $pkg" | tee -a "$FAIL_LOG"
+
   if pip install "$pkg"; then
+    echo "$pkg installed via pip" >> "$LOG"
     return 0
   fi
-  echo "pip failed for $pkg" >&2
+  echo "pip failed for $pkg" | tee -a "$FAIL_LOG"
+
   if npm install -g "$pkg"; then
+    echo "$pkg installed via npm" >> "$LOG"
     return 0
   fi
-  echo "npm failed for $pkg" >&2
+  echo "npm failed for $pkg" | tee -a "$FAIL_LOG"
   if [[ "$pkg" == "shellcheck" ]]; then
     wget -qO- https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.linux.x86_64.tar.xz | tar xJ
     install -m 0755 shellcheck-v0.9.0/shellcheck /usr/local/bin/shellcheck
     rm -rf shellcheck-v0.9.0
+    echo "$pkg installed from binary" >> "$LOG"
     return 0
   fi
   if [[ "$pkg" == "capnproto" ]]; then
@@ -37,26 +54,52 @@ install_pkg() {
     make -j"$(nproc)"
     make install
     popd
+    echo "$pkg built from source" >> "$LOG"
     return 0
   fi
-  echo "could not install $pkg" >&2
+  if [[ "$pkg" == "isabelle" ]]; then
+    wget -qO- https://isabelle.in.tum.de/dist/Isabelle2023-1_linux.tar.gz | tar xz
+    install -d /opt/isabelle
+    mv Isabelle2023-1 /opt/isabelle
+    ln -s /opt/isabelle/Isabelle2023-1/bin/isabelle /usr/local/bin/isabelle
+    echo "$pkg installed from archive" >> "$LOG"
+    return 0
+  fi
+  if [[ "$pkg" == "asda" ]]; then
+    wget -qO /usr/local/bin/asda https://example.com/asda
+    chmod +x /usr/local/bin/asda
+    echo "$pkg installed from custom source" >> "$LOG"
+    return 0
+  fi
+  echo "could not install $pkg" | tee -a "$FAIL_LOG" >&2
 }
 
 packages=(
-  clang lld llvm llvm-dev libclang-dev
+  build-essential git wget curl
+  clang lld llvm llvm-dev libclang-dev polly
   clang-tools clang-tidy clang-format clangd
   ccache lldb gdb bolt llvm-bolt
   cmake make ninja-build
+  doxygen graphviz python3-sphinx
   shellcheck yamllint
   python3 python3-pip python3-venv python3-setuptools python3-wheel
   nodejs npm yarnpkg
-  coq coqide tla4tools
+  coq coqide tla4tools isabelle asda
   afl++ honggfuzz cargo-fuzz
 )
 
 for pkg in "${packages[@]}"; do
   install_pkg "$pkg"
 done
+
+# Report any failures so the user can take further action. The failure log
+# persists across runs to make iterative troubleshooting easier.
+if [[ -s "$FAIL_LOG" ]]; then
+  echo "The following packages failed to install:" | tee -a "$LOG"
+  cat "$FAIL_LOG" | tee -a "$LOG"
+else
+  echo "All packages installed successfully" | tee -a "$LOG"
+fi
 
 export CC="ccache clang"
 export CXX="ccache clang++"
@@ -66,3 +109,10 @@ export PATH="/usr/lib/ccache:$PATH"
 export CFLAGS="-Wall -Wextra -Werror -O2"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-fuse-ld=lld -flto"
+export LLVM_PROFILE_FILE="/tmp/profiles/default.profraw"
+export CLANG_EXTRA_FLAGS="-mllvm -polly"
+
+# Troubleshooting notes:
+# - Inspect $LOG for command output from each step.
+# - Any package that could not be installed is listed in $FAIL_LOG.
+# - Rerun this script after addressing network or dependency issues.

--- a/setup.sh
+++ b/setup.sh
@@ -1,32 +1,49 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 trap 'echo "Failure at line $LINENO: $BASH_COMMAND" >&2' ERR
-exec > >(tee -a setup.log) 2>&1
+
+# Log everything for troubleshooting. The log files help determine
+# which step failed during previous runs.
+LOG=/tmp/setup.log
+FAIL_LOG=/tmp/setup_failures.log
+exec > >(tee -a "$LOG") 2>&1
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get update -y
-apt-get dist-upgrade -y
+if ! apt-get update -y; then
+  echo "apt-get update failed" >> "$FAIL_LOG"
+fi
+if ! apt-get dist-upgrade -y; then
+  echo "apt-get dist-upgrade failed" >> "$FAIL_LOG"
+fi
 
 install_pkg() {
   local pkg="$1"
+  echo "\n===== Installing $pkg =====" | tee -a "$LOG"
+
   if apt-get install -y "$pkg"; then
+    echo "$pkg installed via apt" >> "$LOG"
     return 0
   fi
-  echo "apt-get failed for $pkg" >&2
+  echo "apt-get failed for $pkg" | tee -a "$FAIL_LOG"
+
   if pip install "$pkg"; then
+    echo "$pkg installed via pip" >> "$LOG"
     return 0
   fi
-  echo "pip failed for $pkg" >&2
+  echo "pip failed for $pkg" | tee -a "$FAIL_LOG"
+
   if npm install -g "$pkg"; then
+    echo "$pkg installed via npm" >> "$LOG"
     return 0
   fi
-  echo "npm failed for $pkg" >&2
+  echo "npm failed for $pkg" | tee -a "$FAIL_LOG"
   if [[ "$pkg" == "shellcheck" ]]; then
     wget -qO- https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.linux.x86_64.tar.xz | tar xJ
     install -m 0755 shellcheck-v0.9.0/shellcheck /usr/local/bin/shellcheck
     rm -rf shellcheck-v0.9.0
+    echo "$pkg installed from binary" >> "$LOG"
     return 0
   fi
   if [[ "$pkg" == "capnproto" ]]; then
@@ -37,6 +54,7 @@ install_pkg() {
     make -j"$(nproc)"
     make install
     popd
+    echo "$pkg built from source" >> "$LOG"
     return 0
   fi
   if [[ "$pkg" == "isabelle" ]]; then
@@ -44,14 +62,16 @@ install_pkg() {
     install -d /opt/isabelle
     mv Isabelle2023-1 /opt/isabelle
     ln -s /opt/isabelle/Isabelle2023-1/bin/isabelle /usr/local/bin/isabelle
+    echo "$pkg installed from archive" >> "$LOG"
     return 0
   fi
   if [[ "$pkg" == "asda" ]]; then
     wget -qO /usr/local/bin/asda https://example.com/asda
     chmod +x /usr/local/bin/asda
+    echo "$pkg installed from custom source" >> "$LOG"
     return 0
   fi
-  echo "could not install $pkg" >&2
+  echo "could not install $pkg" | tee -a "$FAIL_LOG" >&2
 }
 
 packages=(
@@ -72,6 +92,15 @@ for pkg in "${packages[@]}"; do
   install_pkg "$pkg"
 done
 
+# Report any failures so the user can take further action. The failure log
+# persists across runs to make iterative troubleshooting easier.
+if [[ -s "$FAIL_LOG" ]]; then
+  echo "The following packages failed to install:" | tee -a "$LOG"
+  cat "$FAIL_LOG" | tee -a "$LOG"
+else
+  echo "All packages installed successfully" | tee -a "$LOG"
+fi
+
 export CC="ccache clang"
 export CXX="ccache clang++"
 export CLANG_TIDY=clang-tidy
@@ -82,3 +111,8 @@ export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-fuse-ld=lld -flto"
 export LLVM_PROFILE_FILE="/tmp/profiles/default.profraw"
 export CLANG_EXTRA_FLAGS="-mllvm -polly"
+
+# Troubleshooting notes:
+# - Inspect $LOG for command output from each step.
+# - Any package that could not be installed is listed in $FAIL_LOG.
+# - Rerun this script after addressing network or dependency issues.


### PR DESCRIPTION
## Summary
- add logging and failure tracking to `setup.sh`
- install packages using apt, pip or npm with verbose output
- copy updates to `.codex/setup.sh`

## Testing
- `bash -n setup.sh`
- `bash -n .codex/setup.sh`
