### PR TITLE
Replace bzero/bcopy/bcmp usage in server

### DIFF
--- a/server/i386/serv_machdep.c
+++ b/server/i386/serv_machdep.c
@@ -279,7 +279,7 @@ void pagemove(
 	kern_return_t kr = KERN_SUCCESS;
 
 	if(size % PAGE_SIZE || (int)from % PAGE_SIZE) 
-		bcopy(from, to, size);
+		memcpy(to, from, size);
 	else
 		kr = vm_write(mach_task_self(), (vm_offset_t) to,
 		      (vm_offset_t) from, size);

--- a/server/kern/init_main.c
+++ b/server/kern/init_main.c
@@ -231,7 +231,7 @@ _Noreturn void system_setup(void)
 	p->p_flag = P_INMEM | P_SYSTEM;
 	p->p_stat = SRUN;
 	p->p_nice = NZERO;
-	bcopy("swapper", p->p_comm, sizeof ("swapper"));
+	memcpy(p->p_comm, "swapper", sizeof ("swapper"));
 
 	/* Create credentials. */
 	cred0.p_refcnt = 1;

--- a/server/kern/kern_descrip.c
+++ b/server/kern/kern_descrip.c
@@ -468,12 +468,10 @@ fdalloc(p, want, result)
 		 * Copy the existing ofile and ofileflags arrays
 		 * and zero the new portion of each array.
 		 */
-		bcopy(fdp->fd_ofiles, newofile,
-			(i = sizeof(struct file *) * fdp->fd_nfiles));
-		bzero((char *)newofile + i, nfiles * sizeof(struct file *) - i);
-		bcopy(fdp->fd_ofileflags, newofileflags,
-			(i = sizeof(char) * fdp->fd_nfiles));
-		bzero(newofileflags + i, nfiles * sizeof(char) - i);
+		memcpy(newofile, fdp->fd_ofiles, (i = sizeof(struct file *) * fdp->fd_nfiles));
+		memset((char *)newofile + i, 0, nfiles * sizeof(struct file *) - i);
+		memcpy(newofileflags, fdp->fd_ofileflags, (i = sizeof(char) * fdp->fd_nfiles));
+		memset(newofileflags + i, 0, nfiles * sizeof(char) - i);
 		if (fdp->fd_nfiles > NDFILE)
 			FREE(fdp->fd_ofiles, M_FILEDESC);
 		fdp->fd_ofiles = newofile;
@@ -531,7 +529,7 @@ falloc(p, resultfp, resultfd)
 	 */
 	nfiles++;
 	MALLOC(fp, struct file *, sizeof(struct file), M_FILE, M_WAITOK);
-	bzero(fp, sizeof(struct file));
+	memset(fp, 0, sizeof(struct file));
 	if (fq = p->p_fd->fd_ofiles[0])
 		fpp = &fq->f_filef;
 	else
@@ -592,7 +590,7 @@ fdcopy(p)
 
 	MALLOC(newfdp, struct filedesc *, sizeof(struct filedesc0),
 	    M_FILEDESC, M_WAITOK);
-	bcopy(fdp, newfdp, sizeof(struct filedesc));
+	memcpy(newfdp, fdp, sizeof(struct filedesc));
 	VREF(newfdp->fd_cdir);
 	if (newfdp->fd_rdir)
 		VREF(newfdp->fd_rdir);
@@ -623,8 +621,8 @@ fdcopy(p)
 		newfdp->fd_ofileflags = (char *) &newfdp->fd_ofiles[i];
 	}
 	newfdp->fd_nfiles = i;
-	bcopy(fdp->fd_ofiles, newfdp->fd_ofiles, i * sizeof(struct file **));
-	bcopy(fdp->fd_ofileflags, newfdp->fd_ofileflags, i * sizeof(char));
+	memcpy(newfdp->fd_ofiles, fdp->fd_ofiles, i * sizeof(struct file **));
+	memcpy(newfdp->fd_ofileflags, fdp->fd_ofileflags, i * sizeof(char));
 	fpp = newfdp->fd_ofiles;
 	for (i = newfdp->fd_lastfile; i-- >= 0; fpp++)
 		if (*fpp != NULL)

--- a/server/kern/kern_proc.c
+++ b/server/kern/kern_proc.c
@@ -204,8 +204,7 @@ enterpgrp(p, pgid, mksess)
 			sess->s_count = 1;
 			sess->s_ttyvp = NULL;
 			sess->s_ttyp = NULL;
-			bcopy(p->p_session->s_login, sess->s_login,
-			    sizeof(sess->s_login));
+			memcpy(sess->s_login, p->p_session->s_login, sizeof(sess->s_login));
 			p->p_flag &= ~P_CONTROLT;
 			pgrp->pg_session = sess;
 #if DIAGNOSTIC

--- a/server/kern/kern_prot.c
+++ b/server/kern/kern_prot.c
@@ -495,7 +495,7 @@ crget()
 	register struct ucred *cr;
 
 	MALLOC(cr, struct ucred *, sizeof(*cr), M_CRED, M_WAITOK);
-	bzero((caddr_t)cr, sizeof(*cr));
+	memset((caddr_t)cr, 0, sizeof(*cr));
 	cr->cr_ref = 1;
 	return (cr);
 }

--- a/server/kern/kern_resource.c
+++ b/server/kern/kern_resource.c
@@ -516,8 +516,7 @@ limcopy(lim)
 
 	MALLOC(copy, struct plimit *, sizeof(struct plimit),
 	    M_SUBPROC, M_WAITOK);
-	bcopy(lim->pl_rlimit, copy->pl_rlimit,
-	    sizeof(struct rlimit) * RLIM_NLIMITS);
+	memcpy(copy->pl_rlimit, lim->pl_rlimit, sizeof(struct rlimit) * RLIM_NLIMITS);
 	copy->p_lflags = 0;
 	copy->p_refcnt = 1;
 	return (copy);

--- a/server/kern/kern_sig.c
+++ b/server/kern/kern_sig.c
@@ -1401,7 +1401,7 @@ mach_error_t coredump(struct proc *p)
 	LEASE_CHECK(vp, p, cred, LEASE_WRITE);
 	VOP_SETATTR(vp, &vattr, cred, p);
 	p->p_acflag |= ACORE;
-	bcopy(p, &p->p_addr->u_kproc.kp_proc, sizeof(struct proc));
+	memcpy(&p->p_addr->u_kproc.kp_proc, p, sizeof(struct proc));
 	fill_eproc(p, &p->p_addr->u_kproc.kp_eproc);
 	error = cpu_coredump(p, vp, cred);
 	if (error == 0)

--- a/server/kern/kern_subr.c
+++ b/server/kern/kern_subr.c
@@ -111,7 +111,7 @@ mach_error_t uiomove(cp, n, uio)
 		if (uio->uio_segflg == UIO_SYSSPACE || pk->k_reply_msg == 0) {
 		      /* UIO_SYSSPACE */
 			if (uio->uio_rw == UIO_READ) {
-				bcopy((caddr_t)cp, iov->iov_base, cnt);
+				memcpy(iov->iov_base, (caddr_t)cp, cnt);
 			} else {
 				boolean_t on_master = pk->k_master_lock;
 				/*
@@ -119,7 +119,7 @@ mach_error_t uiomove(cp, n, uio)
 				 */
 				if (on_master)
 				    unix_release();
-				bcopy(iov->iov_base, (caddr_t)cp, cnt);
+				memcpy((caddr_t)cp, iov->iov_base, cnt);
 				if (on_master)
 				    unix_master();
 			}
@@ -132,7 +132,7 @@ mach_error_t uiomove(cp, n, uio)
 						(vm_offset_t) iov->iov_base,
 							     cnt,
 							     iov->iov_len);
-				bcopy(cp, (void *) user_addr, cnt);
+				memcpy((void *) user_addr, cp, cnt);
 				extend_current_output(cnt);
 			} else {
 				error = copyin(iov->iov_base, cp, cnt);

--- a/server/kern/kern_sysctl.c
+++ b/server/kern/kern_sysctl.c
@@ -489,10 +489,10 @@ sysctl_string(oldp, oldlenp, newp, newlen, str, maxlen)
 		return (EINVAL);
 	if (oldp) {
 		*oldlenp = len;
-		bcopy(str, oldp, len);
+		memcpy(oldp, str, len);
 	}
 	if (error == 0 && newp) {
-		bcopy(newp, str, newlen);
+		memcpy(str, newp, newlen);
 		str[newlen] = 0;
 	}
 	return (error);
@@ -516,7 +516,7 @@ sysctl_rdstring(oldp, oldlenp, newp, str)
 		return (EPERM);
 	*oldlenp = len;
 	if (oldp)
-		bcopy(str, oldp, len);
+		memcpy(oldp, str, len);
 	return (error);
 }
 
@@ -540,10 +540,10 @@ sysctl_struct(oldp, oldlenp, newp, newlen, sp, len)
 		return (EINVAL);
 	if (oldp) {
 		*oldlenp = len;
-		bcopy(sp, oldp, len);
+		memcpy(oldp, sp, len);
 	}
 	if (error == 0 && newp)
-		bcopy(newp, sp, len);
+		memcpy(sp, newp, len);
 	return (error);
 }
 
@@ -565,7 +565,7 @@ sysctl_rdstruct(oldp, oldlenp, newp, sp, len)
 		return (EPERM);
 	*oldlenp = len;
 	if (oldp)
-		bcopy(sp, oldp, len);
+		memcpy(oldp, sp, len);
 	return (error);
 }
 
@@ -596,7 +596,7 @@ sysctl_file(where, sizep)
 		*sizep = 0;
 		return (0);
 	}
-	bcopy((caddr_t)&filehead, where, sizeof(filehead));
+	memcpy(where, (caddr_t)&filehead, sizeof(filehead));
 	buflen -= sizeof(filehead);
 	where += sizeof(filehead);
 
@@ -608,7 +608,7 @@ sysctl_file(where, sizep)
 			*sizep = where - start;
 			return (ENOMEM);
 		}
-		bcopy((caddr_t)fp, where, sizeof (struct file));
+		memcpy(where, (caddr_t)fp, sizeof (struct file));
 		buflen -= sizeof(struct file);
 		where += sizeof(struct file);
 	}
@@ -683,8 +683,8 @@ again:
 		}
 		if (buflen >= sizeof(struct kinfo_proc)) {
 			fill_eproc(p, &eproc);
-			bcopy((caddr_t)p, &dp->kp_proc, sizeof (struct proc));
-			bcopy((caddr_t)&eproc, &dp->kp_eproc, sizeof (eproc));
+			memcpy(&dp->kp_proc, (caddr_t)p, sizeof (struct proc));
+			memcpy(&dp->kp_eproc, (caddr_t)&eproc, sizeof (eproc));
 			dp++;
 			buflen -= sizeof(struct kinfo_proc);
 		}

--- a/server/kern/subr_prf.c
+++ b/server/kern/subr_prf.c
@@ -552,7 +552,7 @@ static void putchar(
 	    c != '\0' && c != '\r' && c != 0177 && msgbufmapped) {
 		mbp = msgbufp;	/* XXX locking */
 		if (mbp->msg_magic != MSG_MAGIC) {
-			bzero((caddr_t)mbp, sizeof(*mbp));
+			memset((caddr_t)mbp, 0, sizeof(*mbp));
 			mbp->msg_magic = MSG_MAGIC;
 		}
 		mbp->msg_bufc[mbp->msg_bufx++] = c;

--- a/server/kern/sys_generic.c
+++ b/server/kern/sys_generic.c
@@ -177,7 +177,7 @@ s_readv(p, uap, retval)
 	 */
 	if (KTRPOINT(p, KTR_GENIO))  {
 		MALLOC(ktriov, struct iovec *, iovlen, M_TEMP, M_WAITOK);
-		bcopy((caddr_t)auio.uio_iov, (caddr_t)ktriov, iovlen);
+		memcpy((caddr_t)ktriov, (caddr_t)auio.uio_iov, iovlen);
 	}
 #endif
 	cnt = auio.uio_resid;
@@ -328,7 +328,7 @@ writev(p, uap, retval)
 	 */
 	if (KTRPOINT(p, KTR_GENIO))  {
 		MALLOC(ktriov, struct iovec *, iovlen, M_TEMP, M_WAITOK);
-		bcopy((caddr_t)auio.uio_iov, (caddr_t)ktriov, iovlen);
+		memcpy((caddr_t)ktriov, (caddr_t)auio.uio_iov, iovlen);
 	}
 #endif
 	cnt = auio.uio_resid;
@@ -424,7 +424,7 @@ ioctl(p, uap, retval)
 		 * Zero the buffer so the user always
 		 * gets back something deterministic.
 		 */
-		bzero(data, size);
+		memset(data, 0, size);
 	else if (com&IOC_VOID)
 		*(caddr_t *)data = uap->data;
 

--- a/server/kern/tty.c
+++ b/server/kern/tty.c
@@ -170,7 +170,7 @@ ttyopen(device, tp)
 	tp->t_dev = device;
 	if (!ISSET(tp->t_state, TS_ISOPEN)) {
 		SET(tp->t_state, TS_ISOPEN);
-		bzero(&tp->t_winsize, sizeof(tp->t_winsize));
+		memset(&tp->t_winsize, 0, sizeof(tp->t_winsize));
 	}
 	CLR(tp->t_state, TS_WOPEN);
 	splx(s);
@@ -719,7 +719,7 @@ ttioctl(
 	case TIOCGETA: {		/* get termios struct */
 		struct termios *t = (struct termios *)data;
 
-		bcopy(&tp->t_termios, t, sizeof(struct termios));
+		memcpy(t, &tp->t_termios, sizeof(struct termios));
 		break;
 	}
 	case TIOCGETD:			/* get line discipline */
@@ -809,7 +809,7 @@ ttioctl(
 		else
 			CLR(t->c_lflag, EXTPROC);
 		tp->t_lflag = t->c_lflag | ISSET(tp->t_lflag, PENDIN);
-		bcopy(t->c_cc, tp->t_cc, sizeof(t->c_cc));
+		memcpy(tp->t_cc, t->c_cc, sizeof(t->c_cc));
 		splx(s);
 		break;
 	}
@@ -884,7 +884,7 @@ ttioctl(
 		break;
 	}
 	case TIOCSWINSZ:		/* set window size */
-		if (bcmp((caddr_t)&tp->t_winsize, data,
+		if (memcmp((caddr_t)&tp->t_winsize, data,
 		    sizeof (struct winsize))) {
 			tp->t_winsize = *(struct winsize *)data;
 			pgsignal(tp->t_pgrp, SIGWINCH, 1);
@@ -1025,7 +1025,7 @@ ttychars(tp)
 	struct tty *tp;
 {
 
-	bcopy(ttydefchars, tp->t_cc, sizeof(ttydefchars));
+	memcpy(tp->t_cc, ttydefchars, sizeof(ttydefchars));
 }
 
 /*

--- a/server/kern/tty_subr.c
+++ b/server/kern/tty_subr.c
@@ -143,7 +143,7 @@ q_to_b(struct clist *clp, char *cp, int count)
     while (count && clp->c_cc) {
 	register int bytes;
 	bytes = min(count, clpbytestoread(clp));
-	bcopy(clp->c_cf, cp, bytes);
+	memcpy(cp, clp->c_cf, bytes);
 	clp->c_cf += bytes;
 	clp->c_cc -= bytes;
 	count -= bytes;
@@ -278,7 +278,7 @@ b_to_q(char *cp, int count, struct clist *clp)
 		return count;
 	    }
 	    ts = min(clpbytestowrite(clp),count);
-	    bcopy(cp, clp->c_cl, ts);
+	    memcpy(clp->c_cl, cp, ts);
 	    clp->c_cl += ts-1;
 	    clp->c_cc += ts-1;
 	    count -= ts;

--- a/server/kern/tty_tb.c
+++ b/server/kern/tty_tb.c
@@ -115,7 +115,7 @@ tbopen(dev, tp)
 	tbp->tbflags = TBTIGER|TBPOINT;		/* default */
 	tp->t_cp = tbp->cbuf;
 	tp->t_inbuf = 0;
-	bzero((caddr_t)&tbp->rets, sizeof (tbp->rets));
+	memset((caddr_t)&tbp->rets, 0, sizeof (tbp->rets));
 	tp->T_LINEP = (caddr_t)tbp;
 	tp->t_flags |= LITOUT;
 	return (0);

--- a/server/kern/uipc_mbuf.c
+++ b/server/kern/uipc_mbuf.c
@@ -166,7 +166,7 @@ m_getclr(int nowait, int type)
 	MGET(m, nowait, type);
 	if (m == 0)
 		return (0);
-	bzero(mtod(m, caddr_t), MLEN);
+	memset(mtod(m, 0, caddr_t), MLEN);
 	return (m);
 }
 
@@ -290,7 +290,7 @@ m_copym(struct mbuf *m, int off0, int len, int wait)
 			n->m_ext.ext_buf = (caddr_t)new_addr;
 			n->m_flags |= M_EXT;
 		} else {
-			bcopy(mtod(m, caddr_t)+off, mtod(n, caddr_t),
+			memcpy(caddr_t)+off, mtod(m, mtod(n, caddr_t),
 			    (unsigned)n->m_len);
 		}
 		if (len != M_COPYALL)
@@ -331,7 +331,7 @@ m_copydata(struct mbuf *m, int off, int len, caddr_t cp)
 		if (m == 0)
 			panic("m_copydata");
 		count = min(m->m_len - off, len);
-		bcopy(mtod(m, caddr_t) + off, cp, count);
+		memcpy(caddr_t) + off, mtod(m, cp, count);
 		len -= count;
 		cp += count;
 		off = 0;
@@ -357,7 +357,7 @@ m_cat(struct mbuf *m, struct mbuf *n)
 			return;
 		}
 		/* splat the data from one into the other */
-		bcopy(mtod(n, caddr_t), mtod(m, caddr_t) + m->m_len,
+		memcpy(caddr_t), mtod(n, mtod(m, caddr_t) + m->m_len,
 		    (u_int)n->m_len);
 		m->m_len += n->m_len;
 		n = m_free(n);
@@ -480,7 +480,7 @@ m_pullup(struct mbuf *n, int len)
 	space = &m->m_dat[MLEN] - (m->m_data + m->m_len);
 	do {
 		count = min(min(max(len, max_protohdr), space), n->m_len);
-		bcopy(mtod(n, caddr_t), mtod(m, caddr_t) + m->m_len,
+		memcpy(caddr_t), mtod(n, mtod(m, caddr_t) + m->m_len,
 		  (unsigned)count);
 		len -= count;
 		m->m_len += count;
@@ -563,7 +563,7 @@ extpacket:
 		panic("m_split: M_EXT");
 #endif
 	} else {
-		bcopy(mtod(m, caddr_t) + len, mtod(n, caddr_t), remain);
+		memcpy(caddr_t) + len, mtod(m, mtod(n, caddr_t), remain);
 	}
 	n->m_len = remain;
 	m->m_len = len;

--- a/server/kern/uipc_socket.c
+++ b/server/kern/uipc_socket.c
@@ -79,7 +79,7 @@ socreate(dom, aso, type, proto)
 	if (prp->pr_type != type)
 		return (EPROTOTYPE);
 	MALLOC(so, struct socket *, sizeof(*so), M_SOCKET, M_WAIT);
-	bzero((caddr_t)so, sizeof(*so));
+	memset((caddr_t)so, 0, sizeof(*so));
 	so->so_type = type;
 	if (p->p_ucred->cr_uid == 0)
 		so->so_state = SS_PRIV;
@@ -817,7 +817,7 @@ sorflush(so)
 	socantrcvmore(so);
 	sbunlock(sb);
 	asb = *sb;
-	bzero((caddr_t)sb, sizeof (*sb));
+	memset((caddr_t)sb, 0, sizeof (*sb));
 	splx(s);
 	if (pr->pr_flags & PR_RIGHTS && pr->pr_domain->dom_dispose)
 		(*pr->pr_domain->dom_dispose)(asb.sb_mb);

--- a/server/kern/uipc_socket2.c
+++ b/server/kern/uipc_socket2.c
@@ -158,7 +158,7 @@ sonewconn1(head, connstatus)
 	MALLOC(so, struct socket *, sizeof(*so), M_SOCKET, M_DONTWAIT);
 	if (so == NULL) 
 		return ((struct socket *)0);
-	bzero((caddr_t)so, sizeof(*so));
+	memset((caddr_t)so, 0, sizeof(*so));
 	so->so_type = head->so_type;
 	so->so_options = head->so_options &~ SO_ACCEPTCONN;
 	so->so_linger = head->so_linger;
@@ -581,7 +581,7 @@ panic("sbappendaddr");
 	if (m == 0)
 		return (0);
 	m->m_len = asa->sa_len;
-	bcopy((caddr_t)asa, mtod(m, caddr_t), asa->sa_len);
+	memcpy(mtod(m, (caddr_t)asa, caddr_t), asa->sa_len);
 	if (n)
 		n->m_next = m0;		/* concatenate data to control */
 	else
@@ -653,7 +653,7 @@ sbcompress(sb, m, n)
 		if (n && (n->m_flags & (M_EXT | M_EOR)) == 0 &&
 		    (n->m_data + n->m_len + m->m_len) < &n->m_dat[MLEN] &&
 		    n->m_type == m->m_type) {
-			bcopy(mtod(m, caddr_t), mtod(n, caddr_t) + n->m_len,
+			memcpy(caddr_t), mtod(m, mtod(n, caddr_t) + n->m_len,
 			    (unsigned)m->m_len);
 			n->m_len += m->m_len;
 			sb->sb_cc += m->m_len;

--- a/server/kern/uipc_syscalls.c
+++ b/server/kern/uipc_syscalls.c
@@ -450,8 +450,7 @@ mach_error_t s_recvmsg(
 			if (len > from_mbuf->m_len)
 				len = from_mbuf->m_len;
 			/* else if len < from_mbuf->m_len ??? */
-			bcopy (mtod(from_mbuf, caddr_t),
-			       from, (unsigned) len);
+			memcpy(caddr_t), mtod(from_mbuf, from, (unsigned) len);
 		}
 		*fromlen = len;
 	}
@@ -485,7 +484,7 @@ mach_error_t s_recvmsg(
 				len = control->m_len;
 			else
 				*outflags |= MSG_CTRUNC;
-			bcopy((caddr_t) mtod(control, caddr_t), cmsg, len);
+			memcpy(caddr_t), (caddr_t) mtod(control, cmsg, len);
 		}
 		*cmsglen = len;
 	}
@@ -535,7 +534,7 @@ mach_error_t s_setsockopt(
 		m = m_get(M_WAIT, MT_SOOPTS);
 		if (m == NULL)
 			return (ENOBUFS);
-		bcopy(val, mtod(m, caddr_t), (u_int)valsize);
+		memcpy(mtod(m, val, caddr_t), (u_int)valsize);
 		m->m_len = valsize;
 	}
 	return sosetopt((struct socket *)fp->f_data, level, name, m);
@@ -556,7 +555,7 @@ mach_error_t s_getsockopt(
 	if (error = getsock(p->p_fd, s, &fp))
 		return (error);
 	if (val)
-		bcopy((caddr_t)avalsize, (caddr_t)&valsize, sizeof (valsize));
+		memcpy((caddr_t)&valsize, (caddr_t)avalsize, sizeof (valsize));
 	else
 		valsize = 0;
 	if ((error = sogetopt((struct socket *)fp->f_data, level,
@@ -725,7 +724,7 @@ NEWsockargs(mp, buf, buflen, type)
 	if (m == NULL)
 		return (ENOBUFS);
 	m->m_len = buflen;
-	bcopy(buf, mtod(m, caddr_t), (u_int)buflen);
+	memcpy(mtod(m, buf, caddr_t), (u_int)buflen);
 	*mp = m;
 	if (type == MT_SONAME) {
 		sa = mtod(m, struct sockaddr *);
@@ -914,7 +913,7 @@ sendit(p, s, mp, flags, retsize)
 		int iovlen = auio.uio_iovcnt * sizeof (struct iovec);
 
 		MALLOC(ktriov, struct iovec *, iovlen, M_TEMP, M_WAITOK);
-		bcopy((caddr_t)auio.uio_iov, (caddr_t)ktriov, iovlen);
+		memcpy((caddr_t)ktriov, (caddr_t)auio.uio_iov, iovlen);
 	}
 #endif
 	len = auio.uio_resid;
@@ -1024,7 +1023,7 @@ recvit(p, s, mp, namelenp, retsize)
 		int iovlen = auio.uio_iovcnt * sizeof (struct iovec);
 
 		MALLOC(ktriov, struct iovec *, iovlen, M_TEMP, M_WAITOK);
-		bcopy((caddr_t)auio.uio_iov, (caddr_t)ktriov, iovlen);
+		memcpy((caddr_t)ktriov, (caddr_t)auio.uio_iov, iovlen);
 	}
 #endif
 	len = auio.uio_resid;

--- a/server/kern/uipc_usrreq.c
+++ b/server/kern/uipc_usrreq.c
@@ -124,8 +124,7 @@ uipc_usrreq(so, req, m, nam, control)
 		 */
 		if (unp->unp_conn && unp->unp_conn->unp_addr) {
 			nam->m_len = unp->unp_conn->unp_addr->m_len;
-			bcopy(mtod(unp->unp_conn->unp_addr, caddr_t),
-			    mtod(nam, caddr_t), (unsigned)nam->m_len);
+			memcpy(caddr_t), mtod(unp->unp_conn->unp_addr, mtod(nam, caddr_t), (unsigned)nam->m_len);
 		} else {
 			nam->m_len = sizeof(sun_noname);
 			*(mtod(nam, struct sockaddr *)) = sun_noname;
@@ -268,8 +267,7 @@ uipc_usrreq(so, req, m, nam, control)
 	case PRU_SOCKADDR:
 		if (unp->unp_addr) {
 			nam->m_len = unp->unp_addr->m_len;
-			bcopy(mtod(unp->unp_addr, caddr_t),
-			    mtod(nam, caddr_t), (unsigned)nam->m_len);
+			memcpy(caddr_t), mtod(unp->unp_addr, mtod(nam, caddr_t), (unsigned)nam->m_len);
 		} else
 			nam->m_len = 0;
 		break;
@@ -277,8 +275,7 @@ uipc_usrreq(so, req, m, nam, control)
 	case PRU_PEERADDR:
 		if (unp->unp_conn && unp->unp_conn->unp_addr) {
 			nam->m_len = unp->unp_conn->unp_addr->m_len;
-			bcopy(mtod(unp->unp_conn->unp_addr, caddr_t),
-			    mtod(nam, caddr_t), (unsigned)nam->m_len);
+			memcpy(caddr_t), mtod(unp->unp_conn->unp_addr, mtod(nam, caddr_t), (unsigned)nam->m_len);
 		} else
 			nam->m_len = 0;
 		break;

--- a/server/kern/vfs_bio.c
+++ b/server/kern/vfs_bio.c
@@ -92,7 +92,7 @@ bufinit()
 	/* finally, initialize each buffer header and stick on empty q */
 	for(i=0;i<nbuf;i++) {
 		bp = &buf[i];
-		bzero(bp, sizeof *bp);
+		memset(bp, 0, sizeof *bp);
 		bp->b_flags = B_INVAL;	/* we're just an empty header */
 		bp->b_dev = NODEV;
 		bp->b_vp = NULL;

--- a/server/kern/vfs_cache.c
+++ b/server/kern/vfs_cache.c
@@ -107,7 +107,7 @@ cache_lookup(dvp, vpp, cnp)
 		if (ncp->nc_dvp == dvp &&
 		    ncp->nc_dvpid == dvp->v_id &&
 		    ncp->nc_nlen == cnp->cn_namelen &&
-		    !bcmp(ncp->nc_name, cnp->cn_nameptr, (u_int)ncp->nc_nlen))
+		    !memcmp(ncp->nc_name, cnp->cn_nameptr, (u_int)ncp->nc_nlen))
 			break;
 	}
 	if (ncp == NULL) {
@@ -207,7 +207,7 @@ cache_enter(dvp, vp, cnp)
 	if (numcache < desiredvnodes) {
 		ncp = (struct namecache *)
 			malloc((u_long)sizeof *ncp, M_CACHE, M_WAITOK);
-		bzero((char *)ncp, sizeof *ncp);
+		memset((char *)ncp, 0, sizeof *ncp);
 		numcache++;
 	} else if (ncp = nchhead) {
 		/* remove from lru chain */
@@ -236,7 +236,7 @@ cache_enter(dvp, vp, cnp)
 	ncp->nc_dvp = dvp;
 	ncp->nc_dvpid = dvp->v_id;
 	ncp->nc_nlen = cnp->cn_namelen;
-	bcopy(cnp->cn_nameptr, ncp->nc_name, (unsigned)ncp->nc_nlen);
+	memcpy(ncp->nc_name, cnp->cn_nameptr, (unsigned)ncp->nc_nlen);
 	/* link at end of lru chain */
 	ncp->nc_nxt = NULL;
 	ncp->nc_prev = nchtail;

--- a/server/kern/vfs_init.c
+++ b/server/kern/vfs_init.c
@@ -121,7 +121,7 @@ vfs_opv_init()
 			/* XXX - shouldn't be M_VNODE */
 			MALLOC(*opv_desc_vector_p, PFI*,
 			       vfs_opv_numops*sizeof(PFI), M_VNODE, M_WAITOK);
-			bzero (*opv_desc_vector_p, vfs_opv_numops*sizeof(PFI));
+			memset(*opv_desc_vector_p, 0, vfs_opv_numops*sizeof(PFI));
 			DODEBUG(printf("vector at %x allocated\n",
 			    opv_desc_vector_p));
 		}

--- a/server/kern/vfs_lookup.c
+++ b/server/kern/vfs_lookup.c
@@ -191,7 +191,7 @@ namei(ndp)
 			break;
 		}
 		if (ndp->ni_pathlen > 1) {
-			bcopy(ndp->ni_next, cp + linklen, ndp->ni_pathlen);
+			memcpy(cp + linklen, ndp->ni_next, ndp->ni_pathlen);
 			FREE(cnp->cn_pnbuf, M_NAMEI);
 			cnp->cn_pnbuf = cp;
 		} else
@@ -304,19 +304,19 @@ dirloop:
 	if (cnp->cn_nameptr[0] == '@') {
 		extern char hostname[], machine[], atsys[];
 		if (cnp->cn_namelen == 4) {
-			if (!bcmp("sys", cnp->cn_nameptr + 1, 3)) {
+			if (!memcmp("sys", cnp->cn_nameptr + 1, 3)) {
 				cnp->cn_nameptr = atsys;
 				cnp->cn_namelen = strlen(cnp->cn_nameptr);
-			} else if (!bcmp("cpu", cnp->cn_nameptr + 1, 3)) {
+			} else if (!memcmp("cpu", cnp->cn_nameptr + 1, 3)) {
 				cnp->cn_nameptr = machine;
 				cnp->cn_namelen = strlen(cnp->cn_nameptr);
-			} else if (!bcmp("bin", cnp->cn_nameptr + 1, 3)) {
+			} else if (!memcmp("bin", cnp->cn_nameptr + 1, 3)) {
 				cnp->cn_nameptr = (p->p_atbin
 						   ? p->p_atbin : atsys);
 				cnp->cn_namelen = strlen(cnp->cn_nameptr);
 			}
 		} else if (cnp->cn_namelen == 5) {
-			if (!bcmp("host", cnp->cn_nameptr + 1, 4)) {
+			if (!memcmp("host", cnp->cn_nameptr + 1, 4)) {
 				cnp->cn_nameptr = hostname;
 				cnp->cn_namelen = strlen(cnp->cn_nameptr);
 			}

--- a/server/kern/vfs_subr.c
+++ b/server/kern/vfs_subr.c
@@ -255,7 +255,7 @@ getnewvnode(tag, mp, vops, vpp)
 	    numvnodes < desiredvnodes) {
 		vp = (struct vnode *)malloc((u_long)sizeof *vp,
 		    M_VNODE, M_WAITOK);
-		bzero((char *)vp, sizeof *vp);
+		memset((char *)vp, 0, sizeof *vp);
 		vp->v_cache_state = VC_FREE;
 		numvnodes++;
 	} else {
@@ -1139,8 +1139,8 @@ again:
 			   (error = copyout((caddr_t)vp, bp + VPTRSZ, VNODESZ)))
 				return (error);
 #else
-			bcopy((caddr_t)&vp, bp, VPTRSZ);
-			bcopy((caddr_t)vp, bp + VPTRSZ, VNODESZ);
+			memcpy(bp, (caddr_t)&vp, VPTRSZ);
+			memcpy(bp + VPTRSZ, (caddr_t)vp, VNODESZ);
 #endif
 			bp += VPTRSZ + VNODESZ;
 		}
@@ -1204,7 +1204,7 @@ vfs_hang_addrlist(mp, nep, argp)
 	}
 	i = sizeof(struct netcred) + argp->ex_addrlen + argp->ex_masklen;
 	np = (struct netcred *)malloc(i, M_NETADDR, M_WAITOK);
-	bzero((caddr_t)np, i);
+	memset((caddr_t)np, 0, i);
 	saddr = (struct sockaddr *)(np + 1);
 	if (error = copyin(argp->ex_addr, (caddr_t)saddr, argp->ex_addrlen))
 		goto out;

--- a/server/kern/vfs_syscalls.c
+++ b/server/kern/vfs_syscalls.c
@@ -135,7 +135,7 @@ mount(p, uap, retval)
 	 */
 	mp = (struct mount *)malloc((u_long)sizeof(struct mount),
 		M_MOUNT, M_WAITOK);
-	bzero((char *)mp, (u_long)sizeof(struct mount));
+	memset((char *)mp, 0, (u_long)sizeof(struct mount));
 	mp->mnt_op = vfssw[uap->type];
 	if (error = vfs_lock(mp)) {
 		free((caddr_t)mp, M_MOUNT);
@@ -1728,7 +1728,7 @@ rename(p, uap, retval)
 	 */
 	if (fvp == tvp && fromnd.ni_dvp == tdvp &&
 	    fromnd.ni_cnd.cn_namelen == tond.ni_cnd.cn_namelen &&
-	    !bcmp(fromnd.ni_cnd.cn_nameptr, tond.ni_cnd.cn_nameptr,
+	    !memcmp(fromnd.ni_cnd.cn_nameptr, tond.ni_cnd.cn_nameptr,
 	      fromnd.ni_cnd.cn_namelen))
 		error = -1;
 out:

--- a/server/mips/serv_machdep.c
+++ b/server/mips/serv_machdep.c
@@ -107,7 +107,7 @@ void set_emulator_state(
     unsigned int count;
     kern_return_t ret;
 
-    bzero(&ts, sizeof(ts));
+    memset(&ts, 0, sizeof(ts));
     ts.pc  = li->pc;
     ts.r29 = li->sp;
     ts.r6  = li->sp;
@@ -274,5 +274,5 @@ pagemove(from, to, size)
 /* XXX */
 void blkclr(caddr_t addr, size_t count)
 {
-	bzero(addr, count);
+	memset(addr, 0, count);
 }

--- a/server/miscfs/fdesc/fdesc_vfsops.c
+++ b/server/miscfs/fdesc/fdesc_vfsops.c
@@ -92,9 +92,9 @@ fdesc_mount(mp, path, data, ndp, p)
 	getnewfsid(mp, MOUNT_FDESC);
 
 	(void) copyinstr(path, mp->mnt_stat.f_mntonname, MNAMELEN - 1, &size);
-	bzero(mp->mnt_stat.f_mntonname + size, MNAMELEN - size);
-	bzero(mp->mnt_stat.f_mntfromname, MNAMELEN);
-	bcopy("fdesc", mp->mnt_stat.f_mntfromname, sizeof("fdesc"));
+	memset(mp->mnt_stat.f_mntonname + size, 0, MNAMELEN - size);
+	memset(mp->mnt_stat.f_mntfromname, 0, MNAMELEN);
+	memcpy(mp->mnt_stat.f_mntfromname, "fdesc", sizeof("fdesc"));
 	return (0);
 }
 
@@ -224,9 +224,9 @@ fdesc_statfs(mp, sbp, p)
 	sbp->f_files = lim + 1;		/* Allow for "." */
 	sbp->f_ffree = freefd;		/* See comments above */
 	if (sbp != &mp->mnt_stat) {
-		bcopy(&mp->mnt_stat.f_fsid, &sbp->f_fsid, sizeof(sbp->f_fsid));
-		bcopy(mp->mnt_stat.f_mntonname, sbp->f_mntonname, MNAMELEN);
-		bcopy(mp->mnt_stat.f_mntfromname, sbp->f_mntfromname, MNAMELEN);
+		memcpy(&sbp->f_fsid, &mp->mnt_stat.f_fsid, sizeof(sbp->f_fsid));
+		memcpy(sbp->f_mntonname, mp->mnt_stat.f_mntonname, MNAMELEN);
+		memcpy(sbp->f_mntfromname, mp->mnt_stat.f_mntfromname, MNAMELEN);
 	}
 	strncpy(sbp->f_fstypename, mp->mnt_op->vfs_name, MFSNAMELEN);
 	return (0);

--- a/server/miscfs/fdesc/fdesc_vnops.c
+++ b/server/miscfs/fdesc/fdesc_vnops.c
@@ -210,7 +210,7 @@ fdesc_lookup(ap)
 		goto bad;
 
 	case Froot:
-		if (ap->a_cnp->cn_namelen == 2 && bcmp(pname, "fd", 2) == 0) {
+		if (ap->a_cnp->cn_namelen == 2 && memcmp(pname, "fd", 2) == 0) {
 			error = fdesc_allocvp(Fdevfd, FD_DEVFD, dvp->v_mount, &fvp);
 			if (error)
 				goto bad;
@@ -220,7 +220,7 @@ fdesc_lookup(ap)
 			return (0);
 		}
 
-		if (ap->a_cnp->cn_namelen == 3 && bcmp(pname, "tty", 3) == 0) {
+		if (ap->a_cnp->cn_namelen == 3 && memcmp(pname, "tty", 3) == 0) {
 			struct vnode *ttyvp = cttyvp(p);
 			if (ttyvp == NULL) {
 				error = ENXIO;
@@ -238,17 +238,17 @@ fdesc_lookup(ap)
 		ln = 0;
 		switch (ap->a_cnp->cn_namelen) {
 		case 5:
-			if (bcmp(pname, "stdin", 5) == 0) {
+			if (memcmp(pname, "stdin", 5) == 0) {
 				ln = "fd/0";
 				fd = FD_STDIN;
 			}
 			break;
 		case 6:
-			if (bcmp(pname, "stdout", 6) == 0) {
+			if (memcmp(pname, "stdout", 6) == 0) {
 				ln = "fd/1";
 				fd = FD_STDOUT;
 			} else
-			if (bcmp(pname, "stderr", 6) == 0) {
+			if (memcmp(pname, "stderr", 6) == 0) {
 				ln = "fd/2";
 				fd = FD_STDERR;
 			}
@@ -272,7 +272,7 @@ fdesc_lookup(ap)
 		/* FALL THROUGH */
 
 	case Fdevfd:
-		if (ap->a_cnp->cn_namelen == 2 && bcmp(pname, "..", 2) == 0) {
+		if (ap->a_cnp->cn_namelen == 2 && memcmp(pname, "..", 2) == 0) {
 			error = fdesc_root(dvp->v_mount, vpp);
 			return (error);
 		}
@@ -423,7 +423,7 @@ fdesc_getattr(ap)
 	case Fdevfd:
 	case Flink:
 	case Fctty:
-		bzero((caddr_t) vap, sizeof(*vap));
+		memset((caddr_t) vap, 0, sizeof(*vap));
 		vattr_null(vap);
 		vap->va_fileid = VTOFDESC(vp)->fd_ix;
 
@@ -605,12 +605,12 @@ fdesc_readdir(ap)
 					continue;
 				break;
 			}
-			bzero((caddr_t) dp, UIO_MX);
+			memset((caddr_t) dp, 0, UIO_MX);
 			dp->d_fileno = dt->d_fileno;
 			dp->d_namlen = dt->d_namlen;
 			dp->d_type = DT_UNKNOWN;
 			dp->d_reclen = dt->d_reclen;
-			bcopy(dt->d_name, dp->d_name, dp->d_namlen+1);
+			memcpy(dp->d_name, dt->d_name, dp->d_namlen+1);
 			error = uiomove((caddr_t) dp, UIO_MX, uio);
 			if (error)
 				break;
@@ -629,7 +629,7 @@ fdesc_readdir(ap)
 			struct dirent d;
 			struct dirent *dp = &d;
 
-			bzero((caddr_t) dp, UIO_MX);
+			memset((caddr_t) dp, 0, UIO_MX);
 
 			dp->d_namlen = sprintf(dp->d_name, "%d", i);
 			dp->d_reclen = UIO_MX;

--- a/server/miscfs/kernfs/kernfs_vfsops.c
+++ b/server/miscfs/kernfs/kernfs_vfsops.c
@@ -157,9 +157,9 @@ mach_error_t kernfs_mount(mp, path, data, ndp, p)
 	getnewfsid(mp, MOUNT_KERNFS);
 
 	(void) copyinstr(path, mp->mnt_stat.f_mntonname, MNAMELEN - 1, &size);
-	bzero(mp->mnt_stat.f_mntonname + size, MNAMELEN - size);
-	bzero(mp->mnt_stat.f_mntfromname, MNAMELEN);
-	bcopy("kernfs", mp->mnt_stat.f_mntfromname, sizeof("kernfs"));
+	memset(mp->mnt_stat.f_mntonname + size, 0, MNAMELEN - size);
+	memset(mp->mnt_stat.f_mntfromname, 0, MNAMELEN);
+	memcpy(mp->mnt_stat.f_mntfromname, "kernfs", sizeof("kernfs"));
 #ifdef KERNFS_DIAGNOSTIC
 	printf("kernfs_mount: at %s\n", mp->mnt_stat.f_mntonname);
 #endif
@@ -276,9 +276,9 @@ mach_error_t kernfs_statfs(mp, sbp, p)
 	sbp->f_files = 0;
 	sbp->f_ffree = 0;
 	if (sbp != &mp->mnt_stat) {
-		bcopy(&mp->mnt_stat.f_fsid, &sbp->f_fsid, sizeof(sbp->f_fsid));
-		bcopy(mp->mnt_stat.f_mntonname, sbp->f_mntonname, MNAMELEN);
-		bcopy(mp->mnt_stat.f_mntfromname, sbp->f_mntfromname, MNAMELEN);
+		memcpy(&sbp->f_fsid, &mp->mnt_stat.f_fsid, sizeof(sbp->f_fsid));
+		memcpy(sbp->f_mntonname, mp->mnt_stat.f_mntonname, MNAMELEN);
+		memcpy(sbp->f_mntfromname, mp->mnt_stat.f_mntfromname, MNAMELEN);
 	}
         strncpy(sbp->f_fstypename, mp->mnt_op->vfs_name, MFSNAMELEN);
 	return (0);

--- a/server/miscfs/kernfs/kernfs_vnops.c
+++ b/server/miscfs/kernfs/kernfs_vnops.c
@@ -172,7 +172,7 @@ kernfs_xread(kt, buf, len, lenp)
 		if (xlen >= len)
 			return (EINVAL);
 
-		bcopy(cp, buf, xlen);
+		memcpy(buf, cp, xlen);
 		break;
 	}
 
@@ -183,7 +183,7 @@ kernfs_xread(kt, buf, len, lenp)
 		if (xlen >= (len-2))
 			return (EINVAL);
 
-		bcopy(cp, buf, xlen);
+		memcpy(buf, cp, xlen);
 		buf[xlen] = '\n';
 		buf[xlen+1] = '\0';
 		break;
@@ -252,7 +252,7 @@ kernfs_xwrite(kt, buf, len)
 	case KTT_HOSTNAME: {
 		if (buf[len-1] == '\n')
 			--len;
-		bcopy(buf, hostname, len);
+		memcpy(hostname, buf, len);
 		hostname[len] = '\0';
 		hostnamelen = len;
 		return (0);
@@ -298,7 +298,7 @@ mach_error_t kernfs_lookup(ap)
 	}
 
 #if 0
-	if (cnp->cn_namelen == 4 && bcmp(pname, "root", 4) == 0) {
+	if (cnp->cn_namelen == 4 && memcmp(pname, "root", 4) == 0) {
 		*vpp = rootdir;
 		VREF(rootdir);
 		VOP_LOCK(rootdir);
@@ -309,7 +309,7 @@ mach_error_t kernfs_lookup(ap)
 	/*
 	 * /kern/rootdev is the root device
 	 */
-	if (cnp->cn_namelen == 7 && bcmp(pname, "rootdev", 7) == 0) {
+	if (cnp->cn_namelen == 7 && memcmp(pname, "rootdev", 7) == 0) {
 		*vpp = rootvp;
 		VREF(rootvp);
 		VOP_LOCK(rootvp);
@@ -320,7 +320,7 @@ mach_error_t kernfs_lookup(ap)
 	/*
 	 * /kern/rrootdev is the raw root device
 	 */
-	if (cnp->cn_namelen == 8 && bcmp(pname, "rrootdev", 8) == 0) {
+	if (cnp->cn_namelen == 8 && memcmp(pname, "rrootdev", 8) == 0) {
 		if (rrootvp) {
 			*vpp = rrootvp;
 			VREF(rrootvp);
@@ -337,7 +337,7 @@ mach_error_t kernfs_lookup(ap)
 	for (i = 0; i < nkern_targets; i++) {
 		struct kern_target *kt = &kern_targets[i];
 		if (cnp->cn_namelen == strlen(kt->kt_name) &&
-		    bcmp(kt->kt_name, pname, cnp->cn_namelen) == 0) {
+		    memcmp(kt->kt_name, pname, cnp->cn_namelen) == 0) {
 			error = 0;
 			break;
 		}
@@ -451,7 +451,7 @@ mach_error_t kernfs_getattr(ap)
 	int error = 0;
 	char strbuf[KSTRING];
 
-	bzero((caddr_t) vap, sizeof(*vap));
+	memset((caddr_t) vap, 0, sizeof(*vap));
 	vattr_null(vap);
 	vap->va_uid = 0;
 	vap->va_gid = 0;
@@ -608,10 +608,10 @@ mach_error_t kernfs_readdir(ap)
 		printf("kernfs_readdir: i = %d\n", i);
 #endif
 
-		bzero((caddr_t) dp, UIO_MX);
+		memset((caddr_t) dp, 0, UIO_MX);
 
 		dp->d_namlen = strlen(kt->kt_name);
-		bcopy(kt->kt_name, dp->d_name, dp->d_namlen+1);
+		memcpy(dp->d_name, kt->kt_name, dp->d_namlen+1);
 
 #ifdef KERNFS_DIAGNOSTIC
 		printf("kernfs_readdir: name = %s, len = %d\n",

--- a/server/miscfs/nullfs/null_vfsops.c
+++ b/server/miscfs/nullfs/null_vfsops.c
@@ -145,10 +145,10 @@ nullfs_mount(mp, path, data, ndp, p)
 	getnewfsid(mp, MOUNT_LOFS);
 
 	(void) copyinstr(path, mp->mnt_stat.f_mntonname, MNAMELEN - 1, &size);
-	bzero(mp->mnt_stat.f_mntonname + size, MNAMELEN - size);
+	memset(mp->mnt_stat.f_mntonname + size, 0, MNAMELEN - size);
 	(void) copyinstr(args.target, mp->mnt_stat.f_mntfromname, MNAMELEN - 1, 
 	    &size);
-	bzero(mp->mnt_stat.f_mntfromname + size, MNAMELEN - size);
+	memset(mp->mnt_stat.f_mntfromname + size, 0, MNAMELEN - size);
 #ifdef NULLFS_DIAGNOSTIC
 	printf("nullfs_mount: lower %s, alias at %s\n",
 		mp->mnt_stat.f_mntfromname, mp->mnt_stat.f_mntonname);
@@ -281,7 +281,7 @@ nullfs_statfs(mp, sbp, p)
 			);
 #endif
 
-	bzero(&mstat, sizeof(mstat));
+	memset(&mstat, 0, sizeof(mstat));
 
 	error = VFS_STATFS(MOUNTTONULLMOUNT(mp)->nullm_vfs, &mstat, p);
 	if (error)
@@ -298,9 +298,9 @@ nullfs_statfs(mp, sbp, p)
 	sbp->f_files = mstat.f_files;
 	sbp->f_ffree = mstat.f_ffree;
 	if (sbp != &mp->mnt_stat) {
-		bcopy(&mp->mnt_stat.f_fsid, &sbp->f_fsid, sizeof(sbp->f_fsid));
-		bcopy(mp->mnt_stat.f_mntonname, sbp->f_mntonname, MNAMELEN);
-		bcopy(mp->mnt_stat.f_mntfromname, sbp->f_mntfromname, MNAMELEN);
+		memcpy(&sbp->f_fsid, &mp->mnt_stat.f_fsid, sizeof(sbp->f_fsid));
+		memcpy(sbp->f_mntonname, mp->mnt_stat.f_mntonname, MNAMELEN);
+		memcpy(sbp->f_mntfromname, mp->mnt_stat.f_mntfromname, MNAMELEN);
 	}
         strncpy(sbp->f_fstypename, mp->mnt_op->vfs_name, MFSNAMELEN);
 	return (0);

--- a/server/miscfs/portal/portal_vfsops.c
+++ b/server/miscfs/portal/portal_vfsops.c
@@ -124,14 +124,14 @@ portal_mount(mp, path, data, ndp, p)
 	getnewfsid(mp, MOUNT_PORTAL);
 
 	(void)copyinstr(path, mp->mnt_stat.f_mntonname, MNAMELEN - 1, &size);
-	bzero(mp->mnt_stat.f_mntonname + size, MNAMELEN - size);
+	memset(mp->mnt_stat.f_mntonname + size, 0, MNAMELEN - size);
 	(void)copyinstr(args.pa_config,
 	    mp->mnt_stat.f_mntfromname, MNAMELEN - 1, &size);
-	bzero(mp->mnt_stat.f_mntfromname + size, MNAMELEN - size);
+	memset(mp->mnt_stat.f_mntfromname + size, 0, MNAMELEN - size);
 
 #ifdef notdef
-	bzero(mp->mnt_stat.f_mntfromname, MNAMELEN);
-	bcopy("portal", mp->mnt_stat.f_mntfromname, sizeof("portal"));
+	memset(mp->mnt_stat.f_mntfromname, 0, MNAMELEN);
+	memcpy(mp->mnt_stat.f_mntfromname, "portal", sizeof("portal"));
 #endif
 
 	return (0);
@@ -254,9 +254,9 @@ portal_statfs(mp, sbp, p)
 	sbp->f_files = 1;		/* Allow for "." */
 	sbp->f_ffree = 0;		/* See comments above */
 	if (sbp != &mp->mnt_stat) {
-		bcopy(&mp->mnt_stat.f_fsid, &sbp->f_fsid, sizeof(sbp->f_fsid));
-		bcopy(mp->mnt_stat.f_mntonname, sbp->f_mntonname, MNAMELEN);
-		bcopy(mp->mnt_stat.f_mntfromname, sbp->f_mntfromname, MNAMELEN);
+		memcpy(&sbp->f_fsid, &mp->mnt_stat.f_fsid, sizeof(sbp->f_fsid));
+		memcpy(sbp->f_mntonname, mp->mnt_stat.f_mntonname, MNAMELEN);
+		memcpy(sbp->f_mntfromname, mp->mnt_stat.f_mntfromname, MNAMELEN);
 	}
         strncpy(sbp->f_fstypename, mp->mnt_op->vfs_name, MFSNAMELEN);
 	return (0);

--- a/server/miscfs/portal/portal_vnops.c
+++ b/server/miscfs/portal/portal_vnops.c
@@ -132,7 +132,7 @@ portal_lookup(ap)
 
 	pt->pt_arg = malloc(size+1, M_TEMP, M_WAITOK);
 	pt->pt_size = size+1;
-	bcopy(pname, pt->pt_arg, pt->pt_size);
+	memcpy(pt->pt_arg, pname, pt->pt_size);
 	pt->pt_fileid = portal_fileid++;
 
 	*ap->a_vpp = fvp;
@@ -288,7 +288,7 @@ portal_open(ap)
 	pcred.pcr_flag = ap->a_mode;
 	pcred.pcr_uid = ap->a_cred->cr_uid;
 	pcred.pcr_ngroups = ap->a_cred->cr_ngroups;
-	bcopy(ap->a_cred->cr_groups, pcred.pcr_groups, NGROUPS * sizeof(gid_t));
+	memcpy(pcred.pcr_groups, ap->a_cred->cr_groups, NGROUPS * sizeof(gid_t));
 	aiov[0].iov_base = (caddr_t) &pcred;
 	aiov[0].iov_len = sizeof(pcred);
 	aiov[1].iov_base = pt->pt_arg;
@@ -425,7 +425,7 @@ portal_getattr(ap)
 	struct vnode *vp = ap->a_vp;
 	struct vattr *vap = ap->a_vap;
 
-	bzero(vap, sizeof(*vap));
+	memset(vap, 0, sizeof(*vap));
 	vattr_null(vap);
 	vap->va_uid = 0;
 	vap->va_gid = 0;

--- a/server/miscfs/procfs/procfs_status.c
+++ b/server/miscfs/procfs/procfs_status.c
@@ -82,7 +82,7 @@ procfs_dostatus(curp, p, pfs, uio)
 /* comm pid ppid pgid sid maj,min ctty,sldr start ut st wmsg uid groups ... */
 
 	ps = psbuf;
-	bcopy(p->p_comm, ps, MAXCOMLEN);
+	memcpy(ps, p->p_comm, MAXCOMLEN);
 	ps[MAXCOMLEN] = '\0';
 	ps += strlen(ps);
 	ps += sprintf(ps, " %d %d %d %d ", pid, ppid, pgid, sid);

--- a/server/miscfs/procfs/procfs_subr.c
+++ b/server/miscfs/procfs/procfs_subr.c
@@ -308,7 +308,7 @@ vfs_findname(nm, buf, buflen)
 	int buflen;
 {
 	for (; nm->nm_name; nm++)
-		if (bcmp(buf, (char *) nm->nm_name, buflen+1) == 0)
+		if (memcmp(buf, (char *) nm->nm_name, buflen+1) == 0)
 			return (nm);
 
 	return (0);

--- a/server/miscfs/procfs/procfs_vfsops.c
+++ b/server/miscfs/procfs/procfs_vfsops.c
@@ -84,11 +84,11 @@ procfs_mount(mp, path, data, ndp, p)
 	getnewfsid(mp, MOUNT_PROCFS);
 
 	(void) copyinstr(path, (caddr_t)mp->mnt_stat.f_mntonname, MNAMELEN, &size);
-	bzero(mp->mnt_stat.f_mntonname + size, MNAMELEN - size);
+	memset(mp->mnt_stat.f_mntonname + size, 0, MNAMELEN - size);
 
 	size = sizeof("procfs") - 1;
-	bcopy("procfs", mp->mnt_stat.f_mntfromname, size);
-	bzero(mp->mnt_stat.f_mntfromname + size, MNAMELEN - size);
+	memcpy(mp->mnt_stat.f_mntfromname, "procfs", size);
+	memset(mp->mnt_stat.f_mntfromname + size, 0, MNAMELEN - size);
 
 	return (0);
 }
@@ -168,9 +168,9 @@ procfs_statfs(mp, sbp, p)
 	sbp->f_ffree = maxproc - nprocs;	/* approx */
 
 	if (sbp != &mp->mnt_stat) {
-		bcopy(&mp->mnt_stat.f_fsid, &sbp->f_fsid, sizeof(sbp->f_fsid));
-		bcopy(mp->mnt_stat.f_mntonname, sbp->f_mntonname, MNAMELEN);
-		bcopy(mp->mnt_stat.f_mntfromname, sbp->f_mntfromname, MNAMELEN);
+		memcpy(&sbp->f_fsid, &mp->mnt_stat.f_fsid, sizeof(sbp->f_fsid));
+		memcpy(sbp->f_mntonname, mp->mnt_stat.f_mntonname, MNAMELEN);
+		memcpy(sbp->f_mntfromname, mp->mnt_stat.f_mntfromname, MNAMELEN);
 	}
         strncpy(sbp->f_fstypename, mp->mnt_op->vfs_name, MFSNAMELEN);
 	return (0);

--- a/server/miscfs/procfs/procfs_vnops.c
+++ b/server/miscfs/procfs/procfs_vnops.c
@@ -567,7 +567,7 @@ procfs_lookup(ap)
 			struct pfsnames *dp = &procent[i];
 
 			if (cnp->cn_namelen == dp->d_namlen &&
-			    bcmp(pname, dp->d_name, dp->d_namlen) == 0) {
+			    memcmp(pname, dp->d_name, dp->d_namlen) == 0) {
 			    	pfs_type = dp->d_pfstype;
 				goto found;
 			}
@@ -655,7 +655,7 @@ procfs_readdir(ap)
 			dp->d_fileno = PROCFS_FILENO(pfs->pfs_pid, dt->d_pfstype);
 			dp->d_type = DT_REG;
 			dp->d_namlen = dt->d_namlen;
-			bcopy(dt->d_name, dp->d_name, sizeof(dt->d_name)-1);
+			memcpy(dp->d_name, dt->d_name, sizeof(dt->d_name)-1);
 			error = uiomove((caddr_t) dp, UIO_MX, uio);
 			if (error)
 				break;
@@ -689,7 +689,7 @@ procfs_readdir(ap)
 		pcnt = PROCFS_XFILES;
 
 		while (p && uio->uio_resid >= UIO_MX) {
-			bzero((char *) dp, UIO_MX);
+			memset((char *) dp, 0, UIO_MX);
 			dp->d_type = DT_DIR;
 			dp->d_reclen = UIO_MX;
 

--- a/server/miscfs/umapfs/umap_vfsops.c
+++ b/server/miscfs/umapfs/umap_vfsops.c
@@ -186,10 +186,10 @@ umapfs_mount(mp, path, data, ndp, p)
 	getnewfsid(mp, MOUNT_LOFS);
 
 	(void) copyinstr(path, mp->mnt_stat.f_mntonname, MNAMELEN - 1, &size);
-	bzero(mp->mnt_stat.f_mntonname + size, MNAMELEN - size);
+	memset(mp->mnt_stat.f_mntonname + size, 0, MNAMELEN - size);
 	(void) copyinstr(args.target, mp->mnt_stat.f_mntfromname, MNAMELEN - 1, 
 	    &size);
-	bzero(mp->mnt_stat.f_mntfromname + size, MNAMELEN - size);
+	memset(mp->mnt_stat.f_mntfromname + size, 0, MNAMELEN - size);
 #ifdef UMAPFS_DIAGNOSTIC
 	printf("umapfs_mount: lower %s, alias at %s\n",
 		mp->mnt_stat.f_mntfromname, mp->mnt_stat.f_mntonname);
@@ -322,7 +322,7 @@ umapfs_statfs(mp, sbp, p)
 			);
 #endif
 
-	bzero(&mstat, sizeof(mstat));
+	memset(&mstat, 0, sizeof(mstat));
 
 	error = VFS_STATFS(MOUNTTOUMAPMOUNT(mp)->umapm_vfs, &mstat, p);
 	if (error)
@@ -339,9 +339,9 @@ umapfs_statfs(mp, sbp, p)
 	sbp->f_files = mstat.f_files;
 	sbp->f_ffree = mstat.f_ffree;
 	if (sbp != &mp->mnt_stat) {
-		bcopy(&mp->mnt_stat.f_fsid, &sbp->f_fsid, sizeof(sbp->f_fsid));
-		bcopy(mp->mnt_stat.f_mntonname, sbp->f_mntonname, MNAMELEN);
-		bcopy(mp->mnt_stat.f_mntfromname, sbp->f_mntfromname, MNAMELEN);
+		memcpy(&sbp->f_fsid, &mp->mnt_stat.f_fsid, sizeof(sbp->f_fsid));
+		memcpy(sbp->f_mntonname, mp->mnt_stat.f_mntonname, MNAMELEN);
+		memcpy(sbp->f_mntfromname, mp->mnt_stat.f_mntfromname, MNAMELEN);
 	}
         strncpy(sbp->f_fstypename, mp->mnt_op->vfs_name, MFSNAMELEN);
 	return (0);

--- a/server/miscfs/union/union_subr.c
+++ b/server/miscfs/union/union_subr.c
@@ -69,7 +69,7 @@ union_init()
 
 	for (i = 0; i < NHASH; i++)
 		LIST_INIT(&unhead[i]);
-	bzero((caddr_t) unvplock, sizeof(unvplock));
+	memset((caddr_t) unvplock, 0, sizeof(unvplock));
 }
 
 static int
@@ -357,8 +357,7 @@ loop:
 				un->un_hash = cnp->cn_hash;
 				un->un_path = malloc(cnp->cn_namelen+1,
 						M_TEMP, M_WAITOK);
-				bcopy(cnp->cn_nameptr, un->un_path,
-						cnp->cn_namelen);
+				memcpy(un->un_path, cnp->cn_nameptr, cnp->cn_namelen);
 				un->un_path[cnp->cn_namelen] = '\0';
 				VREF(dvp);
 				un->un_dirvp = dvp;
@@ -418,7 +417,7 @@ loop:
 	if (cnp && (lowervp != NULLVP) && (lowervp->v_type == VREG)) {
 		un->un_hash = cnp->cn_hash;
 		un->un_path = malloc(cnp->cn_namelen+1, M_TEMP, M_WAITOK);
-		bcopy(cnp->cn_nameptr, un->un_path, cnp->cn_namelen);
+		memcpy(un->un_path, cnp->cn_nameptr, cnp->cn_namelen);
 		un->un_path[cnp->cn_namelen] = '\0';
 		VREF(dvp);
 		un->un_dirvp = dvp;
@@ -579,7 +578,7 @@ union_mkshadow(um, dvp, cnp, vpp)
 	 * The pathname buffer will be FREEed by VOP_MKDIR.
 	 */
 	cn.cn_pnbuf = malloc(cnp->cn_namelen+1, M_NAMEI, M_WAITOK);
-	bcopy(cnp->cn_nameptr, cn.cn_pnbuf, cnp->cn_namelen);
+	memcpy(cn.cn_pnbuf, cnp->cn_nameptr, cnp->cn_namelen);
 	cn.cn_pnbuf[cnp->cn_namelen] = '\0';
 
 	cn.cn_nameiop = CREATE;
@@ -655,7 +654,7 @@ union_vn_create(vpp, un, p)
 	 */
 	cn.cn_namelen = strlen(un->un_path);
 	cn.cn_pnbuf = (caddr_t) malloc(cn.cn_namelen, M_NAMEI, M_WAITOK);
-	bcopy(un->un_path, cn.cn_pnbuf, cn.cn_namelen+1);
+	memcpy(cn.cn_pnbuf, un->un_path, cn.cn_namelen+1);
 	cn.cn_nameiop = CREATE;
 	cn.cn_flags = (LOCKPARENT|HASBUF|SAVENAME|SAVESTART|ISLASTCN);
 	cn.cn_proc = p;

--- a/server/miscfs/union/union_vfsops.c
+++ b/server/miscfs/union/union_vfsops.c
@@ -231,7 +231,7 @@ union_mount(mp, path, data, ndp, p)
 	getnewfsid(mp, MOUNT_UNION);
 
 	(void) copyinstr(path, mp->mnt_stat.f_mntonname, MNAMELEN - 1, &size);
-	bzero(mp->mnt_stat.f_mntonname + size, MNAMELEN - size);
+	memset(mp->mnt_stat.f_mntonname + size, 0, MNAMELEN - size);
 
 	switch (um->um_op) {
 	case UNMNT_ABOVE:
@@ -245,13 +245,13 @@ union_mount(mp, path, data, ndp, p)
 		break;
 	}
 	len = strlen(cp);
-	bcopy(cp, mp->mnt_stat.f_mntfromname, len);
+	memcpy(mp->mnt_stat.f_mntfromname, cp, len);
 
 	cp = mp->mnt_stat.f_mntfromname + len;
 	len = MNAMELEN - len;
 
 	(void) copyinstr(args.target, cp, len - 1, &size);
-	bzero(cp + size, len - size);
+	memset(cp + size, 0, len - size);
 
 #ifdef UNION_DIAGNOSTIC
 	printf("union_mount: from %s, on %s\n",
@@ -431,7 +431,7 @@ union_statfs(mp, sbp, p)
 	       		um->um_uppervp);
 #endif
 
-	bzero(&mstat, sizeof(mstat));
+	memset(&mstat, 0, sizeof(mstat));
 
 	if (um->um_lowervp) {
 		error = VFS_STATFS(um->um_lowervp->v_mount, &mstat, p);
@@ -480,9 +480,9 @@ union_statfs(mp, sbp, p)
 	sbp->f_ffree += mstat.f_ffree;
 
 	if (sbp != &mp->mnt_stat) {
-		bcopy(&mp->mnt_stat.f_fsid, &sbp->f_fsid, sizeof(sbp->f_fsid));
-		bcopy(mp->mnt_stat.f_mntonname, sbp->f_mntonname, MNAMELEN);
-		bcopy(mp->mnt_stat.f_mntfromname, sbp->f_mntfromname, MNAMELEN);
+		memcpy(&sbp->f_fsid, &mp->mnt_stat.f_fsid, sizeof(sbp->f_fsid));
+		memcpy(sbp->f_mntonname, mp->mnt_stat.f_mntonname, MNAMELEN);
+		memcpy(sbp->f_mntfromname, mp->mnt_stat.f_mntfromname, MNAMELEN);
 	}
         strncpy(sbp->f_fstypename, mp->mnt_op->vfs_name, MFSNAMELEN);
 	return (0);

--- a/server/net/bpf.c
+++ b/server/net/bpf.c
@@ -79,7 +79,7 @@
  * Older BSDs don't have kernel malloc.
  */
 #if BSD < 199103
-extern bcopy();
+#include <string.h>
 static caddr_t bpf_alloc();
 #include <net/bpf_compat.h>
 #define BPF_BUFSIZE (MCLBYTES-8)
@@ -321,7 +321,7 @@ bpfopen(dev, flag)
 		return (EBUSY);
 
 	/* Mark "free" and do most initialization. */
-	bzero((char *)d, sizeof(*d));
+	memset((char *)d, 0, sizeof(*d));
 	d->bd_bufsize = bpf_bufsize;
 
 	return (0);
@@ -1034,7 +1034,7 @@ bpf_mcopy(src_arg, dst_arg, len)
 		if (m == 0)
 			panic("bpf_mcopy");
 		count = min(m->m_len, len);
-		bcopy(mtod(m, caddr_t), (caddr_t)dst, count);
+		memcpy(caddr_t), mtod(m, (caddr_t)dst, count);
 		m = m->m_next;
 		dst += count;
 		len -= count;

--- a/server/net/if.c
+++ b/server/net/if.c
@@ -115,7 +115,7 @@ if_attach(ifp)
 		struct ifaddr **q = (struct ifaddr **)
 					bsd_malloc(n, M_IFADDR, M_WAITOK);
 		if (ifnet_addrs) {
-			bcopy((caddr_t)ifnet_addrs, (caddr_t)q, n/2);
+			memcpy((caddr_t)q, (caddr_t)ifnet_addrs, n/2);
 			bsd_free((caddr_t)ifnet_addrs, M_IFADDR);
 		}
 		ifnet_addrs = q;
@@ -136,12 +136,12 @@ if_attach(ifp)
 		socksize = sizeof(*sdl);
 	ifasize = sizeof(*ifa) + 2 * socksize;
 	if (ifa = (struct ifaddr *)bsd_malloc(ifasize, M_IFADDR, M_WAITOK)) {
-		bzero((caddr_t)ifa, ifasize);
+		memset((caddr_t)ifa, 0, ifasize);
 		sdl = (struct sockaddr_dl *)(ifa + 1);
 		sdl->sdl_len = socksize;
 		sdl->sdl_family = AF_LINK;
-		bcopy(ifp->if_name, sdl->sdl_data, namelen);
-		bcopy(unitname, namelen + (caddr_t)sdl->sdl_data, unitlen);
+		memcpy(sdl->sdl_data, ifp->if_name, namelen);
+		memcpy(namelen + (caddr_t)sdl->sdl_data, unitname, unitlen);
 		sdl->sdl_nlen = (namelen += unitlen);
 		sdl->sdl_index = ifp->if_index;
 		sdl->sdl_type = ifp->if_type;
@@ -173,7 +173,7 @@ ifa_ifwithaddr(addr)
 	register struct ifaddr *ifa;
 
 #define	equal(a1, a2) \
-  (bcmp((caddr_t)(a1), (caddr_t)(a2), ((struct sockaddr *)(a1))->sa_len) == 0)
+  (memcmp((caddr_t)(a1), (caddr_t)(a2), ((struct sockaddr *)(a1))->sa_len) == 0)
 	for (ifp = ifnet; ifp; ifp = ifp->if_next)
 	    for (ifa = ifp->if_addrlist; ifa; ifa = ifa->ifa_next) {
 		if (ifa->ifa_addr->sa_family != addr->sa_family)
@@ -444,7 +444,7 @@ ifunit(name)
 		unit = unit * 10 + *cp++ - '0';
 	*ep = 0;
 	for (ifp = ifnet; ifp; ifp = ifp->if_next) {
-		if (bcmp(ifp->if_name, name, len))
+		if (memcmp(ifp->if_name, name, len))
 			continue;
 		if (unit == ifp->if_unit)
 			break;
@@ -642,7 +642,7 @@ ifconf(cmd, data)
 			continue;
 		*cp++ = '0' + ifp->if_unit; *cp = '\0';
 		if ((ifa = ifp->if_addrlist) == 0) {
-			bzero((caddr_t)&ifr.ifr_addr, sizeof(ifr.ifr_addr));
+			memset((caddr_t)&ifr.ifr_addr, 0, sizeof(ifr.ifr_addr));
 			error = copyout((caddr_t)&ifr, (caddr_t)ifrp,
 			    sizeof (ifr));
 			if (error)

--- a/server/net/if_ppp.c
+++ b/server/net/if_ppp.c
@@ -307,7 +307,7 @@ pppopen(dev, tp)
     }
 
     sc->sc_ilen = 0;
-    bzero(sc->sc_asyncmap, sizeof(sc->sc_asyncmap));
+    memset(sc->sc_asyncmap, 0, sizeof(sc->sc_asyncmap));
     sc->sc_asyncmap[0] = 0xffffffff;
     sc->sc_asyncmap[3] = 0x60000000;
     sc->sc_rasyncmap = 0;
@@ -513,14 +513,14 @@ ppptioctl(tp, cmd, data, flag, p)
     case PPPIOCSXASYNCMAP:
 	if (error = suser(p->p_ucred, &p->p_acflag))
 	    return (error);
-	bcopy(data, sc->sc_asyncmap, sizeof(sc->sc_asyncmap));
+	memcpy(sc->sc_asyncmap, data, sizeof(sc->sc_asyncmap));
 	sc->sc_asyncmap[1] = 0;		    /* mustn't escape 0x20 - 0x3f */
 	sc->sc_asyncmap[2] &= ~0x40000000;  /* mustn't escape 0x5e */
 	sc->sc_asyncmap[3] |= 0x60000000;   /* must escape 0x7d, 0x7e */
 	break;
 
     case PPPIOCGXASYNCMAP:
-	bcopy(sc->sc_asyncmap, data, sizeof(sc->sc_asyncmap));
+	memcpy(data, sc->sc_asyncmap, sizeof(sc->sc_asyncmap));
 	break;
 
     case PPPIOCSMRU:
@@ -1089,7 +1089,7 @@ ppp_btom(sc)
 	if (m == NULL)
 	    return (NULL);
 
-	bcopy(mtod(sc->sc_mc, caddr_t), mtod(m, caddr_t), sc->sc_mc->m_len);
+	memcpy(caddr_t), mtod(sc->sc_mc, mtod(m, caddr_t), sc->sc_mc->m_len);
 	m->m_len = sc->sc_mc->m_len;
 	for (mp = &top; *mp != sc->sc_mc; mp = &(*mp)->m_next)
 	    ;

--- a/server/net/if_sl.c
+++ b/server/net/if_sl.c
@@ -453,7 +453,7 @@ slstart(tp)
 			do {
 				register int mlen = m1->m_len;
 
-				bcopy(mtod(m1, caddr_t), cp, mlen);
+				memcpy(caddr_t), mtod(m1, cp, mlen);
 				cp += mlen;
 				len += mlen;
 			} while (m1 = m1->m_next);
@@ -472,7 +472,7 @@ slstart(tp)
 			 * mbuf.
 			 */
 			bpfbuf[SLX_DIR] = SLIPDIR_OUT;
-			bcopy(mtod(m, caddr_t), &bpfbuf[SLX_CHDR], CHDR_LEN);
+			memcpy(caddr_t), mtod(m, &bpfbuf[SLX_CHDR], CHDR_LEN);
 			bpf_tap(sc->sc_bpf, bpfbuf, len + SLIP_HDRLEN);
 		}
 #endif
@@ -604,7 +604,7 @@ sl_btom(sc, len)
 		m->m_data = (caddr_t)sc->sc_buf;
 		m->m_ext.ext_buf = (caddr_t)((int)sc->sc_buf &~ MCLOFSET);
 	} else
-		bcopy((caddr_t)sc->sc_buf, mtod(m, caddr_t), len);
+		memcpy(mtod(m, (caddr_t)sc->sc_buf, caddr_t), len);
 
 	m->m_len = len;
 	m->m_pkthdr.len = len;
@@ -703,7 +703,7 @@ slinput(c, tp)
 			 * where the buffer started so we can
 			 * compute the new header length.
 			 */
-			bcopy(sc->sc_buf, chdr, CHDR_LEN);
+			memcpy(chdr, sc->sc_buf, CHDR_LEN);
 		}
 #endif
 
@@ -745,7 +745,7 @@ slinput(c, tp)
 			register u_char *hp = sc->sc_buf - SLIP_HDRLEN;
 
 			hp[SLX_DIR] = SLIPDIR_IN;
-			bcopy(chdr, &hp[SLX_CHDR], CHDR_LEN);
+			memcpy(&hp[SLX_CHDR], chdr, CHDR_LEN);
 			bpf_tap(sc->sc_bpf, hp, len + SLIP_HDRLEN);
 		}
 #endif

--- a/server/net/radix.c
+++ b/server/net/radix.c
@@ -57,7 +57,7 @@ static char *rn_zeros, *rn_ones;
 
 #define rn_masktop (mask_rnhead->rnh_treetop)
 #undef Bcmp
-#define Bcmp(a, b, l) (l == 0 ? 0 : bcmp((caddr_t)(a), (caddr_t)(b), (u_long)l))
+#define Bcmp(a, b, l) (l == 0 ? 0 : memcmp((caddr_t)(a), (caddr_t)(b), (u_long)l))
 /*
  * The data structure for the keys is a radix tree with one way
  * branching removed.  The index rn_b at an internal node n represents a bit

--- a/server/net/raw_usrreq.c
+++ b/server/net/raw_usrreq.c
@@ -92,7 +92,7 @@ raw_input(m0, proto, src, dst)
 		 * the comparison will fail at the first byte.
 		 */
 #define	equal(a1, a2) \
-  (bcmp((caddr_t)(a1), (caddr_t)(a2), a1->sa_len) == 0)
+  (memcmp((caddr_t)(a1), (caddr_t)(a2), a1->sa_len) == 0)
 		if (rp->rcb_laddr && !equal(rp->rcb_laddr, dst))
 			continue;
 		if (rp->rcb_faddr && !equal(rp->rcb_faddr, src))
@@ -282,7 +282,7 @@ raw_usrreq(so, req, m, nam, control)
 			break;
 		}
 		len = rp->rcb_laddr->sa_len;
-		bcopy((caddr_t)rp->rcb_laddr, mtod(nam, caddr_t), (unsigned)len);
+		memcpy(mtod(nam, (caddr_t)rp->rcb_laddr, caddr_t), (unsigned)len);
 		nam->m_len = len;
 		break;
 
@@ -292,7 +292,7 @@ raw_usrreq(so, req, m, nam, control)
 			break;
 		}
 		len = rp->rcb_faddr->sa_len;
-		bcopy((caddr_t)rp->rcb_faddr, mtod(nam, caddr_t), (unsigned)len);
+		memcpy(mtod(nam, (caddr_t)rp->rcb_faddr, caddr_t), (unsigned)len);
 		nam->m_len = len;
 		break;
 

--- a/server/net/route.c
+++ b/server/net/route.c
@@ -124,7 +124,7 @@ rtalloc1(dst, report)
 	} else {
 		rtstat.rts_unreach++;
 	miss:	if (report) {
-			bzero((caddr_t)&info, sizeof(info));
+			memset((caddr_t)&info, 0, sizeof(info));
 			info.rti_info[RTAX_DST] = dst;
 			rt_missmsg(msgtype, &info, 0, err);
 		}
@@ -202,7 +202,7 @@ rtredirect(dst, gateway, netmask, flags, src, rtp)
 	 * we have a routing loop, perhaps as a result of an interface
 	 * going down recently.
 	 */
-#define	equal(a1, a2) (bcmp((caddr_t)(a1), (caddr_t)(a2), (a1)->sa_len) == 0)
+#define	equal(a1, a2) (memcmp((caddr_t)(a1), (caddr_t)(a2), (a1)->sa_len) == 0)
 	if (!(flags & RTF_DONE) && rt &&
 	     (!equal(src, rt->rt_gateway) || rt->rt_ifa != ifa))
 		error = EINVAL;
@@ -258,7 +258,7 @@ out:
 		rtstat.rts_badredirect++;
 	else if (stat != NULL)
 		(*stat)++;
-	bzero((caddr_t)&info, sizeof(info));
+	memset((caddr_t)&info, 0, sizeof(info));
 	info.rti_info[RTAX_DST] = dst;
 	info.rti_info[RTAX_GATEWAY] = gateway;
 	info.rti_info[RTAX_NETMASK] = netmask;
@@ -473,7 +473,7 @@ rt_maskedcopy(src, dst, netmask)
 	while (cp2 < cplim)
 		*cp2++ = *cp1++ & *cp3++;
 	if (cp2 < cplim2)
-		bzero((caddr_t)cp2, (unsigned)(cplim2 - cp2));
+		memset((caddr_t)cp2, 0, (unsigned)(cplim2 - cp2));
 }
 
 /*

--- a/server/net/rtsock.c
+++ b/server/net/rtsock.c
@@ -85,7 +85,7 @@ route_usrreq(so, req, m, nam, control)
 	if (req == PRU_ATTACH) {
 		MALLOC(rp, struct rawcb *, sizeof(*rp), M_PCB, M_WAITOK);
 		if (so->so_pcb = (caddr_t)rp)
-			bzero(so->so_pcb, sizeof(*rp));
+			memset(so->so_pcb, 0, sizeof(*rp));
 
 	}
 	if (req == PRU_DETACH && rp) {
@@ -363,7 +363,7 @@ rt_xaddrs(cp, cplim, rtinfo)
 	register struct sockaddr *sa;
 	register int i;
 
-	bzero(rtinfo->rti_info, sizeof(rtinfo->rti_info));
+	memset(rtinfo->rti_info, 0, sizeof(rtinfo->rti_info));
 	for (i = 0; (i < RTAX_MAX) && (cp < cplim); i++) {
 		if ((rtinfo->rti_addrs & (1 << i)) == 0)
 			continue;
@@ -404,7 +404,7 @@ m_copyback(m0, off, len, cp)
 	}
 	while (len > 0) {
 		mlen = min (m->m_len - off, len);
-		bcopy(cp, off + mtod(m, caddr_t), (unsigned)mlen);
+		memcpy(off + mtod(m, cp, caddr_t), (unsigned)mlen);
 		cp += mlen;
 		len -= mlen;
 		mlen += off;
@@ -458,7 +458,7 @@ rt_msg1(type, rtinfo)
 	m->m_pkthdr.len = m->m_len = len;
 	m->m_pkthdr.rcvif = 0;
 	rtm = mtod(m, struct rt_msghdr *);
-	bzero((caddr_t)rtm, len);
+	memset((caddr_t)rtm, 0, len);
 	for (i = 0; i < RTAX_MAX; i++) {
 		if ((sa = rtinfo->rti_info[i]) == NULL)
 			continue;
@@ -514,7 +514,7 @@ again:
 		rtinfo->rti_addrs |= (1 << i);
 		dlen = ROUNDUP(sa->sa_len);
 		if (cp) {
-			bcopy((caddr_t)sa, cp, (unsigned)dlen);
+			memcpy(cp, (caddr_t)sa, (unsigned)dlen);
 			cp += dlen;
 		}
 		len += dlen;
@@ -591,7 +591,7 @@ rt_ifmsg(ifp)
 
 	if (route_cb.any_count == 0)
 		return;
-	bzero((caddr_t)&info, sizeof(info));
+	memset((caddr_t)&info, 0, sizeof(info));
 	m = rt_msg1(RTM_IFINFO, &info);
 	if (m == 0)
 		return;
@@ -627,7 +627,7 @@ rt_newaddrmsg(cmd, ifa, error, rt)
 	if (route_cb.any_count == 0)
 		return;
 	for (pass = 1; pass < 3; pass++) {
-		bzero((caddr_t)&info, sizeof(info));
+		memset((caddr_t)&info, 0, sizeof(info));
 		if ((cmd == RTM_ADD && pass == 1) ||
 		    (cmd == RTM_DELETE && pass == 2)) {
 			register struct ifa_msghdr *ifam;
@@ -681,7 +681,7 @@ sysctl_dumpentry(rn, w)
 
 	if (w->w_op == NET_RT_FLAGS && !(rt->rt_flags & w->w_arg))
 		return 0;
-	bzero((caddr_t)&info, sizeof(info));
+	memset((caddr_t)&info, 0, sizeof(info));
 	dst = rt_key(rt);
 	gate = rt->rt_gateway;
 	netmask = rt_mask(rt);
@@ -702,7 +702,7 @@ sysctl_dumpentry(rn, w)
 		else
 			w->w_where += size;
 #else
-		bcopy((caddr_t)rtm, w->w_where, size);
+		memcpy(w->w_where, (caddr_t)rtm, size);
 		w->w_where += size;
 #endif
 	}
@@ -719,7 +719,7 @@ sysctl_iflist(af, w)
 	struct	rt_addrinfo info;
 	int	len, error = 0;
 
-	bzero((caddr_t)&info, sizeof(info));
+	memset((caddr_t)&info, 0, sizeof(info));
 	for (ifp = ifnet; ifp; ifp = ifp->if_next) {
 		if (w->w_arg && w->w_arg != ifp->if_index)
 			continue;
@@ -739,7 +739,7 @@ sysctl_iflist(af, w)
 			if (error = copyout((caddr_t)ifm, w->w_where, len))
 				return (error);
 #else
-			bcopy((caddr_t)ifm, w->w_where, len);
+			memcpy(w->w_where, (caddr_t)ifm, len);
 #endif
 			w->w_where += len;
 		}
@@ -762,7 +762,7 @@ sysctl_iflist(af, w)
 				if (error = copyout(w->w_tmem, w->w_where, len))
 					return (error);
 #else
-				bcopy(w->w_tmem, w->w_where, len);
+				memcpy(w->w_where, w->w_tmem, len);
 #endif
 				w->w_where += len;
 			}

--- a/server/net/slcompress.c
+++ b/server/net/slcompress.c
@@ -62,8 +62,8 @@
 #define INCR(counter)
 #endif
 
-#define BCMP(p1, p2, n) bcmp((char *)(p1), (char *)(p2), (int)(n))
-#define BCOPY(p1, p2, n) bcopy((char *)(p1), (char *)(p2), (int)(n))
+#define BCMP(p1, p2, n) memcmp((char *)(p1), (char *)(p2), (int)(n))
+#define BCOPY(p1, p2, n) memcpy((char *)(p2), (char *)(p1), (int)(n))
 #ifndef KERNEL
 #define ovbcopy bcopy
 #endif
@@ -78,7 +78,7 @@ sl_compress_init(comp)
 	register u_int i;
 	register struct cstate *tstate = comp->tstate;
 
-	bzero((char *)comp, sizeof(*comp));
+	memset((char *)comp, 0, sizeof(*comp));
 	for (i = MAX_STATES - 1; i > 0; --i) {
 		tstate[i].cs_id = i;
 		tstate[i].cs_next = &tstate[i - 1];
@@ -106,7 +106,7 @@ sl_compress_setup(comp, max_state)
 
 	if ((unsigned) max_state > MAX_STATES - 1)
 		max_state = MAX_STATES - 1;
-	bzero((char *)comp, sizeof(*comp));
+	memset((char *)comp, 0, sizeof(*comp));
 	for (i = max_state; i > 0; --i) {
 		tstate[i].cs_id = i;
 		tstate[i].cs_next = &tstate[i - 1];

--- a/server/netccitt/hd_subr.c
+++ b/server/netccitt/hd_subr.c
@@ -90,7 +90,7 @@ struct sockaddr *addr;
 		MALLOC(hdp, struct hdcb *, sizeof (*hdp), M_PCB, M_DONTWAIT);
 		if (hdp == 0)
 			return (ENOBUFS);
-		bzero((caddr_t)hdp, sizeof(*hdp));
+		memset((caddr_t)hdp, 0, sizeof(*hdp));
 		hdp->hd_pkp =
 			(caddr_t) pk_newlink ((struct x25_ifaddr *) ifa, 
 					      (caddr_t) hdp);
@@ -301,7 +301,7 @@ register int frametype, pf;
 
 	case FRMR: 
 		frame -> control = FRMR_CONTROL;
-		bcopy ((caddr_t)&hd_frmr, (caddr_t)frame -> info, 3);
+		memcpy((caddr_t)frame -> info, (caddr_t)&hd_frmr, 3);
 		buf -> m_len = 5;
 		hdp->hd_frmrs_out++;
 

--- a/server/netccitt/if_x25subr.c
+++ b/server/netccitt/if_x25subr.c
@@ -778,7 +778,7 @@ struct mbuf *m0;
 		/* Add VC to rtentry */
 		lcp->lcd_so = 0;
 		lcp->lcd_sb = so->so_snd; /* structure copy */
-		bzero((caddr_t)&so->so_snd, sizeof(so->so_snd)); /* XXXXXX */
+		memset((caddr_t)&so->so_snd, 0, sizeof(so->so_snd)); /* XXXXXX */
 		so->so_pcb = 0;
 		x25_rtattach(lcp, rt);
 		transfer_sockbuf(&so->so_rcv, x25_ifinput, lcp);

--- a/server/netccitt/llc_output.c
+++ b/server/netccitt/llc_output.c
@@ -224,9 +224,7 @@ llc_rawsend(struct llc_linkcb *linkp, struct mbuf *m, struct llc *frame,
 		frame->llc_control = LLC_FRMR;
 		/* get more space --- FRMR frame are longer then usual */
 		LLC_SETLEN(m, LLC_FRMRLEN);
-		bcopy((caddr_t) &linkp->llcl_frmrinfo, 
-		      (caddr_t) &frame->llc_frmrinfo,
-		      sizeof(struct frmrinfo));
+		memcpy((caddr_t) &frame->llc_frmrinfo, (caddr_t) &linkp->llcl_frmrinfo, sizeof(struct frmrinfo));
 		break;
 	default:
 		/*

--- a/server/netccitt/llc_subr.c
+++ b/server/netccitt/llc_subr.c
@@ -108,7 +108,7 @@ sdl_cmp(struct sockaddr_dl *sdl_a, struct sockaddr_dl *sdl_b)
 {
 	if (LLADDRLEN(sdl_a) != LLADDRLEN(sdl_b))
 		return(1);
-	return(bcmp((caddr_t) sdl_a->sdl_data, (caddr_t) sdl_b->sdl_data,
+	return(memcmp((caddr_t) sdl_a->sdl_data, (caddr_t) sdl_b->sdl_data,
 		    LLADDRLEN(sdl_a)));
 }
 
@@ -116,7 +116,7 @@ sdl_cmp(struct sockaddr_dl *sdl_a, struct sockaddr_dl *sdl_b)
 
 sdl_copy(struct sockaddr_dl *sdl_f, struct sockaddr_dl *sdl_t)
 {
-	bcopy((caddr_t) sdl_f, (caddr_t) sdl_t, sdl_f->sdl_len);
+	memcpy((caddr_t) sdl_t, (caddr_t) sdl_f, sdl_f->sdl_len);
 }
 
 /* Swap sdl_a w/ sdl_b */
@@ -167,7 +167,7 @@ sdl_setaddrif(struct ifnet *ifp, u_char *mac_addr, u_char dlsap_addr,
 
 	if ((sdl_tmp = sdl_getaddrif(ifp)) ) { 	
 		sdl_copy(sdl_tmp, sdl_to); 	
-		bcopy((caddr_t) mac_addr, (caddr_t) LLADDR(sdl_to), mac_len);
+		memcpy((caddr_t) LLADDR(sdl_to), (caddr_t) mac_addr, mac_len);
 		*(LLADDR(sdl_to)+mac_len) = dlsap_addr;
 		sdl_to->sdl_alen = mac_len+1; 	
 		return(1); 
@@ -242,7 +242,7 @@ llc_setsapinfo(struct ifnet *ifp, u_char af, u_char sap, struct dllconfig *llcon
 	sirt->rt_llinfo = malloc(size , M_PCB, M_WAITOK); 
 	sapinfo = (struct npaidbentry *) sirt->rt_llinfo; 
 	if (sapinfo) { 	
-		bzero ((caddr_t)sapinfo, size); 	
+		memset((caddr_t)sapinfo, 0, size); 	
 		/* 	 
 		 * For the time being we support LLC CLASS II here 	 
 		 * only 	 
@@ -2111,7 +2111,7 @@ llc_newlink(struct sockaddr_dl *dst, struct ifnet *ifp, struct rtentry *nlrt,
 	       M_PCB, M_DONTWAIT);
 	if (nlinkp == 0)
 		return (NULL);
-	bzero((caddr_t)nlinkp, sizeof(struct llc_linkcb));
+	memset((caddr_t)nlinkp, 0, sizeof(struct llc_linkcb));
 	
 	/* copy link address */
 	sdl_copy(dst, &nlinkp->llcl_addr);
@@ -2148,8 +2148,7 @@ llc_newlink(struct sockaddr_dl *dst, struct ifnet *ifp, struct rtentry *nlrt,
 		FREE(nlinkp, M_PCB);
 		return(NULL);
 	}
-	bzero((caddr_t)nlinkp->llcl_output_buffers, 
-	      llcwindow*sizeof(struct mbuf *));
+	memset((caddr_t)nlinkp->llcl_output_buffers, 0, llcwindow*sizeof(struct mbuf *));
 
 	/* set window size & slotsfree */
 	nlinkp->llcl_slotsfree = nlinkp->llcl_window = llcwindow;

--- a/server/netccitt/llc_var.h
+++ b/server/netccitt/llc_var.h
@@ -376,13 +376,13 @@ struct sdl_hdr {
 				struct mbuf *_m = (struct mbuf *) (m); \
 				if (_m) { \
 					M_PREPEND(_m, LLC_ISFRAMELEN, M_DONTWAIT); \
-					bzero(mtod(_m, caddr_t), LLC_ISFRAMELEN); \
+					memset(mtod(_m, 0, caddr_t), LLC_ISFRAMELEN); \
 				} else { \
 					MGETHDR (_m, M_DONTWAIT, MT_HEADER); \
 					if (_m != NULL) { \
 						_m->m_pkthdr.len = _m->m_len = LLC_UFRAMELEN; \
 						_m->m_next = _m->m_act = NULL; \
-						bzero(mtod(_m, caddr_t), LLC_UFRAMELEN); \
+						memset(mtod(_m, 0, caddr_t), LLC_UFRAMELEN); \
 					} else return; \
 				} \
 				(m) = _m; \

--- a/server/netccitt/pk_acct.c
+++ b/server/netccitt/pk_acct.c
@@ -106,7 +106,7 @@ register struct pklcd *lcp;
 
 	if ((vp = pkacctp) == 0)
 		return;
-	bzero ((caddr_t)&acbuf, sizeof (acbuf));
+	memset((caddr_t)&acbuf, 0, sizeof (acbuf));
 	if (lcp -> lcd_ceaddr != 0)
 		sa = lcp -> lcd_ceaddr;
 	else if (lcp -> lcd_craddr != 0) {
@@ -134,8 +134,7 @@ register struct pklcd *lcp;
 			*dst = *src++ << 4;
 	acbuf.x25acct_addrlen = len;
 
-	bcopy (sa -> x25_udata, acbuf.x25acct_udata,
-		sizeof (acbuf.x25acct_udata));
+	memcpy(acbuf.x25acct_udata, sa -> x25_udata, sizeof (acbuf.x25acct_udata));
 	acbuf.x25acct_txcnt = lcp -> lcd_txcnt;
 	acbuf.x25acct_rxcnt = lcp -> lcd_rxcnt;
 

--- a/server/netccitt/pk_debug.c
+++ b/server/netccitt/pk_debug.c
@@ -123,11 +123,11 @@ struct mbuf *m;
 		copy_size = new_size - zero_size;
 		c->mbc_oldsize = c->mbc_size;
 		if (copy_size)
-			bcopy(cache, (caddr_t)c->mbc_cache, copy_size);
+			memcpy((caddr_t)c->mbc_cache, cache, copy_size);
 		if (cache)
 			free(cache, M_MBUF);
 		if (zero_size)
-			bzero(copy_size + (caddr_t)c->mbc_cache, zero_size);
+			memset(copy_size + (caddr_t)c->mbc_cache, 0, zero_size);
 	}
 	if (c->mbc_size == 0)
 		return;

--- a/server/netccitt/pk_input.c
+++ b/server/netccitt/pk_input.c
@@ -113,7 +113,7 @@ caddr_t llnext;
 	pkp = (struct pkcb *) malloc (size, M_PCB, M_WAITOK);
 	if (pkp == 0)
 		return ((struct pkcb *)0);
-	bzero ((caddr_t) pkp, size);
+	memset((caddr_t) pkp, 0, size);
 	pkp -> pk_lloutput = pp -> pr_output;
 	pkp -> pk_llctlinput = (caddr_t (*)()) pp -> pr_ctlinput;
 	pkp -> pk_xcp = xcp;
@@ -219,7 +219,7 @@ register struct pkcb *pkp;
 		pkp -> pk_chan =
 			(struct pklcd **) malloc (size, M_IFADDR, M_WAITOK);
 		if (pkp -> pk_chan) {
-			bzero ((caddr_t) pkp -> pk_chan, size);
+			memset((caddr_t) pkp -> pk_chan, 0, size);
 			/*
 			 * Allocate a logical channel descriptor for lcn 0
 			 */
@@ -841,7 +841,7 @@ register struct x25config *xcp;
 	octet *cp;
 	unsigned count;
 
-	bzero ((caddr_t) sa, sizeof (*sa));
+	memset((caddr_t) sa, 0, sizeof (*sa));
 	sa -> x25_len = sizeof (*sa);
 	sa -> x25_family = AF_CCITT;
 	if (iscalling) {
@@ -858,7 +858,7 @@ register struct x25config *xcp;
 		sprintf ((char *) dnicname, "%d", xcp -> xc_addr.x25_net);
 		prune_dnic ((char *) buf, sa -> x25_addr, dnicname, xcp);
 	} else
-		bcopy ((caddr_t) buf, (caddr_t) sa -> x25_addr, count + 1);
+		memcpy((caddr_t) sa -> x25_addr, (caddr_t) buf, count + 1);
 }
 
 static
@@ -879,7 +879,7 @@ struct socket *so;
 		M_PREPEND (m, sizeof (cmsghdr), M_DONTWAIT);
 		if (m == 0)
 			return;
-		bcopy ((caddr_t)&cmsghdr, mtod (m, caddr_t), sizeof (cmsghdr));
+		memcpy(mtod (m, (caddr_t)&cmsghdr, caddr_t), sizeof (cmsghdr));
 		MCHTYPE(m, MT_CONTROL);
 		sbappendrecord (&so -> so_rcv, m);
 	}
@@ -924,7 +924,7 @@ struct pkcb *pkp;
 		udlen = 0;
 	pk_from_bcd (a, 1, sa, pkp -> pk_xcp); /* get calling address */
 	pk_parse_facilities (facp, sa);
-	bcopy ((caddr_t) u, sa -> x25_udata, udlen);
+	memcpy(sa -> x25_udata, (caddr_t) u, udlen);
 	sa -> x25_udlen = udlen;
 
 	/*
@@ -937,7 +937,7 @@ struct pkcb *pkp;
 	for (l = pk_listenhead; l; l = l -> lcd_listen) {
 		struct sockaddr_x25 *sxp = l -> lcd_ceaddr;
 
-		if (bcmp (sxp -> x25_udata, u, sxp -> x25_udlen))
+               if (memcmp (sxp -> x25_udata, u, sxp -> x25_udlen))
 			continue;
 		if (sxp -> x25_net &&
 		    sxp -> x25_net != xcp -> xc_addr.x25_net)
@@ -1008,10 +1008,10 @@ struct pkcb *pkp;
 	 * CONFIRMATION.
 	 */
 #ifdef WATERLOO		/* be explicit */
-	if (l == 0 && bcmp (sa -> x25_udata, "ean", 3) == 0)
+       if (l == 0 && memcmp (sa -> x25_udata, "ean", 3) == 0)
 		pk_message (lcn, pkp -> pk_xcp, "host=%s ean%c: %s",
 			sa -> x25_addr, sa -> x25_udata[3] & 0xff, errstr);
-	else if (l == 0 && bcmp (sa -> x25_udata, "\1\0\0\0", 4) == 0)
+       else if (l == 0 && memcmp (sa -> x25_udata, "\1\0\0\0", 4) == 0)
 		pk_message (lcn, pkp -> pk_xcp, "host=%s x29d: %s",
 			sa -> x25_addr, errstr);
 	else

--- a/server/netccitt/pk_llcsubr.c
+++ b/server/netccitt/pk_llcsubr.c
@@ -118,7 +118,7 @@
 			  (struct pkcb *) NULL) : \
 			 (struct pkcb *)((rt)->rt_llinfo))
 
-#define equal(a1, a2) (bcmp((caddr_t)(a1), \
+#define equal(a1, a2) (memcmp((caddr_t)(a1), \
 			       (caddr_t)(a2), \
 			       (a1)->sa_len) == 0)
 #define XIFA(rt) ((struct x25_ifaddr *)((rt)->rt_ifa))
@@ -292,8 +292,7 @@ npaidb_enter(struct sockaddr_dl *key, struct sockaddr *value,
 		 * are zeroed out.
 		 */
 		npdl_netmask.sdl_data[saploc] = NPDL_SAPNETMASK;
-		bzero((caddr_t)&npdl_netmask.sdl_data[saploc+1], 
-		      npdl_datasize-saploc-1);
+		memset((caddr_t)&npdl_netmask.sdl_data[saploc+1], 0, npdl_datasize-saploc-1);
 
 		if (value == 0)
 			value = &npdl_dummy;
@@ -308,7 +307,7 @@ npaidb_enter(struct sockaddr_dl *key, struct sockaddr *value,
 
 		nprt->rt_llinfo = malloc(size , M_PCB, M_WAITOK);
 		if (nprt->rt_llinfo) {
-			bzero (nprt->rt_llinfo, size);
+			memset(nprt->rt_llinfo, 0, size);
 			((struct npaidbentry *) (nprt->rt_llinfo))->np_rt = rt;
 		}
 	} else nprt->rt_refcnt--;

--- a/server/netccitt/pk_subr.c
+++ b/server/netccitt/pk_subr.c
@@ -96,7 +96,7 @@ struct socket *so;
 
 	MALLOC(lcp, struct pklcd *, sizeof (*lcp), M_PCB, M_NOWAIT);
 	if (lcp) {
-		bzero ((caddr_t)lcp, sizeof (*lcp));
+		memset((caddr_t)lcp, 0, sizeof (*lcp));
 		insque (&lcp -> lcd_q, &pklcd_q);
 		lcp -> lcd_state = READY;
 		lcp -> lcd_send = pk_output;
@@ -316,8 +316,8 @@ pk_ifwithaddr (sx)
 		for (ifa = ifp -> if_addrlist; ifa; ifa = ifa -> ifa_next)
 			if (ifa -> ifa_addr -> sa_family == AF_CCITT) {
 				ia = (struct x25_ifaddr *)ifa;
-				if (bcmp (addr, ia -> ia_xc.xc_addr.x25_addr,
-					 16) == 0)
+                               if (memcmp (addr, ia -> ia_xc.xc_addr.x25_addr,
+                                        16) == 0)
 					return (ia);
 				
 			}
@@ -372,8 +372,8 @@ struct mbuf *nam;
 		register struct sockaddr_x25 *sa2 = pp -> lcd_ceaddr;
 		if ((sa2 -> x25_udlen == sa -> x25_udlen) &&
 		    (sa2 -> x25_udlen == 0 ||
-		     (bcmp (sa2 -> x25_udata, sa -> x25_udata,
-			    min (sa2 -> x25_udlen, sa -> x25_udlen)) == 0)))
+                    (memcmp (sa2 -> x25_udata, sa -> x25_udata,
+                            min (sa2 -> x25_udlen, sa -> x25_udlen)) == 0)))
 				return (EADDRINUSE);
 	}
 	lcp -> lcd_laddr = *sa;

--- a/server/netccitt/pk_usrreq.c
+++ b/server/netccitt/pk_usrreq.c
@@ -170,8 +170,9 @@ struct mbuf *control;
 	case PRU_ACCEPT: 
 		if (lcp -> lcd_craddr == NULL)
 			break;
-		bcopy ((caddr_t)lcp -> lcd_craddr, mtod (nam, caddr_t),
-			sizeof (struct sockaddr_x25));
+               memcpy(mtod (nam, caddr_t),
+                       (caddr_t)lcp -> lcd_craddr,
+                       sizeof (struct sockaddr_x25));
 		nam -> m_len = sizeof (struct sockaddr_x25);
 		if (lcp -> lcd_flags & X25_OLDSOCKADDR)
 			new_to_old (nam);
@@ -248,8 +249,9 @@ struct mbuf *control;
 		if (lcp -> lcd_ceaddr == 0)
 			return (EADDRNOTAVAIL);
 		nam -> m_len = sizeof (struct sockaddr_x25);
-		bcopy ((caddr_t)lcp -> lcd_ceaddr, mtod (nam, caddr_t),
-			sizeof (struct sockaddr_x25));
+               memcpy(mtod (nam, caddr_t),
+                       (caddr_t)lcp -> lcd_ceaddr,
+                       sizeof (struct sockaddr_x25));
 		if (lcp -> lcd_flags & X25_OLDSOCKADDR)
 			new_to_old (nam);
 		break;
@@ -258,9 +260,10 @@ struct mbuf *control;
 		if (lcp -> lcd_state != DATA_TRANSFER)
 			return (ENOTCONN);
 		nam -> m_len = sizeof (struct sockaddr_x25);
-		bcopy (lcp -> lcd_craddr ? (caddr_t)lcp -> lcd_craddr :
-			(caddr_t)lcp -> lcd_ceaddr,
-			mtod (nam, caddr_t), sizeof (struct sockaddr_x25));
+               memcpy (mtod (nam, caddr_t),
+                       lcp -> lcd_craddr ? (caddr_t)lcp -> lcd_craddr :
+                       (caddr_t)lcp -> lcd_ceaddr,
+                       sizeof (struct sockaddr_x25));
 		if (lcp -> lcd_flags & X25_OLDSOCKADDR)
 			new_to_old (nam);
 		break;
@@ -278,7 +281,7 @@ struct mbuf *control;
 				    (n = m_pullup (n, len)) == 0)
 					break;
 				m -> m_len = len;
-				bcopy (mtod (m, caddr_t), mtod (n, caddr_t), len);
+                               memcpy(mtod (m, caddr_t), mtod (n, caddr_t), len);
 				m_freem (n);
 			}
 			break;
@@ -360,7 +363,7 @@ register struct ifnet *ifp;
 				M_IFADDR, M_WAITOK);
 			if (ia == 0)
 				return (ENOBUFS);
-			bzero ((caddr_t)ia, sizeof (*ia));
+			memset((caddr_t)ia, 0, sizeof (*ia));
 			if (ifa = ifp -> if_addrlist) {
 				for ( ; ifa -> ifa_next; ifa = ifa -> ifa_next)
 					;
@@ -470,7 +473,7 @@ register struct mbuf *m;
 
 	oldp = mtod (m, struct x25_sockaddr *);
 	newp = &new;
-	bzero ((caddr_t)newp, sizeof (*newp));
+	memset((caddr_t)newp, 0, sizeof (*newp));
 
 	newp -> x25_family = AF_CCITT;
 	newp -> x25_len = sizeof(*newp);
@@ -478,10 +481,9 @@ register struct mbuf *m;
 		| X25_MQBIT | X25_OLDSOCKADDR;
 	if (oldp -> xaddr_facilities & XS_HIPRIO)	/* Datapac specific */
 		newp -> x25_opts.op_psize = X25_PS128;
-	bcopy ((caddr_t)oldp -> xaddr_addr, newp -> x25_addr,
-	       (unsigned)min (oldp -> xaddr_len, sizeof (newp -> x25_addr) - 1));
-	if (bcmp ((caddr_t)oldp -> xaddr_proto, newp -> x25_udata, 4) != 0) {
-		bcopy ((caddr_t)oldp -> xaddr_proto, newp -> x25_udata, 4);
+	memcpy(newp -> x25_addr, (caddr_t)oldp -> xaddr_addr, (unsigned)min (oldp -> xaddr_len, sizeof (newp -> x25_addr) - 1));
+       if (memcmp ((caddr_t)oldp -> xaddr_proto, newp -> x25_udata, 4) != 0) {
+		memcpy(newp -> x25_udata, (caddr_t)oldp -> xaddr_proto, 4);
 		newp -> x25_udlen = 4;
 	}
 	ocp = (caddr_t)oldp -> xaddr_userdata;
@@ -492,7 +494,7 @@ register struct mbuf *m;
 		*ncp++ = *ocp++;
 		newp -> x25_udlen++;
 	}
-	bcopy ((caddr_t)newp, mtod (m, char *), sizeof (*newp));
+       memcpy(mtod (m, char *), (caddr_t)newp, sizeof (*newp));
 	m -> m_len = sizeof (*newp);
 }
 
@@ -512,7 +514,7 @@ register struct mbuf *m;
 
 	oldp = &old;
 	newp = mtod (m, struct sockaddr_x25 *);
-	bzero ((caddr_t)oldp, sizeof (*oldp));
+	memset((caddr_t)oldp, 0, sizeof (*oldp));
 
 	oldp -> xaddr_facilities = newp -> x25_opts.op_flags & X25_REVERSE_CHARGE;
 	if (newp -> x25_opts.op_psize == X25_PS128)
@@ -524,12 +526,12 @@ register struct mbuf *m;
 		oldp -> xaddr_len++;
 	}
 
-	bcopy (newp -> x25_udata, (caddr_t)oldp -> xaddr_proto, 4);
-	if (newp -> x25_udlen > 4)
-		bcopy (newp -> x25_udata + 4, (caddr_t)oldp -> xaddr_userdata,
-			(unsigned)(newp -> x25_udlen - 4));
+       memcpy((caddr_t)oldp -> xaddr_proto, newp -> x25_udata, 4);
+       if (newp -> x25_udlen > 4)
+               memcpy((caddr_t)oldp -> xaddr_userdata, newp -> x25_udata + 4,
+                      (unsigned)(newp -> x25_udlen - 4));
 
-	bcopy ((caddr_t)oldp, mtod (m, char *), sizeof (*oldp));
+       memcpy(mtod (m, char *), (caddr_t)oldp, sizeof (*oldp));
 	m -> m_len = sizeof (*oldp);
 }
 

--- a/server/netinet/if_ether.h
+++ b/server/netinet/if_ether.h
@@ -197,8 +197,8 @@ struct ether_multistep {
 { \
 	for ((enm) = (ac)->ac_multiaddrs; \
 	    (enm) != NULL && \
-	    (bcmp((enm)->enm_addrlo, (addrlo), 6) != 0 || \
-	     bcmp((enm)->enm_addrhi, (addrhi), 6) != 0); \
+	    (memcmp((enm)->enm_addrlo, (addrlo), 6) != 0 || \
+	     memcmp((enm)->enm_addrhi, (addrhi), 6) != 0); \
 		(enm) = (enm)->enm_next); \
 }
 

--- a/server/netinet/igmp.c
+++ b/server/netinet/igmp.c
@@ -296,7 +296,7 @@ igmp_sendreport(inm)
 	igmp->igmp_cksum = in_cksum(m, IGMP_MINLEN);
 
 	imo = &simo;
-	bzero((caddr_t)imo, sizeof(*imo));
+	memset((caddr_t)imo, 0, sizeof(*imo));
 	imo->imo_multicast_ifp = inm->inm_ifp;
 	imo->imo_multicast_ttl = 1;
 	/*

--- a/server/netinet/in.c
+++ b/server/netinet/in.c
@@ -209,7 +209,7 @@ in_control(so, cmd, data, ifp)
 				malloc(sizeof *oia, M_IFADDR, M_WAITOK);
 			if (oia == (struct in_ifaddr *)NULL)
 				return (ENOBUFS);
-			bzero((caddr_t)oia, sizeof *oia);
+			memset((caddr_t)oia, 0, sizeof *oia);
 			if (ia = in_ifaddr) {
 				for ( ; ia->ia_next; ia = ia->ia_next)
 					continue;

--- a/server/netinet/in_pcb.c
+++ b/server/netinet/in_pcb.c
@@ -67,7 +67,7 @@ in_pcballoc(so, head)
 	MALLOC(inp, struct inpcb *, sizeof(*inp), M_PCB, M_WAITOK);
 	if (inp == NULL)
 		return (ENOBUFS);
-	bzero((caddr_t)inp, sizeof(*inp));
+	memset((caddr_t)inp, 0, sizeof(*inp));
 	inp->inp_head = head;
 	inp->inp_socket = so;
 	insque(inp, head);
@@ -311,7 +311,7 @@ in_setsockaddr(inp, nam)
 	
 	nam->m_len = sizeof (*sin);
 	sin = mtod(nam, struct sockaddr_in *);
-	bzero((caddr_t)sin, sizeof (*sin));
+	memset((caddr_t)sin, 0, sizeof (*sin));
 	sin->sin_family = AF_INET;
 	sin->sin_len = sizeof(*sin);
 	sin->sin_port = inp->inp_lport;
@@ -327,7 +327,7 @@ in_setpeeraddr(inp, nam)
 	
 	nam->m_len = sizeof (*sin);
 	sin = mtod(nam, struct sockaddr_in *);
-	bzero((caddr_t)sin, sizeof (*sin));
+	memset((caddr_t)sin, 0, sizeof (*sin));
 	sin->sin_family = AF_INET;
 	sin->sin_len = sizeof(*sin);
 	sin->sin_port = inp->inp_fport;
@@ -412,7 +412,7 @@ in_losing(inp)
 
 	if ((rt = inp->inp_route.ro_rt)) {
 		inp->inp_route.ro_rt = 0;
-		bzero((caddr_t)&info, sizeof(info));
+		memset((caddr_t)&info, 0, sizeof(info));
 		info.rti_info[RTAX_DST] =
 			(struct sockaddr *)&inp->inp_route.ro_dst;
 		info.rti_info[RTAX_GATEWAY] = rt->rt_gateway;

--- a/server/netinet/ip_icmp.c
+++ b/server/netinet/ip_icmp.c
@@ -136,7 +136,7 @@ icmp_error(n, type, code, dest, destifp)
 	}
 
 	icp->icmp_code = code;
-	bcopy((caddr_t)oip, (caddr_t)&icp->icmp_ip, icmplen);
+	memcpy((caddr_t)&icp->icmp_ip, (caddr_t)oip, icmplen);
 	nip = &icp->icmp_ip;
 	nip->ip_len = htons((u_short)(nip->ip_len + oiplen));
 
@@ -151,7 +151,7 @@ icmp_error(n, type, code, dest, destifp)
 	m->m_pkthdr.len = m->m_len;
 	m->m_pkthdr.rcvif = n->m_pkthdr.rcvif;
 	nip = mtod(m, struct ip *);
-	bcopy((caddr_t)oip, (caddr_t)nip, sizeof(struct ip));
+	memcpy((caddr_t)nip, (caddr_t)oip, sizeof(struct ip));
 	nip->ip_len = m->m_len;
 	nip->ip_hl = sizeof(struct ip) >> 2;
 	nip->ip_p = IPPROTO_ICMP;
@@ -490,8 +490,7 @@ icmp_reflect(m)
 			     */
 			    if (opt == IPOPT_RR || opt == IPOPT_TS || 
 				opt == IPOPT_SECURITY) {
-				    bcopy((caddr_t)cp,
-					mtod(opts, caddr_t) + opts->m_len, len);
+				    memcpy(mtod(opts, (caddr_t)cp, caddr_t) + opts->m_len, len);
 				    opts->m_len += len;
 			    }
 		    }
@@ -518,8 +517,7 @@ icmp_reflect(m)
 		if (m->m_flags & M_PKTHDR)
 			m->m_pkthdr.len -= optlen;
 		optlen += sizeof(struct ip);
-		bcopy((caddr_t)ip + optlen, (caddr_t)(ip + 1),
-			 (unsigned)(m->m_len - sizeof(struct ip)));
+		memcpy((caddr_t)(ip + 1), (caddr_t)ip + optlen, (unsigned)(m->m_len - sizeof(struct ip)));
 	}
 	m->m_flags &= ~(M_BCAST|M_MCAST);
 	icmp_send(m, opts);

--- a/server/netinet/ip_input.c
+++ b/server/netinet/ip_input.c
@@ -138,7 +138,7 @@ ip_init()
 #if GATEWAY
 	i = (if_index + 1) * (if_index + 1) * sizeof (u_long);
 	ip_ifmatrix = (u_long *) malloc(i, M_RTABLE, M_WAITOK);
-	bzero((char *)ip_ifmatrix, i);
+	memset((char *)ip_ifmatrix, 0, i);
 #endif
 }
 
@@ -734,8 +734,7 @@ ip_dooptions(m)
 			/*
 			 * locate outgoing interface
 			 */
-			bcopy((caddr_t)(cp + off), (caddr_t)&ipaddr.sin_addr,
-			    sizeof(ipaddr.sin_addr));
+			memcpy((caddr_t)&ipaddr.sin_addr, (caddr_t)(cp + off), sizeof(ipaddr.sin_addr));
 			if (opt == IPOPT_SSRR) {
 #define	INA	struct in_ifaddr *
 #define	SA	struct sockaddr *
@@ -749,8 +748,7 @@ ip_dooptions(m)
 				goto bad;
 			}
 			ip->ip_dst = ipaddr.sin_addr;
-			bcopy((caddr_t)&(IA_SIN(ia)->sin_addr),
-			    (caddr_t)(cp + off), sizeof(struct in_addr));
+			memcpy((caddr_t)(cp + off), (caddr_t)&(IA_SIN(ia)->sin_addr), sizeof(struct in_addr));
 			cp[IPOPT_OFFSET] += sizeof(struct in_addr);
 			/*
 			 * Let ip_intr's mcast routing check handle mcast pkts
@@ -769,8 +767,7 @@ ip_dooptions(m)
 			off--;			/* 0 origin */
 			if (off > optlen - sizeof(struct in_addr))
 				break;
-			bcopy((caddr_t)(&ip->ip_dst), (caddr_t)&ipaddr.sin_addr,
-			    sizeof(ipaddr.sin_addr));
+			memcpy((caddr_t)&ipaddr.sin_addr, (caddr_t)(&ip->ip_dst), sizeof(ipaddr.sin_addr));
 			/*
 			 * locate outgoing interface; if we're the destination,
 			 * use the incoming interface (should be same).
@@ -781,8 +778,7 @@ ip_dooptions(m)
 				code = ICMP_UNREACH_HOST;
 				goto bad;
 			}
-			bcopy((caddr_t)&(IA_SIN(ia)->sin_addr),
-			    (caddr_t)(cp + off), sizeof(struct in_addr));
+			memcpy((caddr_t)(cp + off), (caddr_t)&(IA_SIN(ia)->sin_addr), sizeof(struct in_addr));
 			cp[IPOPT_OFFSET] += sizeof(struct in_addr);
 			break;
 
@@ -811,8 +807,7 @@ ip_dooptions(m)
 							    m->m_pkthdr.rcvif);
 				if (ia == 0)
 					continue;
-				bcopy((caddr_t)&IA_SIN(ia)->sin_addr,
-				    (caddr_t)sin, sizeof(struct in_addr));
+				memcpy((caddr_t)sin, (caddr_t)&IA_SIN(ia)->sin_addr, sizeof(struct in_addr));
 				ipt->ipt_ptr += sizeof(struct in_addr);
 				break;
 
@@ -820,8 +815,7 @@ ip_dooptions(m)
 				if (ipt->ipt_ptr + sizeof(n_time) +
 				    sizeof(struct in_addr) > ipt->ipt_len)
 					goto bad;
-				bcopy((caddr_t)sin, (caddr_t)&ipaddr.sin_addr,
-				    sizeof(struct in_addr));
+				memcpy((caddr_t)&ipaddr.sin_addr, (caddr_t)sin, sizeof(struct in_addr));
 				if (ifa_ifwithaddr((SA)&ipaddr) == 0)
 					continue;
 				ipt->ipt_ptr += sizeof(struct in_addr);
@@ -831,8 +825,7 @@ ip_dooptions(m)
 				goto bad;
 			}
 			ntime = iptime();
-			bcopy((caddr_t)&ntime, (caddr_t)cp + ipt->ipt_ptr - 1,
-			    sizeof(n_time));
+			memcpy((caddr_t)cp + ipt->ipt_ptr - 1, (caddr_t)&ntime, sizeof(n_time));
 			ipt->ipt_ptr += sizeof(n_time);
 		}
 	}
@@ -894,7 +887,7 @@ save_rte(option, dst)
 #endif
 	if (olen > sizeof(ip_srcrt) - (1 + sizeof(dst)))
 		return;
-	bcopy((caddr_t)option, (caddr_t)ip_srcrt.srcopt, olen);
+	memcpy((caddr_t)ip_srcrt.srcopt, (caddr_t)option, olen);
 	ip_nhops = (olen - IPOPT_OFFSET - 1) / sizeof(struct in_addr);
 	ip_srcrt.dst = dst;
 }
@@ -941,8 +934,7 @@ ip_srcroute()
 	 */
 	ip_srcrt.nop = IPOPT_NOP;
 	ip_srcrt.srcopt[IPOPT_OFFSET] = IPOPT_MINOFF;
-	bcopy((caddr_t)&ip_srcrt.nop,
-	    mtod(m, caddr_t) + sizeof(struct in_addr), OPTSIZ);
+	memcpy(mtod(m, (caddr_t)&ip_srcrt.nop, caddr_t) + sizeof(struct in_addr), OPTSIZ);
 	q = (struct in_addr *)(mtod(m, caddr_t) +
 	    sizeof(struct in_addr) + OPTSIZ);
 #undef OPTSIZ
@@ -988,7 +980,7 @@ ip_stripoptions(m, mopt)
 	olen = (ip->ip_hl<<2) - sizeof (struct ip);
 	opts = (caddr_t)(ip + 1);
 	i = m->m_len - (sizeof (struct ip) + olen);
-	bcopy(opts  + olen, opts, (unsigned)i);
+	memcpy(opts, opts  + olen, (unsigned)i);
 	m->m_len -= olen;
 	if (m->m_flags & M_PKTHDR)
 		m->m_pkthdr.len -= olen;

--- a/server/netinet/ip_mroute.c
+++ b/server/netinet/ip_mroute.c
@@ -97,7 +97,7 @@ static	void phyint_send (struct mbuf *, struct vif *);
 static	void tunnel_send (struct mbuf *, struct vif *);
 
 #define INSIZ sizeof(struct in_addr)
-#define	same(a1, a2) (bcmp((caddr_t)(a1), (caddr_t)(a2), INSIZ) == 0)
+#define	same(a1, a2) (memcmp((caddr_t)(a1), (caddr_t)(a2), INSIZ) == 0)
 #define	satosin(sa)	((struct sockaddr_in *)(sa))
 
 /*
@@ -239,7 +239,7 @@ ip_mrouter_done()
 			(*ifp->if_ioctl)(ifp, SIOCDELMULTI, (caddr_t)&ifr);
 		}
 	}
-	bzero((caddr_t)viftable, sizeof(viftable));
+	memset((caddr_t)viftable, 0, sizeof(viftable));
 	numvifs = 0;
 
 	/*
@@ -248,7 +248,7 @@ ip_mrouter_done()
 	for (i = 0; i < MRTHASHSIZ; i++)
 		if (mrttable[i])
 			free(mrttable[i], M_MRTABLE);
-	bzero((caddr_t)mrttable, sizeof(mrttable));
+	memset((caddr_t)mrttable, 0, sizeof(mrttable));
 	cached_mrt = NULL;
 
 	ip_mrouter = NULL;
@@ -347,7 +347,7 @@ del_vif(vifip)
 		(*ifp->if_ioctl)(ifp, SIOCDELMULTI, (caddr_t)&ifr);
 	}
 
-	bzero((caddr_t)vifp, sizeof (*vifp));
+	memset((caddr_t)vifp, 0, sizeof (*vifp));
 
 	/* Adjust numvifs down */
 	for (i = numvifs - 1; i >= 0; i--)
@@ -395,9 +395,8 @@ add_lgrp(gcp)
 			return (ENOBUFS);
 		}
 
-		bzero((caddr_t)ip, num * sizeof(*ip));	/* XXX paranoid */
-		bcopy((caddr_t)vifp->v_lcl_grps, (caddr_t)ip,
-		    vifp->v_lcl_grps_n * sizeof(*ip));
+		memset((caddr_t)ip, 0, num * sizeof(*ip));	/* XXX paranoid */
+		memcpy((caddr_t)ip, (caddr_t)vifp->v_lcl_grps, vifp->v_lcl_grps_n * sizeof(*ip));
 
 		vifp->v_lcl_grps_max = num;
 		if (vifp->v_lcl_grps)
@@ -444,9 +443,7 @@ del_lgrp(gcp)
 		if (same(&gcp->lgc_gaddr, &vifp->v_lcl_grps[i])) {
 			error = 0;
 			vifp->v_lcl_grps_n--;
-			bcopy((caddr_t)&vifp->v_lcl_grps[i + 1],
-			    (caddr_t)&vifp->v_lcl_grps[i],
-			    (vifp->v_lcl_grps_n - i) * sizeof(struct in_addr));
+			memcpy((caddr_t)&vifp->v_lcl_grps[i], (caddr_t)&vifp->v_lcl_grps[i + 1], (vifp->v_lcl_grps_n - i) * sizeof(struct in_addr));
 			error = 0;
 			break;
 		}

--- a/server/netinet/ip_output.c
+++ b/server/netinet/ip_output.c
@@ -114,7 +114,7 @@ ip_output(m0, opt, ro, flags, imo)
 	 */
 	if (ro == 0) {
 		ro = &iproute;
-		bzero((caddr_t)ro, sizeof (*ro));
+		memset((caddr_t)ro, 0, sizeof (*ro));
 	}
 	dst = (struct sockaddr_in *)&ro->ro_dst;
 	/*
@@ -425,7 +425,7 @@ ip_insertoptions(m, opt, phlen)
 		m = n;
 		m->m_len = optlen + sizeof(struct ip);
 		m->m_data += max_linkhdr;
-		bcopy((caddr_t)ip, mtod(m, caddr_t), sizeof(struct ip));
+		memcpy(mtod(m, (caddr_t)ip, caddr_t), sizeof(struct ip));
 	} else {
 		m->m_data -= optlen;
 		m->m_len += optlen;
@@ -433,7 +433,7 @@ ip_insertoptions(m, opt, phlen)
 		ovbcopy((caddr_t)ip, mtod(m, caddr_t), sizeof(struct ip));
 	}
 	ip = mtod(m, struct ip *);
-	bcopy((caddr_t)p->ipopt_list, (caddr_t)(ip + 1), (unsigned)optlen);
+	memcpy((caddr_t)(ip + 1), (caddr_t)p->ipopt_list, (unsigned)optlen);
 	*phlen = sizeof(struct ip) + optlen;
 	ip->ip_len += optlen;
 	return (m);
@@ -468,7 +468,7 @@ ip_optcopy(ip, jp)
 		if (optlen > cnt)
 			optlen = cnt;
 		if (IPOPT_COPIED(opt)) {
-			bcopy((caddr_t)cp, (caddr_t)dp, (unsigned)optlen);
+			memcpy((caddr_t)dp, (caddr_t)cp, (unsigned)optlen);
 			dp += optlen;
 		}
 	}
@@ -571,8 +571,7 @@ ip_ctloutput(op, so, level, optname, mp)
 			*mp = m = m_get(M_WAIT, MT_SOOPTS);
 			if (inp->inp_options) {
 				m->m_len = inp->inp_options->m_len;
-				bcopy(mtod(inp->inp_options, caddr_t),
-				    mtod(m, caddr_t), (unsigned)m->m_len);
+				memcpy(caddr_t), mtod(inp->inp_options, mtod(m, caddr_t), (unsigned)m->m_len);
 			} else
 				m->m_len = 0;
 			break;
@@ -675,7 +674,7 @@ ip_pcbopts(pcbopt, m)
 	m->m_len += sizeof(struct in_addr);
 	cp = mtod(m, u_char *) + sizeof(struct in_addr);
 	ovbcopy(mtod(m, caddr_t), (caddr_t)cp, (unsigned)cnt);
-	bzero(mtod(m, caddr_t), sizeof(struct in_addr));
+	memset(mtod(m, 0, caddr_t), sizeof(struct in_addr));
 
 	for (; cnt > 0; cnt -= optlen, cp += optlen) {
 		opt = cp[IPOPT_OPTVAL];
@@ -712,7 +711,7 @@ ip_pcbopts(pcbopt, m)
 			/*
 			 * Move first hop before start of options.
 			 */
-			bcopy((caddr_t)&cp[IPOPT_OFFSET+1], mtod(m, caddr_t),
+			memcpy(mtod(m, (caddr_t)&cp[IPOPT_OFFSET+1], caddr_t),
 			    sizeof(struct in_addr));
 			/*
 			 * Then copy rest of options back

--- a/server/netinet/tcp_debug.c
+++ b/server/netinet/tcp_debug.c
@@ -91,11 +91,11 @@ tcp_trace(act, ostate, tp, ti, req)
 	if (tp)
 		td->td_cb = *tp;
 	else
-		bzero((caddr_t)&td->td_cb, sizeof (*tp));
+		memset((caddr_t)&td->td_cb, 0, sizeof (*tp));
 	if (ti)
 		td->td_ti = *ti;
 	else
-		bzero((caddr_t)&td->td_ti, sizeof (*ti));
+		memset((caddr_t)&td->td_ti, 0, sizeof (*ti));
 	td->td_req = req;
 #ifdef TCPDEBUG
 	if (tcpconsdebug == 0)

--- a/server/netinet/tcp_input.c
+++ b/server/netinet/tcp_input.c
@@ -558,7 +558,7 @@ findpcb:
 		sin->sin_len = sizeof(*sin);
 		sin->sin_addr = ti->ti_src;
 		sin->sin_port = ti->ti_sport;
-		bzero((caddr_t)sin->sin_zero, sizeof(sin->sin_zero));
+		memset((caddr_t)sin->sin_zero, 0, sizeof(sin->sin_zero));
 		laddr = inp->inp_laddr;
 		if (inp->inp_laddr.s_addr == INADDR_ANY)
 			inp->inp_laddr = ti->ti_dst;
@@ -1351,7 +1351,7 @@ tcp_dooptions(tp, cp, cnt, ti, ts_present, ts_val, ts_ecr)
 				continue;
 			if (!(ti->ti_flags & TH_SYN))
 				continue;
-			bcopy((char *) cp + 2, (char *) &mss, sizeof(mss));
+			memcpy((char *) &mss, (char *) cp + 2, sizeof(mss));
 			NTOHS(mss);
 			(void) tcp_mss(tp, mss);	/* sets t_maxseg */
 			break;
@@ -1369,9 +1369,9 @@ tcp_dooptions(tp, cp, cnt, ti, ts_present, ts_val, ts_ecr)
 			if (optlen != TCPOLEN_TIMESTAMP)
 				continue;
 			*ts_present = 1;
-			bcopy((char *)cp + 2, (char *) ts_val, sizeof(*ts_val));
+			memcpy((char *) ts_val, (char *)cp + 2, sizeof(*ts_val));
 			NTOHL(*ts_val);
-			bcopy((char *)cp + 6, (char *) ts_ecr, sizeof(*ts_ecr));
+			memcpy((char *) ts_ecr, (char *)cp + 6, sizeof(*ts_ecr));
 			NTOHL(*ts_ecr);
 
 			/* 
@@ -1409,7 +1409,7 @@ tcp_pulloutofband(so, ti, m)
 
 			tp->t_iobc = *cp;
 			tp->t_oobflags |= TCPOOB_HAVEDATA;
-			bcopy(cp+1, cp, (unsigned)(m->m_len - cnt - 1));
+			memcpy(cp, cp+1, (unsigned)(m->m_len - cnt - 1));
 			m->m_len--;
 			return;
 		}

--- a/server/netinet/tcp_output.c
+++ b/server/netinet/tcp_output.c
@@ -281,7 +281,7 @@ send:
 			opt[0] = TCPOPT_MAXSEG;
 			opt[1] = 4;
 			mss = htons((u_short) tcp_mss(tp, 0));
-			bcopy((caddr_t)&mss, (caddr_t)(opt + 2), sizeof(mss));
+			memcpy((caddr_t)(opt + 2), (caddr_t)&mss, sizeof(mss));
 			optlen = 4;
 	 
 			if ((tp->t_flags & TF_REQ_SCALE) &&
@@ -406,7 +406,7 @@ send:
 	ti = mtod(m, struct tcpiphdr *);
 	if (tp->t_template == 0)
 		panic("tcp_output");
-	bcopy((caddr_t)tp->t_template, (caddr_t)ti, sizeof (struct tcpiphdr));
+	memcpy((caddr_t)ti, (caddr_t)tp->t_template, sizeof (struct tcpiphdr));
 
 	/*
 	 * Fill in fields, remembering maximum advertised
@@ -435,7 +435,7 @@ send:
 		ti->ti_seq = htonl(tp->snd_max);
 	ti->ti_ack = htonl(tp->rcv_nxt);
 	if (optlen) {
-		bcopy((caddr_t)opt, (caddr_t)(ti + 1), optlen);
+		memcpy((caddr_t)(ti + 1), (caddr_t)opt, optlen);
 		ti->ti_off = (sizeof (struct tcphdr) + optlen) >> 2;
 	}
 	ti->ti_flags = flags;

--- a/server/netinet/tcp_subr.c
+++ b/server/netinet/tcp_subr.c
@@ -212,7 +212,7 @@ tcp_newtcpcb(inp)
 	tp = malloc(sizeof(*tp), M_PCB, M_NOWAIT);
 	if (tp == NULL)
 		return ((struct tcpcb *)0);
-	bzero((char *) tp, sizeof(struct tcpcb));
+	memset((char *) tp, 0, sizeof(struct tcpcb));
 	tp->seg_next = tp->seg_prev = (struct tcpiphdr *)tp;
 	tp->t_maxseg = tcp_mssdflt;
 

--- a/server/netinet/udp_usrreq.c
+++ b/server/netinet/udp_usrreq.c
@@ -330,7 +330,7 @@ udp_saveopt(p, size, type)
 	if ((m = m_get(M_DONTWAIT, MT_CONTROL)) == NULL)
 		return ((struct mbuf *) NULL);
 	cp = (struct cmsghdr *) mtod(m, struct cmsghdr *);
-	bcopy(p, CMSG_DATA(cp), size);
+	memcpy(CMSG_DATA(cp), p, size);
 	size += sizeof(*cp);
 	m->m_len = size;
 	cp->cmsg_len = size;

--- a/server/netiso/clnp_er.c
+++ b/server/netiso/clnp_er.c
@@ -248,7 +248,7 @@ char					reason;	/* reason for discard */
 		printf("clnp_emit_er: m x%x, hdr len %d\n", m, clnp->cnf_hdr_len);
 	ENDDEBUG
 
-	bzero((caddr_t)&route, sizeof(route));
+	memset((caddr_t)&route, 0, sizeof(route));
 
 	/*
 	 *	If header length is incorrect, or entire header is not contained

--- a/server/netiso/clnp_frag.c
+++ b/server/netiso/clnp_frag.c
@@ -132,7 +132,7 @@ struct rtentry *rt;			/* route if direct ether */
 
 
 		INCSTAT(cns_fragmented);
-        (void) bcopy(segoff + mtod(m, caddr_t), (caddr_t)&seg_part,
+        (void) memcpy(caddr_t), segoff + mtod(m, (caddr_t)&seg_part,
             sizeof(seg_part));
 		frag_base = ntohs(seg_part.cng_off);
 		/*
@@ -214,7 +214,7 @@ struct rtentry *rt;			/* route if direct ether */
 			m_cat(frag_hdr, frag_data);
 
 			/* insert segmentation part; updated below */
-			bcopy((caddr_t)&seg_part, mtod(frag_hdr, caddr_t) + segoff,
+			memcpy(mtod(frag_hdr, (caddr_t)&seg_part, caddr_t) + segoff,
 				sizeof(struct clnp_segment));
 
 			{
@@ -414,8 +414,8 @@ struct clnp_segment	*seg;	/* segment part of fragment header */
 	}
 	
 	/* Fill in rest of fragl structure */
-	bcopy((caddr_t)src, (caddr_t)&cfh->cfl_src, sizeof(struct iso_addr));
-	bcopy((caddr_t)dst, (caddr_t)&cfh->cfl_dst, sizeof(struct iso_addr));
+	memcpy((caddr_t)&cfh->cfl_src, (caddr_t)src, sizeof(struct iso_addr));
+	memcpy((caddr_t)&cfh->cfl_dst, (caddr_t)dst, sizeof(struct iso_addr));
 	cfh->cfl_id = seg->cng_id;
 	cfh->cfl_ttl = clnp->cnf_ttl;
 	cfh->cfl_last = (seg->cng_tot_len - clnp->cnf_hdr_len) - 1;

--- a/server/netiso/clnp_input.c
+++ b/server/netiso/clnp_input.c
@@ -186,14 +186,13 @@ next:
 			goto next;
 		}
 	}
-	bzero((caddr_t)&sh, sizeof(sh));
+	memset((caddr_t)&sh, 0, sizeof(sh));
 	sh.snh_flags = m->m_flags & (M_MCAST|M_BCAST);
 	switch((sh.snh_ifp = m->m_pkthdr.rcvif)->if_type) {
 		extern int ether_output();
 	case IFT_EON:
-		bcopy(mtod(m, caddr_t), (caddr_t)sh.snh_dhost, sizeof(u_long));
-		bcopy(sizeof(u_long) + mtod(m, caddr_t),
-					(caddr_t)sh.snh_shost, sizeof(u_long));
+		memcpy(caddr_t), mtod(m, (caddr_t)sh.snh_dhost, sizeof(u_long));
+		memcpy(caddr_t), sizeof(u_long) + mtod(m, (caddr_t)sh.snh_shost, sizeof(u_long));
 		sh.snh_dhost[4] = mtod(m, u_char *)[sizeof(struct ip) +
 								_offsetof(struct eon_hdr, eonh_class)];
 		m->m_data += EONIPLEN;
@@ -203,8 +202,7 @@ next:
 
 	default:
 		if (sh.snh_ifp->if_output == ether_output) {
-			bcopy((caddr_t)(mtod(m, struct ether_header *)->ether_dhost),
-				(caddr_t)sh.snh_dhost, 2*sizeof(sh.snh_dhost));
+			memcpy(struct ether_header *)->ether_dhost), (caddr_t)(mtod(m, (caddr_t)sh.snh_dhost, 2*sizeof(sh.snh_dhost));
 			m->m_data += sizeof (struct ether_header);
 			m->m_len -= sizeof (struct ether_header);
 			m->m_pkthdr.len -= sizeof (struct ether_header);
@@ -397,7 +395,7 @@ struct snpa_hdr	*shp;	/* subnetwork header */
 			clnp_discard(m, GEN_INCOMPLETE);
 			return;
 		} else {
-			(void) bcopy(hoff, (caddr_t)&seg_part, sizeof(struct clnp_segment));
+			(void) memcpy((caddr_t)&seg_part, hoff, sizeof(struct clnp_segment));
 			/* make sure segmentation fields are in host order */
 			seg_part.cng_id = ntohs(seg_part.cng_id);
 			seg_part.cng_off = ntohs(seg_part.cng_off);

--- a/server/netiso/clnp_options.c
+++ b/server/netiso/clnp_options.c
@@ -110,7 +110,7 @@ struct clnp_optidx	*oidx;		/* ptr to option index */
 	}
 
 	len = CLNPSRCRT_CLEN(oidx, options);
-	bcopy(CLNPSRCRT_CADDR(oidx, options), (caddr_t)&isoa, len);
+	memcpy(options), CLNPSRCRT_CADDR(oidx, (caddr_t)&isoa, len);
 	isoa.isoa_len = len;
 		
 	IFDEBUG(D_OPTIONS)
@@ -187,7 +187,7 @@ struct iso_addr		*isoa;		/* ptr to our address for this ifp */
 						rec_start, new_addrlen);
 				ENDDEBUG
 
-				bcopy((caddr_t)isoa, rec_start, new_addrlen);
+				memcpy(rec_start, (caddr_t)isoa, new_addrlen);
 
 				/* update offset field */
 				*(opt + 1) += new_addrlen;
@@ -288,7 +288,7 @@ struct clnp_optidx	*oidx;	/* RETURN: filled in with option idx info */
 	ENDDEBUG
 
 	/* clear option index field if passed */
-	bzero((caddr_t)oidx, sizeof(struct clnp_optidx));
+	memset((caddr_t)oidx, 0, sizeof(struct clnp_optidx));
 
 	/*
 	 *	We need to indicate whether the ER option is present. This is done

--- a/server/netiso/clnp_output.c
+++ b/server/netiso/clnp_output.c
@@ -314,7 +314,7 @@ int					flags;		/* flags */
 		IFDEBUG(D_OUTPUT)
 			printf("clnp_output: NEW clcp x%x\n",clcp);
 		ENDDEBUG
-		bzero((caddr_t)clcp, sizeof(struct clnp_cache));
+		memset((caddr_t)clcp, 0, sizeof(struct clnp_cache));
 
 		if (isop->isop_optindex)
 			oidx = mtod(isop->isop_optindex, struct clnp_optidx *);
@@ -461,7 +461,7 @@ int					flags;		/* flags */
 		 *	previously
 		 */
 		if ((m->m_len + sizeof(qos_option)) < MLEN) {
-			bcopy((caddr_t)qos_option, hoff, sizeof(qos_option));
+			memcpy(hoff, (caddr_t)qos_option, sizeof(qos_option));
 			clnp->cnf_hdr_len += sizeof(qos_option);
 			hdrlen += sizeof(qos_option);
 			m->m_len += sizeof(qos_option);
@@ -512,8 +512,7 @@ int					flags;		/* flags */
 		seg_part.cng_id = htons(clnp_id++);
 		seg_part.cng_off = htons(0);
 		seg_part.cng_tot_len = htons(total_len);
-		(void) bcopy((caddr_t)&seg_part, (caddr_t) clnp + clcp->clc_segoff, 
-			sizeof(seg_part));
+		(void) memcpy((caddr_t) clnp + clcp->clc_segoff, (caddr_t)&seg_part, sizeof(seg_part));
 	}
 	if (total_len <= SN_MTU(clcp->clc_ifp, clcp->clc_rt)) {
 		HTOC(clnp->cnf_seglen_msb, clnp->cnf_seglen_lsb, total_len);

--- a/server/netiso/clnp_raw.c
+++ b/server/netiso/clnp_raw.c
@@ -285,7 +285,7 @@ clnp_usrreq(so, req, m, nam, control)
 		MALLOC(rp, struct rawisopcb *, sizeof *rp, M_PCB, M_WAITOK);
 		if (rp == 0)
 			return (ENOBUFS);
-		bzero((caddr_t)rp, sizeof *rp);
+		memset((caddr_t)rp, 0, sizeof *rp);
 		so->so_pcb = (caddr_t)rp;
 		break;
 

--- a/server/netiso/clnp_subr.c
+++ b/server/netiso/clnp_subr.c
@@ -164,7 +164,7 @@ register struct iso_addr	*destp;		/* ptr to destination address buffer */
 		return((caddr_t)0);
 	}
 	len = destp->isoa_len = (u_char)*bufp++;
-	(void) bcopy(bufp, (caddr_t)destp, len);
+	(void) memcpy((caddr_t)destp, bufp, len);
 	buflen -= len;
 	bufp += len;
 
@@ -175,7 +175,7 @@ register struct iso_addr	*destp;		/* ptr to destination address buffer */
 		return((caddr_t)0);
 	}
 	len = srcp->isoa_len = (u_char)* bufp++;
-	(void) bcopy(bufp, (caddr_t)srcp, len);
+	(void) memcpy((caddr_t)srcp, bufp, len);
 	bufp += len;
 
 	/*
@@ -216,7 +216,7 @@ register struct iso_addr *dst;		/* ptr to destination address */
 		 * We are overloading siso_tlen in the if's address, as an nsel length.
 		 */
 		if (dst->isoa_len == ia->ia_addr.siso_nlen &&
-			bcmp((caddr_t)ia->ia_addr.siso_addr.isoa_genaddr,
+			memcmp((caddr_t)ia->ia_addr.siso_addr.isoa_genaddr,
 				 (caddr_t)dst->isoa_genaddr,
 				 ia->ia_addr.siso_nlen - ia->ia_addr.siso_tlen) == 0)
 					return 1;
@@ -259,7 +259,7 @@ struct snpa_hdr		*inbound_shp;	/* subnetwork header of inbound packet */
 	extern int				iso_systype;
 
 	clnp = mtod(m, struct clnp_fixed *);
-	bzero((caddr_t)&route, sizeof(route)); /* MUST be done before "bad:" */
+	memset((caddr_t)&route, 0, sizeof(route)); /* MUST be done before "bad:" */
 
 	/*
 	 *	Don't forward multicast or broadcast packets
@@ -405,11 +405,11 @@ register struct iso_addr	*srcp;	/* ptr to src addr */
 register struct iso_addr	*dstp;	/* ptr to dst addr */
 {
 	*bufp++ = dstp->isoa_len;
-	(void) bcopy((caddr_t)dstp, bufp, dstp->isoa_len);
+	(void) memcpy(bufp, (caddr_t)dstp, dstp->isoa_len);
 	bufp += dstp->isoa_len;
 
 	*bufp++ = srcp->isoa_len;
-	(void) bcopy((caddr_t)srcp, bufp, srcp->isoa_len);
+	(void) memcpy(bufp, (caddr_t)srcp, srcp->isoa_len);
 	bufp += srcp->isoa_len;
 
 	return bufp;
@@ -450,9 +450,8 @@ clnp_route(dst, ro, flags, first_hop, ifa)
 			RTFREE(ro->ro_rt);
 			ro->ro_rt = 0;
 		}
-		bzero((caddr_t)&ro->ro_dst, sizeof(ro->ro_dst));
-		bcopy((caddr_t)dst, (caddr_t)&ro->ro_dst.siso_addr,
-			1 + (unsigned)dst->isoa_len);
+		memset((caddr_t)&ro->ro_dst, 0, sizeof(ro->ro_dst));
+		memcpy((caddr_t)&ro->ro_dst.siso_addr, (caddr_t)dst, 1 + (unsigned)dst->isoa_len);
 		ro->ro_dst.siso_family = AF_ISO;
 		ro->ro_dst.siso_len = sizeof(ro->ro_dst);
 		ia = iso_localifa(&ro->ro_dst);
@@ -488,7 +487,7 @@ clnp_route(dst, ro, flags, first_hop, ifa)
 
 	if (ro->ro_rt == 0) {
 		/* set up new route structure */
-		bzero((caddr_t)&ro->ro_dst, sizeof(ro->ro_dst));
+		memset((caddr_t)&ro->ro_dst, 0, sizeof(ro->ro_dst));
 		ro->ro_dst.siso_len = sizeof(ro->ro_dst);
 		ro->ro_dst.siso_family = AF_ISO;
 		Bcopy(dst, &ro->ro_dst.siso_addr, 1 + dst->isoa_len);
@@ -548,13 +547,13 @@ struct iso_addr		*final_dst;		/* final destination */
 	 */
 	if CLNPSRCRT_TERM(oidx, options) {
 		dst.isoa_len = final_dst->isoa_len;
-		bcopy(final_dst->isoa_genaddr, dst.isoa_genaddr, dst.isoa_len);
+		memcpy(dst.isoa_genaddr, final_dst->isoa_genaddr, dst.isoa_len);
 	} else {
 		/*
 		 * setup dst based on src rt specified
 		 */
 		dst.isoa_len = CLNPSRCRT_CLEN(oidx, options);
-		bcopy(CLNPSRCRT_CADDR(oidx, options), dst.isoa_genaddr, dst.isoa_len);
+		memcpy(options), CLNPSRCRT_CADDR(oidx, dst.isoa_genaddr, dst.isoa_len);
 	}
 
 	/*
@@ -599,7 +598,7 @@ struct clnp_optidx	*ec_oidxp;	/* options index to ec packet */
 	int				ret;
 
 	/* fill in fake isopcb to pass to output function */
-	bzero(&isopcb, sizeof(isopcb));
+	memset(&isopcb, 0, sizeof(isopcb));
 	isopcb.isop_laddr = ec_dst;
 	isopcb.isop_faddr = ec_src;
 

--- a/server/netiso/cltp_usrreq.c
+++ b/server/netiso/cltp_usrreq.c
@@ -98,9 +98,9 @@ cltp_input(m0, srcsa, dstsa, cons_channel, output)
 				goto bad;
 			m->m_len = src->siso_len;
 			src = mtod(m, struct sockaddr_iso *);
-			bcopy((caddr_t)srcsa, (caddr_t)src, srcsa->sa_len);
+			memcpy((caddr_t)src, (caddr_t)srcsa, srcsa->sa_len);
 		}
-		bcopy((caddr_t)up + 2, TSEL(src), up[1]);
+		memcpy(TSEL(src), (caddr_t)up + 2, up[1]);
 		up += 2 + src->siso_tlen;
 		continue;
 	
@@ -131,7 +131,7 @@ cltp_input(m0, srcsa, dstsa, cons_channel, output)
 			goto bad;
 		}
 		if (isop->isop_laddr &&
-		    bcmp(TSEL(isop->isop_laddr), dtsap, dlen) == 0)
+		    memcmp(TSEL(isop->isop_laddr), dtsap, dlen) == 0)
 			break;
 	}
 	m = m0;
@@ -228,12 +228,12 @@ cltp_output(isop, m)
 	up[2] = CLTPOVAL_SRC;
 	up[3] = (siso = isop->isop_laddr)->siso_tlen;
 	up += 4;
-	bcopy(TSEL(siso), (caddr_t)up, siso->siso_tlen);
+	memcpy((caddr_t)up, TSEL(siso), siso->siso_tlen);
 	up += siso->siso_tlen;
 	up[0] = CLTPOVAL_DST;
 	up[1] = (siso = isop->isop_faddr)->siso_tlen;
 	up += 2;
-	bcopy(TSEL(siso), (caddr_t)up, siso->siso_tlen);
+	memcpy((caddr_t)up, TSEL(siso), siso->siso_tlen);
 	/*
 	 * Stuff checksum and output datagram.
 	 */
@@ -366,13 +366,13 @@ cltp_usrreq(so, req, m, nam, control)
 
 	case PRU_SOCKADDR:
 		if (isop->isop_laddr)
-			bcopy((caddr_t)isop->isop_laddr, mtod(m, caddr_t),
+			memcpy(mtod(m, (caddr_t)isop->isop_laddr, caddr_t),
 				nam->m_len = isop->isop_laddr->siso_len);
 		break;
 
 	case PRU_PEERADDR:
 		if (isop->isop_faddr)
-			bcopy((caddr_t)isop->isop_faddr, mtod(m, caddr_t),
+			memcpy(mtod(m, (caddr_t)isop->isop_faddr, caddr_t),
 				nam->m_len = isop->isop_faddr->siso_len);
 		break;
 

--- a/server/netiso/esis.c
+++ b/server/netiso/esis.c
@@ -188,7 +188,7 @@ struct mbuf		*control;	/* optional control */
 		}
 		MALLOC(rp, struct rawcb *, sizeof(*rp), M_PCB, M_WAITOK);
 		if (so->so_pcb = (caddr_t)rp) {
-			bzero(so->so_pcb, sizeof(*rp));
+			memset(so->so_pcb, 0, sizeof(*rp));
 			insque(rp, &esis_pcb);
 			rp->rcb_socket = so;
 			error = soreserve(so, esis_sendspace, esis_recvspace);
@@ -344,7 +344,7 @@ struct rtentry		*rt;			/* snpa cache info regarding next hop of
 		esis_stat.es_nomem++;
 		return;
 	}
-	bzero(mtod(m, caddr_t), MHLEN);
+	memset(mtod(m, 0, caddr_t), MHLEN);
 
 	pdu = mtod(m, struct esis_fixed *);
 	cp = (caddr_t)(pdu + 1); /*pointer arith.; 1st byte after header */
@@ -363,7 +363,7 @@ struct rtentry		*rt;			/* snpa cache info regarding next hop of
 
 	/* Insert the snpa of better next hop */
 	*cp++ = sdl->sdl_alen;
-	bcopy(LLADDR(sdl), cp, sdl->sdl_alen);
+	memcpy(cp, LLADDR(sdl), sdl->sdl_alen);
 	cp += sdl->sdl_alen;
 	len += (sdl->sdl_alen + 1);
 
@@ -417,18 +417,15 @@ struct rtentry		*rt;			/* snpa cache info regarding next hop of
 		 *	the option code and length
 		 */
 		if (inbound_oidx->cni_qos_formatp) {
-			bcopy(mtod(inbound_m, caddr_t) + inbound_oidx->cni_qos_formatp - 2,
-				cp, (unsigned)(inbound_oidx->cni_qos_len + 2));
+			memcpy(caddr_t) + inbound_oidx->cni_qos_formatp - 2, mtod(inbound_m, cp, (unsigned)(inbound_oidx->cni_qos_len + 2));
 			cp += inbound_oidx->cni_qos_len + 2;
 		}
 		if (inbound_oidx->cni_priorp) {
-			bcopy(mtod(inbound_m, caddr_t) + inbound_oidx->cni_priorp - 2,
-					cp, 3);
+			memcpy(caddr_t) + inbound_oidx->cni_priorp - 2, mtod(inbound_m, cp, 3);
 			cp += 3;
 		}
 		if (inbound_oidx->cni_securep) {
-			bcopy(mtod(inbound_m, caddr_t) + inbound_oidx->cni_securep - 2, cp, 
-				(unsigned)(inbound_oidx->cni_secure_len + 2));
+			memcpy(caddr_t) + inbound_oidx->cni_securep - 2, cp, mtod(inbound_m, (unsigned)(inbound_oidx->cni_secure_len + 2));
 			cp += inbound_oidx->cni_secure_len + 2;
 		}
 		m->m_len += optlen;
@@ -438,12 +435,12 @@ struct rtentry		*rt;			/* snpa cache info regarding next hop of
 	pdu->esis_hdr_len = m0->m_pkthdr.len = len;
 	iso_gen_csum(m0, ESIS_CKSUM_OFF, (int)pdu->esis_hdr_len);
 
-	bzero((caddr_t)&siso, sizeof(siso));
+	memset((caddr_t)&siso, 0, sizeof(siso));
 	siso.siso_family = AF_ISO;
 	siso.siso_data[0] = AFI_SNA;
 	siso.siso_nlen = 6 + 1;	/* should be taken from snpa_hdr */
 										/* +1 is for AFI */
-	bcopy(inbound_shp->snh_shost, siso.siso_data + 1, 6);
+	memcpy(siso.siso_data + 1, inbound_shp->snh_shost, 6);
 	(ifp->if_output)(ifp, m0, (struct sockaddr *)&siso, 0);
 }
 
@@ -470,7 +467,7 @@ int							nsellen;
 	isoa->isoa_len -= nsellen;
 	newlen = isoa->isoa_len + 1;
 	if (newlen <=  M_TRAILINGSPACE(m)) {
-		bcopy((caddr_t)isoa, *buf, newlen);
+		memcpy(*buf, (caddr_t)isoa, newlen);
 		*len += newlen;
 		*buf += newlen;
 		m->m_len += newlen;
@@ -833,7 +830,7 @@ struct	iso_addr *isoa;
 		esis_stat.es_nomem++;
 		return;
 	}
-	bzero(mtod(m, caddr_t), MHLEN);
+	memset(mtod(m, 0, caddr_t), MHLEN);
 
 	pdu = mtod(m, struct esis_fixed *);
 	naddrp = cp = (caddr_t)(pdu + 1);
@@ -917,11 +914,11 @@ struct	iso_addr *isoa;
 	pdu->esis_hdr_len = len;
 	iso_gen_csum(m0, ESIS_CKSUM_OFF, (int)pdu->esis_hdr_len);
 
-	bzero((caddr_t)&siso, sizeof(siso));
+	memset((caddr_t)&siso, 0, sizeof(siso));
 	siso.siso_family = AF_ISO;
 	siso.siso_data[0] = AFI_SNA;
 	siso.siso_nlen = sn_len + 1;
-	bcopy(sn_addr, siso.siso_data + 1, (unsigned)sn_len);
+	memcpy(siso.siso_data + 1, sn_addr, (unsigned)sn_len);
 	(ifp->if_output)(ifp, m0, (struct sockaddr *)&siso, 0);
 }
 
@@ -960,7 +957,7 @@ struct snpa_hdr	*shp;	/* subnetwork header */
 	ENDDEBUG
 	esis_dl.sdl_alen = ifp->if_addrlen;
 	esis_dl.sdl_index = ifp->if_index;
-	bcopy(shp->snh_shost, (caddr_t)esis_dl.sdl_data, esis_dl.sdl_alen);
+	memcpy((caddr_t)esis_dl.sdl_data, shp->snh_shost, esis_dl.sdl_alen);
 	for (rp = esis_pcb.rcb_next; rp != &esis_pcb; rp = rp->rcb_next) {
 		if (first_rp == 0) {
 			first_rp = rp;
@@ -1016,11 +1013,11 @@ struct mbuf *m;
 		}
 		printf("\n");
 	ENDDEBUG
-	bzero((caddr_t)&siso, sizeof(siso));
+	memset((caddr_t)&siso, 0, sizeof(siso));
 	siso.siso_family = AF_ISO; /* This convention may be useful for X.25 */
 	siso.siso_data[0] = AFI_SNA;
 	siso.siso_nlen = sn_len + 1;
-	bcopy(LLADDR(sdl), siso.siso_data + 1, sn_len);
+	memcpy(siso.siso_data + 1, LLADDR(sdl), sn_len);
 	error = (ifp->if_output)(ifp, m, (struct sockaddr *)&siso, 0);
 	if (error) {
 		IFDEBUG(D_ISISOUTPUT)

--- a/server/netiso/idrp_usrreq.c
+++ b/server/netiso/idrp_usrreq.c
@@ -89,12 +89,10 @@ idrp_input(m, src, dst)
 	bad:	m_freem(m);
 		return 0;
 	}
-	bzero(idrp_addrs[0].siso_data, sizeof(idrp_addrs[0].siso_data));
-	bcopy((caddr_t)&(src->siso_addr), (caddr_t)&idrp_addrs[0].siso_addr,
-		1 + src->siso_nlen);
-	bzero(idrp_addrs[1].siso_data, sizeof(idrp_addrs[1].siso_data));
-	bcopy((caddr_t)&(dst->siso_addr), (caddr_t)&idrp_addrs[1].siso_addr,
-		1 + dst->siso_nlen);
+	memset(idrp_addrs[0].siso_data, 0, sizeof(idrp_addrs[0].siso_data));
+	memcpy((caddr_t)&idrp_addrs[0].siso_addr, (caddr_t)&(src->siso_addr), 1 + src->siso_nlen);
+	memset(idrp_addrs[1].siso_data, 0, sizeof(idrp_addrs[1].siso_data));
+	memcpy((caddr_t)&idrp_addrs[1].siso_addr, (caddr_t)&(dst->siso_addr), 1 + dst->siso_nlen);
 	if (sbappendaddr(&idrp_isop.isop_socket->so_rcv,
 		(struct sockaddr *)idrp_addrs, m, (struct mbuf *)0) == 0)
 		goto bad;
@@ -108,11 +106,9 @@ idrp_output(m, addr)
 	register struct sockaddr_iso *siso = mtod(addr, struct sockaddr_iso *);
 	int s = splnet(), i;
 
-	bcopy((caddr_t)&(siso->siso_addr),
-	      (caddr_t)&idrp_isop.isop_sfaddr.siso_addr, 1 + siso->siso_nlen);
+	memcpy((caddr_t)&idrp_isop.isop_sfaddr.siso_addr, (caddr_t)&(siso->siso_addr), 1 + siso->siso_nlen);
 	siso++;
-	bcopy((caddr_t)&(siso->siso_addr),
-	      (caddr_t)&idrp_isop.isop_sladdr.siso_addr, 1 + siso->siso_nlen);
+	memcpy((caddr_t)&idrp_isop.isop_sladdr.siso_addr, (caddr_t)&(siso->siso_addr), 1 + siso->siso_nlen);
 	i = clnp_output(m, idrp_isop, m->m_pkthdr.len, 0);
 	splx(s);
 	return (i);

--- a/server/netiso/if_cons.c
+++ b/server/netiso/if_cons.c
@@ -573,8 +573,7 @@ make_partial_x25_packet(isop, lcp)
 			/*
 			 *	The user specified something. Stick it in
 			 */
-			bcopy(isop->isop_x25crud, lcp->lcd_faddr.x25_udata,
-					isop->isop_x25crud_len);
+			memcpy(lcp->lcd_faddr.x25_udata, isop->isop_x25crud, isop->isop_x25crud_len);
 			lcp->lcd_faddr.x25_udlen = isop->isop_x25crud_len;
 		}
 	}
@@ -608,7 +607,7 @@ make_partial_x25_packet(isop, lcp)
 				 * high two bits of which indicate full/partial NSAP
 				 */
 		len = isop->isop_laddr->siso_addr.isoa_len;
-		bcopy( isop->isop_laddr->siso_data, ptr, len);
+		memcpy(ptr, isop->isop_laddr->siso_data, len);
 		*(ptr-2) = len+1; /* facil param len in octets */
 		*(ptr-1) = len<<1; /* facil param len in nibbles */
 		ptr += len;
@@ -624,7 +623,7 @@ make_partial_x25_packet(isop, lcp)
 				 * high two bits of which indicate full/partial NSAP
 				 */
 		len = isop->isop_faddr->siso_nlen;
-		bcopy(isop->isop_faddr->siso_data, ptr, len);
+		memcpy(ptr, isop->isop_faddr->siso_data, len);
 		*(ptr-2) = len+1; /* facil param len = addr len + 1 for each of these
 						  * two length fields, in octets */
 		*(ptr-1) = len<<1; /* facil param len in nibbles */
@@ -722,8 +721,7 @@ NSAPtoDTE(siso, sx25)
 		struct sockaddr_iso nsiso;
 
 		nsiso = blank_siso;
-		bcopy(nsiso.siso_data, siso->siso_data,
-				nsiso.siso_nlen = siso->siso_nlen);
+		memcpy(siso->siso_data, nsiso.siso_data, nsiso.siso_nlen = siso->siso_nlen);
 		if (rt = rtalloc1(&nsiso, 1)) {
 			register struct sockaddr_x25 *sxx =
 							(struct sockaddr_x25 *)rt->rt_gateway;
@@ -731,7 +729,7 @@ NSAPtoDTE(siso, sx25)
 
 			rt->rt_use--;
 			if (sxx && sxx->x25_family == AF_CCITT) {
-				bcopy(sx25->x25_addr, sxx->x25_addr, sizeof(sx25->x25_addr));
+				memcpy(sxx->x25_addr, sx25->x25_addr, sizeof(sx25->x25_addr));
 				while (*in++) {}
 				dtelen = in - sxx->x25_addr;
 			}
@@ -771,14 +769,14 @@ FACILtoNSAP(addr, buf)
 	switch (*buf++ & 0xc0) {
 	case 0:
 		/* Entire OSI NSAP address */
-		bcopy((caddr_t)buf, addr->siso_data, addr->siso_nlen = buf_len);
+		memcpy(addr->siso_data, (caddr_t)buf, addr->siso_nlen = buf_len);
 		break;
 
 	case 40:
 		/* Partial OSI NSAP address, assume trailing */
 		if (buf_len + addr->siso_nlen > sizeof(addr->siso_addr))
 			return -1;
-		bcopy((caddr_t)buf, TSEL(addr), buf_len);
+		memcpy(TSEL(addr), (caddr_t)buf, buf_len);
 		addr->siso_nlen += buf_len;
 		break;
 

--- a/server/netiso/if_eon.c
+++ b/server/netiso/if_eon.c
@@ -219,12 +219,12 @@ caddr_t loc;
 	struct mbuf mhead;
 	register struct sockaddr_in *sin = (struct sockaddr_in *)&ro->ro_dst;
 	if (zero) {
-		bzero((caddr_t)hdr, sizeof (*hdr));
-		bzero((caddr_t)ro, sizeof (*ro));
+		memset((caddr_t)hdr, 0, sizeof (*hdr));
+		memset((caddr_t)ro, 0, sizeof (*ro));
 	}
 	sin->sin_family = AF_INET;
 	sin->sin_len = sizeof (*sin);
-	bcopy(loc, (caddr_t)&sin->sin_addr, sizeof(struct in_addr));
+	memcpy((caddr_t)&sin->sin_addr, loc, sizeof(struct in_addr));
 	/*
 	 * If there is a cached route,
 	 * check that it is to the same destination
@@ -413,8 +413,7 @@ einval:
 	ro = &el->el_iproute;
 	if (el->el_snpaoffset) {
 		if (dst->siso_family == AF_ISO) {
-			bcopy((caddr_t) &dst->siso_data[el->el_snpaoffset],
-					(caddr_t) &ei->ei_ip.ip_dst, sizeof(ei->ei_ip.ip_dst));
+			memcpy((caddr_t) &ei->ei_ip.ip_dst, (caddr_t) &dst->siso_data[el->el_snpaoffset], sizeof(ei->ei_ip.ip_dst));
 		} else
 			goto einval;
 	}

--- a/server/netiso/iso.c
+++ b/server/netiso/iso.c
@@ -159,7 +159,7 @@ register struct iso_addr *isoaa, *isoab;		/* addresses to check */
 		printf("addrs are equal\n");
 		return (1);
 	ENDDEBUG
-	return (!bcmp(isoaa->isoa_genaddr, isoab->isoa_genaddr, compare_len));
+	return (!memcmp(isoaa->isoa_genaddr, isoab->isoa_genaddr, compare_len));
 }
 
 /*
@@ -209,7 +209,7 @@ struct sockaddr_iso *sisoa, *sisob;
 		dump_buf(bufb, lenb);
 	ENDDEBUG
 
-	return ((lena == lenb) && (!bcmp(bufa, bufb, lena)));
+	return ((lena == lenb) && (!memcmp(bufa, bufb, lena)));
 }
 #endif /* notdef */
 
@@ -285,7 +285,7 @@ struct afhash		*hp;		/* RETURN: hash info here */
 	register int	bufsize;
 
 
-	bzero(buf, sizeof(buf));
+	memset(buf, 0, sizeof(buf));
 
 	bufsize = iso_netof(&siso->siso_addr, buf);
 	hp->afh_nethash = iso_hashchar((caddr_t)buf, bufsize);
@@ -365,7 +365,7 @@ caddr_t			buf;		/* RESULT: network portion of address here */
 				len += ADDRRFC986_IDI_LEN + 1;
 
 				/* get inet addr long aligned */
-				bcopy(o986->o986_inetaddr, &inetaddr, sizeof(inetaddr));
+				memcpy(&inetaddr, o986->o986_inetaddr, sizeof(inetaddr));
 				inetaddr = ntohl(inetaddr);	/* convert to host byte order */
 
 				IFDEBUG(D_ROUTE)
@@ -399,7 +399,7 @@ caddr_t			buf;		/* RESULT: network portion of address here */
 			len = 0;
 	}
 
-	bcopy((caddr_t)isoa, buf, len);
+	memcpy(buf, (caddr_t)isoa, len);
 	IFDEBUG(D_ROUTE)
 		printf("iso_netof: isoa ");
 		dump_buf(isoa, len);
@@ -462,7 +462,7 @@ iso_control(so, cmd, data, ifp)
 				       M_IFADDR, M_WAITOK);
 			if (nia == (struct iso_ifaddr *)0)
 				return (ENOBUFS);
-			bzero((caddr_t)nia, sizeof(*nia));
+			memset((caddr_t)nia, 0, sizeof(*nia));
 			if (ia = iso_ifaddr) {
 				for ( ; ia->ia_next; ia = ia->ia_next)
 					;
@@ -755,7 +755,7 @@ struct iso_addr	*isoab;		/* other addr to check */
 		if (isoaa->isoa_afi == AFI_37)
 			return(1);
 		else 
-			return (!bcmp(&isoaa->isoa_u, &isoab->isoa_u, 2));
+			return (!memcmp(&isoaa->isoa_u, &isoab->isoa_u, 2));
 	}
 	return(0);
 }
@@ -873,7 +873,7 @@ struct mbuf	*m;			/* data for set, buffer for get */
 				printf("iso_nlctloutput: setting x25 crud\n");
 			ENDDEBUG
 
-			bcopy(data, (caddr_t)isop->isop_x25crud, (unsigned)data_len);
+			memcpy((caddr_t)isop->isop_x25crud, data, (unsigned)data_len);
 			isop->isop_x25crud_len = data_len;
 			break;
 #endif	/* TPCONS */

--- a/server/netiso/iso_chksum.c
+++ b/server/netiso/iso_chksum.c
@@ -333,7 +333,7 @@ m_compress(in, out)
 			IFDEBUG(D_REQUEST)
 				printf("m_compress copying len %d\n", len);
 			ENDDEBUG
-			bcopy(mtod(in, caddr_t), mtod((*out), caddr_t) + (*out)->m_len,
+			memcpy(caddr_t), mtod(in, mtod((*out), caddr_t) + (*out)->m_len,
 						(unsigned)len);
 
 			(*out)->m_len += len;

--- a/server/netiso/iso_pcb.c
+++ b/server/netiso/iso_pcb.c
@@ -127,7 +127,7 @@ iso_pcballoc(so, head)
 	MALLOC(isop, struct isopcb *, sizeof(*isop), M_PCB, M_NOWAIT);
 	if (isop == NULL)
 		return ENOBUFS;
-	bzero((caddr_t)isop, sizeof(*isop));
+	memset((caddr_t)isop, 0, sizeof(*isop));
 	isop->isop_head = head;
 	isop->isop_socket = so;
 	insque(isop, head);
@@ -220,14 +220,14 @@ iso_pcbbind(isop, nam)
 			return ENOBUFS;
 		isop->isop_laddr = mtod(nam, struct sockaddr_iso *);
 	}
-	bcopy((caddr_t)siso, (caddr_t)isop->isop_laddr, siso->siso_len);
+	memcpy((caddr_t)isop->isop_laddr, (caddr_t)siso, siso->siso_len);
 	if (siso->siso_tlen == 0)
 		goto noname;
 	if ((isop->isop_socket->so_options & SO_REUSEADDR) == 0 &&
 		iso_pcblookup(head, 0, (caddr_t)0, isop->isop_laddr))
 		return EADDRINUSE;
 	if (siso->siso_tlen <= 2) {
-		bcopy(TSEL(siso), suf.data, sizeof(suf.data));
+		memcpy(suf.data, TSEL(siso), sizeof(suf.data));
 		suf.s = ntohs(suf.s);
 		if((suf.s < ISO_PORT_RESERVED) &&
 		   (isop->isop_socket->so_state && SS_PRIV) == 0)
@@ -298,8 +298,7 @@ iso_pcbconnect(isop, nam)
 			int nlen = ia->ia_addr.siso_nlen;
 			ovbcopy(TSEL(siso), nlen + TSEL(siso),
 				siso->siso_plen + siso->siso_tlen + siso->siso_slen);
-			bcopy((caddr_t)&ia->ia_addr.siso_addr,
-				  (caddr_t)&siso->siso_addr, nlen + 1);
+			memcpy((caddr_t)&siso->siso_addr, (caddr_t)&ia->ia_addr.siso_addr, nlen + 1);
 			/* includes siso->siso_nlen = nlen; */
 		} else
 			return EADDRNOTAVAIL;
@@ -361,7 +360,7 @@ iso_pcbconnect(isop, nam)
 		siso->siso_nlen = ia->ia_addr.siso_nlen;
 		newtsel = TSEL(siso);
 		ovbcopy(oldtsel, newtsel, tlen);
-		bcopy(ia->ia_addr.siso_data, siso->siso_data, nlen);
+		memcpy(siso->siso_data, ia->ia_addr.siso_data, nlen);
 		siso->siso_tlen = tlen;
 		siso->siso_family = AF_ISO;
 		siso->siso_len = totlen;
@@ -389,7 +388,7 @@ iso_pcbconnect(isop, nam)
 			isop->isop_faddr = mtod(m, struct sockaddr_iso *);
 		}
 	}
-	bcopy((caddr_t)siso, (caddr_t)isop->isop_faddr, siso->siso_len);
+	memcpy((caddr_t)isop->isop_faddr, (caddr_t)siso, siso->siso_len);
 	IFDEBUG(D_ISO)
 		printf("in iso_pcbconnect after bcopy isop 0x%x isop->sock 0x%x\n", 
 			isop, isop->isop_socket);
@@ -603,10 +602,10 @@ iso_pcblookup(head, fportlen, fport, laddr)
 			continue;
 		if (isop->isop_laddr->siso_tlen != llen)
 			continue;
-		if (bcmp(lp, TSEL(isop->isop_laddr), llen))
+		if (memcmp(lp, TSEL(isop->isop_laddr), llen))
 			continue;
 		if (fportlen && isop->isop_faddr &&
-			bcmp(fport, TSEL(isop->isop_faddr), (unsigned)fportlen))
+			memcmp(fport, TSEL(isop->isop_faddr), (unsigned)fportlen))
 			continue;
 		/*	PHASE2
 		 *	addrmatch1 should be iso_addrmatch(a, b, mask)

--- a/server/netiso/iso_snpac.c
+++ b/server/netiso/iso_snpac.c
@@ -114,7 +114,7 @@ static struct sockaddr_iso
 static struct sockaddr_dl blank_dl = {sizeof(blank_dl), AF_LINK};
 static struct sockaddr_dl gte_dl;
 #define zap_linkaddr(a, b, c, i) \
-	(*a = blank_dl, bcopy(b, a->sdl_data, a->sdl_alen = c), a->sdl_index = i)
+	(*a = blank_dl, memcpy(a->sdl_data, b, a->sdl_alen = c), a->sdl_index = i)
 
 /*
  *	We only keep track of a single IS at a time.
@@ -208,8 +208,7 @@ struct sockaddr *sa;
 		insque(lc, &llinfo_llc);
 		if (gate->sdl.sdl_alen == sizeof(struct esis_req) + addrlen) {
 			gate->sdl.sdl_alen -= sizeof(struct esis_req);
-			bcopy(addrlen + LLADDR(&gate->sdl),
-				  (caddr_t)&lc->lc_er, sizeof(lc->lc_er));
+			memcpy((caddr_t)&lc->lc_er, addrlen + LLADDR(&gate->sdl), sizeof(lc->lc_er));
 		} else if (gate->sdl.sdl_alen == addrlen)
 			lc->lc_flags = (SNPA_ES | SNPA_VALID | SNPA_PERM);
 		break;
@@ -245,9 +244,9 @@ iso_setmcasts(ifp, req)
 	register caddr_t *cpp;
 	int		doreset = 0;
 
-	bzero((caddr_t)&ifr, sizeof(ifr));
+	memset((caddr_t)&ifr, 0, sizeof(ifr));
 	for (cpp = (caddr_t *)addrlist; *cpp; cpp++) {
-		bcopy(*cpp, (caddr_t)ifr.ifr_addr.sa_data, 6);
+		memcpy((caddr_t)ifr.ifr_addr.sa_data, *cpp, 6);
 		if (req == RTM_ADD)
 			if (ether_addmulti(&ifr, (struct arpcom *)ifp) == ENETRESET)
 				doreset++;
@@ -332,7 +331,7 @@ int		*snpa_len;			/* RESULT: length of snpa */
 		found_snpa = (caddr_t)all_es_snpa;
 	} else
 		return (ENETUNREACH);
-	bcopy(found_snpa, snpa, *snpa_len = addrlen);
+	memcpy(snpa, found_snpa, *snpa_len = addrlen);
 	return (0);
 }
 
@@ -627,9 +626,9 @@ caddr_t	snpa;
 u_int	len;
 {
 	return (((iso_systype & SNPA_ES) &&
-			 (!bcmp(snpa, (caddr_t)all_es_snpa, len))) ||
+			 (!memcmp(snpa, (caddr_t)all_es_snpa, len))) ||
 			((iso_systype & SNPA_IS) &&
-			 (!bcmp(snpa, (caddr_t)all_is_snpa, len))));
+			 (!memcmp(snpa, (caddr_t)all_is_snpa, len))));
 }
 
 /*

--- a/server/netiso/tp_emit.c
+++ b/server/netiso/tp_emit.c
@@ -211,7 +211,7 @@ tp_emit(dutype,	tpcb, seq, eot, data)
 	m->m_act = MNULL;
 
 	hdr = mtod(m, struct tpdu *);
-	bzero((caddr_t)hdr, sizeof(struct tpdu));
+	memset((caddr_t)hdr, 0, sizeof(struct tpdu));
 
 	{
 		int 	tp_headersize();
@@ -604,9 +604,9 @@ tp_emit(dutype,	tpcb, seq, eot, data)
 				subseq = htons(tpcb->tp_r_subseq);
 				fcredit = htons(tpcb->tp_fcredit);
 
-				bcopy((caddr_t) &lwe, (caddr_t)&bogus[0], sizeof(SeqNum));
-				bcopy((caddr_t) &subseq, (caddr_t)&bogus[2], sizeof(u_short));
-				bcopy((caddr_t) &fcredit, (caddr_t)&bogus[3], sizeof(u_short));
+				memcpy((caddr_t)&bogus[0], (caddr_t) &lwe, sizeof(SeqNum));
+				memcpy((caddr_t)&bogus[2], (caddr_t) &subseq, sizeof(u_short));
+				memcpy((caddr_t)&bogus[3], (caddr_t) &fcredit, sizeof(u_short));
 
 				IFTRACE(D_ACKSEND)
 					tptraceTPCB(TPPTmisc, 

--- a/server/netiso/tp_inet.c
+++ b/server/netiso/tp_inet.c
@@ -171,7 +171,7 @@ in_putsufx(inp, sufxloc, sufxlen, which)
 	int which;
 {
 	if (which == TP_FOREIGN) {
-		bcopy(sufxloc, (caddr_t)&inp->inp_fport, sizeof(inp->inp_fport));
+		memcpy((caddr_t)&inp->inp_fport, sufxloc, sizeof(inp->inp_fport));
 	}
 }
 
@@ -226,15 +226,13 @@ in_putnetaddr(inp, name, which)
 {
 	switch (which) {
 	case TP_LOCAL:
-		bcopy((caddr_t)&name->sin_addr, 
-			(caddr_t)&inp->inp_laddr, sizeof(struct in_addr));
+		memcpy((caddr_t)&inp->inp_laddr, (caddr_t)&name->sin_addr, sizeof(struct in_addr));
 			/* won't work if the dst address (name) is INADDR_ANY */
 
 		break;
 	case TP_FOREIGN:
 		if( name != (struct sockaddr_in *)0 ) {
-			bcopy((caddr_t)&name->sin_addr, 
-				(caddr_t)&inp->inp_faddr, sizeof(struct in_addr));
+			memcpy((caddr_t)&inp->inp_faddr, (caddr_t)&name->sin_addr, sizeof(struct in_addr));
 		}
 	}
 }
@@ -296,7 +294,7 @@ in_getnetaddr( inp, name, which)
 	int which;
 {
 	register struct sockaddr_in *sin = mtod(name, struct sockaddr_in *);
-	bzero((caddr_t)sin, sizeof(*sin));
+	memset((caddr_t)sin, 0, sizeof(*sin));
 	switch (which) {
 	case TP_LOCAL:
 		sin->sin_addr = inp->inp_laddr;
@@ -422,7 +420,7 @@ tpip_output_dg(laddr, faddr, m0, datalen, ro, nochksum)
 	m->m_len = sizeof(struct ip);
 
 	ip = mtod(m, struct ip *);
-	bzero((caddr_t)ip, sizeof *ip);
+	memset((caddr_t)ip, 0, sizeof *ip);
 
 	ip->ip_p = IPPROTO_TP;
 	m->m_pkthdr.len = ip->ip_len = sizeof(struct ip) + datalen;

--- a/server/netiso/tp_input.c
+++ b/server/netiso/tp_input.c
@@ -158,7 +158,7 @@ tp_inputprep(m)
 		caddr_t ocp = m->m_data;
 
 		m->m_data = (caddr_t)(((int)m->m_data) & ~0x3);
-		bcopy(ocp, m->m_data, (unsigned)m->m_len);
+		memcpy(m->m_data, ocp, (unsigned)m->m_len);
 	}
 	CHANGE_MTYPE(m, TPMT_DATA);
 
@@ -312,7 +312,7 @@ tp_newsocket(so, fname, cons_channel, class_to_use, netservice)
 	newtpcb->tp_lcredit = tpcb->tp_lcredit;
 	newtpcb->tp_l_tpdusize = tpcb->tp_l_tpdusize;
 	newtpcb->tp_lsuffixlen = tpcb->tp_lsuffixlen;
-	bcopy( tpcb->tp_lsuffix, newtpcb->tp_lsuffix, newtpcb->tp_lsuffixlen);
+	memcpy(newtpcb->tp_lsuffix, tpcb->tp_lsuffix, newtpcb->tp_lsuffixlen);
 
 	if( /* old */ tpcb->tp_ucddata) {
 		/* 
@@ -349,7 +349,7 @@ tp_newsocket(so, fname, cons_channel, class_to_use, netservice)
 			 * pcb_connect, which expects the name/addr in an mbuf as well.
 			 * sigh.
 			 */
-			bcopy((caddr_t)fname, mtod(m, caddr_t), fname->sa_len);
+			memcpy(mtod(m, (caddr_t)fname, caddr_t), fname->sa_len);
 			m->m_len = fname->sa_len;
 
 			/* grot  : have to say the kernel can override params in
@@ -698,7 +698,7 @@ again:
 			for (t = tp_listeners; t ; t = t->tp_nextlisten)
 				if ((t->tp_lsuffixlen == 0 ||
 					 (lsufxlen == t->tp_lsuffixlen &&
-					  bcmp(lsufxloc, t->tp_lsuffix, lsufxlen) == 0)) &&
+					  memcmp(lsufxloc, t->tp_lsuffix, lsufxlen) == 0)) &&
 					((t->tp_flags & TPF_GENERAL_ADDR) ||
 					 (laddr->sa_family == t->tp_domain &&
 					  (*t->tp_nlproto->nlp_cmpnetaddr)
@@ -839,13 +839,13 @@ again:
 
 			/* stash the f suffix in the new tpcb */
 			if (tpcb->tp_fsuffixlen = fsufxlen) {
-				bcopy(fsufxloc, tpcb->tp_fsuffix, fsufxlen);
+				memcpy(tpcb->tp_fsuffix, fsufxloc, fsufxlen);
 				(tpcb->tp_nlproto->nlp_putsufx)
 						(tpcb->tp_npcb, fsufxloc, fsufxlen, TP_FOREIGN);
 			}
 			/* stash the l suffix in the new tpcb */
 			tpcb->tp_lsuffixlen = lsufxlen;
-			bcopy(lsufxloc, tpcb->tp_lsuffix, lsufxlen);
+			memcpy(tpcb->tp_lsuffix, lsufxloc, lsufxlen);
 			(tpcb->tp_nlproto->nlp_putsufx)
 					(tpcb->tp_npcb, lsufxloc, lsufxlen, TP_LOCAL);
 #ifdef TP_PERF_MEAS
@@ -1187,13 +1187,13 @@ again:
 			 */
 			if( fsufxlen ) {
 				CHECK( ((tpcb->tp_fsuffixlen != fsufxlen) ||
-					bcmp(fsufxloc, tpcb->tp_fsuffix, fsufxlen)),
+					memcmp(fsufxloc, tpcb->tp_fsuffix, fsufxlen)),
 					E_TP_INV_PVAL,ts_inv_sufx, respond, 
 					(1+fsufxloc - (caddr_t)hdr))
 			}
 			if( lsufxlen ) {
 				CHECK( ((tpcb->tp_lsuffixlen != lsufxlen) ||
-					bcmp(lsufxloc, tpcb->tp_lsuffix, lsufxlen)),
+					memcmp(lsufxloc, tpcb->tp_lsuffix, lsufxlen)),
 					E_TP_INV_PVAL,ts_inv_sufx, respond, 
 					(1+lsufxloc - (caddr_t)hdr))
 			}
@@ -1421,9 +1421,9 @@ again:
 				{m_freem(m); m = 0; datalen = 0; goto invoke; }
 			if (hdr->tpdu_type == DR_TPDU_type) {
 				datalen += sizeof(x) - sizeof(c_hdr);
-				bcopy((caddr_t)&x, mtod(n, caddr_t), n->m_len = sizeof(x));
+				memcpy(mtod(n, (caddr_t)&x, caddr_t), n->m_len = sizeof(x));
 			} else
-				bcopy((caddr_t)&c_hdr, mtod(n, caddr_t),
+				memcpy(mtod(n, (caddr_t)&c_hdr, caddr_t),
 					  n->m_len = sizeof(c_hdr));
 			n->m_next = m;
 			m = n;

--- a/server/netiso/tp_iso.c
+++ b/server/netiso/tp_iso.c
@@ -136,7 +136,7 @@ iso_getsufx(isop, lenp, data_out, which)
 		addr = isop->isop_faddr;
 	}
 	if (addr)
-		bcopy(TSEL(addr), data_out, (*lenp = addr->siso_tlen));
+		memcpy(data_out, TSEL(addr), (*lenp = addr->siso_tlen));
 }
 
 /* CALLED FROM:
@@ -190,7 +190,7 @@ iso_putsufx(isop, sufxloc, sufxlen, which)
 				m->m_len = len;
 		}
 	}
-	bcopy(sufxloc, TSEL(addr), sufxlen);
+	memcpy(TSEL(addr), sufxloc, sufxlen);
 	addr->siso_tlen = sufxlen;
 	addr->siso_len = len;
 }
@@ -287,9 +287,9 @@ iso_cmpnetaddr(isop, name, which)
 		printf("ISO_CMPNETADDR\n");
 		dump_isoaddr(siso);
 	ENDDEBUG
-	if (name->siso_tlen && bcmp(TSEL(name), TSEL(siso), name->siso_tlen))
+	if (name->siso_tlen && memcmp(TSEL(name), TSEL(siso), name->siso_tlen))
 		return (0);
-	return (bcmp((caddr_t)name->siso_data,
+	return (memcmp((caddr_t)name->siso_data,
 			 (caddr_t)siso->siso_data, name->siso_nlen) == 0);
 }
 
@@ -311,7 +311,7 @@ iso_getnetaddr( isop, name, which)
 	struct sockaddr_iso *siso =
 		(which == TP_LOCAL ? isop->isop_laddr : isop->isop_faddr);
 	if (siso)
-		bcopy((caddr_t)siso, mtod(name, caddr_t),
+		memcpy(mtod(name, (caddr_t)siso, caddr_t),
 				(unsigned)(name->m_len = siso->siso_len));
 	else
 		name->m_len = 0;
@@ -424,7 +424,7 @@ tpclnp_output_dg(laddr, faddr, m0, datalen, ro, nochksum)
 	 *	Fill in minimal portion of isopcb so that clnp can send the
 	 *	packet.
 	 */
-	bzero((caddr_t)&tmppcb, sizeof(tmppcb));
+	memset((caddr_t)&tmppcb, 0, sizeof(tmppcb));
 	tmppcb.isop_laddr = &tmppcb.isop_sladdr;
 	tmppcb.isop_laddr->siso_addr = *laddr;
 	tmppcb.isop_faddr = &tmppcb.isop_sfaddr;
@@ -653,8 +653,8 @@ tpclnp_ctlinput1(cmd, isoa)
 	int cmd;
 	struct iso_addr *isoa;
 {
-	bzero((caddr_t)&siso.siso_addr, sizeof(siso.siso_addr));
-	bcopy((caddr_t)isoa, (caddr_t)&siso.siso_addr, isoa->isoa_len);
+	memset((caddr_t)&siso.siso_addr, 0, sizeof(siso.siso_addr));
+	memcpy((caddr_t)&siso.siso_addr, (caddr_t)isoa, isoa->isoa_len);
 	tpclnp_ctlinput(cmd, &siso);
 }
 

--- a/server/netiso/tp_meas.c
+++ b/server/netiso/tp_meas.c
@@ -115,10 +115,9 @@ Tpmeas(ref, kind, timev, seq, win, size)
 	tpm->tpm_tseq = mseq++;
 	tpm->tpm_ref = ref;
 	if(kind == TPtime_from_ll)
-		bcopy((caddr_t)timev, (caddr_t)&tpm->tpm_time, sizeof(struct timeval));
+		memcpy((caddr_t)&tpm->tpm_time, (caddr_t)timev, sizeof(struct timeval));
 	else
-		bcopy( (caddr_t)&time, 
-			(caddr_t)&tpm->tpm_time, sizeof(struct timeval) );
+		memcpy((caddr_t)&tpm->tpm_time, (caddr_t)&time, sizeof(struct timeval) );
 	tpm->tpm_seq = seq;
 	tpm->tpm_window = win;
 	tpm->tpm_size = size;

--- a/server/netiso/tp_output.c
+++ b/server/netiso/tp_output.c
@@ -495,7 +495,7 @@ tp_ctloutput(cmd, so, level, optname, mp)
 #endif
 #if ISO
 					case AF_ISO:
-						if (bcmp(ISOA(t).isoa_genaddr, ISOA(tpcb).isoa_genaddr,
+						if (memcmp(ISOA(t).isoa_genaddr, ISOA(tpcb).isoa_genaddr,
 										ISOA(t).isoa_len) == 0)
 							goto done;
 						continue;
@@ -514,14 +514,14 @@ tp_ctloutput(cmd, so, level, optname, mp)
 	case TPOPT_MY_TSEL:
 		if ( cmd == PRCO_GETOPT ) {
 			ASSERT( tpcb->tp_lsuffixlen <= MAX_TSAP_SEL_LEN );
-			bcopy((caddr_t)tpcb->tp_lsuffix, value, tpcb->tp_lsuffixlen);
+			memcpy(value, (caddr_t)tpcb->tp_lsuffix, tpcb->tp_lsuffixlen);
 			(*mp)->m_len = tpcb->tp_lsuffixlen;
 		} else /* cmd == PRCO_SETOPT  */ {
 			if( (val_len > MAX_TSAP_SEL_LEN) || (val_len <= 0 )) {
 				printf("val_len 0x%x (*mp)->m_len 0x%x\n", val_len, (*mp));
 				error = EINVAL;
 			} else {
-				bcopy(value, (caddr_t)tpcb->tp_lsuffix, val_len);
+				memcpy((caddr_t)tpcb->tp_lsuffix, value, val_len);
 				tpcb->tp_lsuffixlen = val_len;
 			}
 		}
@@ -530,14 +530,14 @@ tp_ctloutput(cmd, so, level, optname, mp)
 	case TPOPT_PEER_TSEL:
 		if ( cmd == PRCO_GETOPT ) {
 			ASSERT( tpcb->tp_fsuffixlen <= MAX_TSAP_SEL_LEN );
-			bcopy((caddr_t)tpcb->tp_fsuffix, value, tpcb->tp_fsuffixlen);
+			memcpy(value, (caddr_t)tpcb->tp_fsuffix, tpcb->tp_fsuffixlen);
 			(*mp)->m_len = tpcb->tp_fsuffixlen;
 		} else /* cmd == PRCO_SETOPT  */ {
 			if( (val_len > MAX_TSAP_SEL_LEN) || (val_len <= 0 )) {
 				printf("val_len 0x%x (*mp)->m_len 0x%x\n", val_len, (*mp));
 				error = EINVAL; 
 			} else {
-				bcopy(value, (caddr_t)tpcb->tp_fsuffix, val_len);
+				memcpy((caddr_t)tpcb->tp_fsuffix, value, val_len);
 				tpcb->tp_fsuffixlen = val_len;
 			}
 		}

--- a/server/netiso/tp_pcb.c
+++ b/server/netiso/tp_pcb.c
@@ -391,7 +391,7 @@ tp_init()
     tp_start_win = 2;
 
 	tp_timerinit();
-	bzero((caddr_t)&tp_stat, sizeof(struct tp_stat));
+	memset((caddr_t)&tp_stat, 0, sizeof(struct tp_stat));
 	return 0;
 }
 
@@ -425,8 +425,8 @@ tp_soisdisconnecting(so)
 		register struct tp_pcb *tpcb = sototpcb(so);
 		u_int 	fsufx, lsufx;
 
-		bcopy ((caddr_t)tpcb->tp_fsuffix, (caddr_t)&fsufx, sizeof(u_int) );
-		bcopy ((caddr_t)tpcb->tp_lsuffix, (caddr_t)&lsufx, sizeof(u_int) );
+		memcpy((caddr_t)&fsufx, (caddr_t)tpcb->tp_fsuffix, sizeof(u_int) );
+		memcpy((caddr_t)&lsufx, (caddr_t)tpcb->tp_lsuffix, sizeof(u_int) );
 
 		tpmeas(tpcb->tp_lref, TPtime_close, &time, fsufx, lsufx, tpcb->tp_fref);
 		tpcb->tp_perf_on = 0; /* turn perf off */
@@ -470,8 +470,8 @@ tp_soisdisconnected(tpcb)
 		u_int 	fsufx, lsufx;
 
 		/* CHOKE */
-		bcopy ((caddr_t)ttpcb->tp_fsuffix, (caddr_t)&fsufx, sizeof(u_int) );
-		bcopy ((caddr_t)ttpcb->tp_lsuffix, (caddr_t)&lsufx, sizeof(u_int) );
+		memcpy((caddr_t)&fsufx, (caddr_t)ttpcb->tp_fsuffix, sizeof(u_int) );
+		memcpy((caddr_t)&lsufx, (caddr_t)ttpcb->tp_lsuffix, sizeof(u_int) );
 
 		tpmeas(ttpcb->tp_lref, TPtime_close, 
 		   &time, &lsufx, &fsufx, ttpcb->tp_fref);
@@ -577,10 +577,10 @@ tp_getref(tpcb)
 		return (--tp_refinfo.tpr_numopen, TP_ENOREF);
 	tp_refinfo.tpr_base = tp_ref = r;
 	tp_refinfo.tpr_size *= 2;
-	bcopy(obase, (caddr_t)r, size);
+	memcpy((caddr_t)r, obase, size);
 	free(obase, M_PCB);
 	r = (struct tp_ref *)(size + (caddr_t)r);
-	bzero((caddr_t)r, size);
+	memset((caddr_t)r, 0, size);
 
 got_one:
 	r->tpr_pcb = tpcb;
@@ -678,7 +678,7 @@ tp_attach(so, protocol)
 		error = ENOBUFS;
 		goto bad2;
 	}
-	bzero( (caddr_t)tpcb, sizeof (struct tp_pcb) );
+	memset((caddr_t)tpcb, 0, sizeof (struct tp_pcb) );
 
 	if ( ((lref = tp_getref(tpcb)) &  TP_ENOREF) != 0 ) { 
 		error = ETOOMANYREFS; 
@@ -907,7 +907,7 @@ register struct sockaddr_iso *siso;
 			t = l; l = t->tp_nextlisten;
 		} else
 			break;
-		if (tlen == t->tp_lsuffixlen && bcmp(tsel, t->tp_lsuffix, tlen) == 0) {
+		if (tlen == t->tp_lsuffixlen && memcmp(tsel, t->tp_lsuffix, tlen) == 0) {
 			if (t->tp_flags & TPF_GENERAL_ADDR) {
 				if (siso == 0 || reuseaddr == 0)
 					return 1;
@@ -979,7 +979,7 @@ register struct mbuf *nam;
 			if (siso) switch (siso->siso_family) {
 #if ISO
 				case AF_ISO:
-					bcopy(tsel, TSEL(siso), tlen);
+					memcpy(TSEL(siso), tsel, tlen);
 					siso->siso_tlen = tlen;
 					break;
 #endif
@@ -989,7 +989,7 @@ register struct mbuf *nam;
 #endif
 				}
 		}
-		bcopy(tsel, tpcb->tp_lsuffix, (tpcb->tp_lsuffixlen = tlen));
+		memcpy(tpcb->tp_lsuffix, tsel, (tpcb->tp_lsuffixlen = tlen));
 		insque(tpcb, &tp_bound_pcbs);
 	} else {
 		if (tlen || siso == 0)

--- a/server/netiso/tp_subr.c
+++ b/server/netiso/tp_subr.c
@@ -912,7 +912,7 @@ register struct tp_pcb *tpcb;
 	if (tpcb->tp_rsyq)
 		tp_rsyflush(tpcb);
 	if (rsyq = (caddr_t)malloc(maxcredit, M_PCB, M_NOWAIT))
-		bzero(rsyq, maxcredit);
+		memset(rsyq, 0, maxcredit);
 	tpcb->tp_rsyq = (struct mbuf **)rsyq;
 }
 

--- a/server/netiso/tp_subr2.c
+++ b/server/netiso/tp_subr2.c
@@ -328,8 +328,8 @@ void
 tp_recycle_tsuffix(tpcb)
 	struct tp_pcb	*tpcb;
 {
-	bzero((caddr_t)tpcb->tp_lsuffix, sizeof( tpcb->tp_lsuffix));
-	bzero((caddr_t)tpcb->tp_fsuffix, sizeof( tpcb->tp_fsuffix));
+	memset((caddr_t)tpcb->tp_lsuffix, 0, sizeof( tpcb->tp_lsuffix));
+	memset((caddr_t)tpcb->tp_fsuffix, 0, sizeof( tpcb->tp_fsuffix));
 	tpcb->tp_fsuffixlen = tpcb->tp_lsuffixlen = 0;
 
 	(tpcb->tp_nlproto->nlp_recycle_suffix)(tpcb->tp_npcb);
@@ -475,7 +475,7 @@ copyQOSparms(src, dst)
 	/* copy all but the bits stuff at the end */
 #define COPYSIZE (12 * sizeof(short))
 
-	bcopy((caddr_t)src, (caddr_t)dst, COPYSIZE);
+	memcpy((caddr_t)dst, (caddr_t)src, COPYSIZE);
 	dst->p_tpdusize = src->p_tpdusize;
 	dst->p_ack_strat = src->p_ack_strat;
 	dst->p_rx_strat = src->p_rx_strat;
@@ -812,7 +812,7 @@ tp_setup_perf(tpcb)
 		q->m_len = sizeof (struct tp_pmeas);
 		tpcb->tp_p_mbuf = q;
 		tpcb->tp_p_meas = mtod(q, struct tp_pmeas *);
-		bzero( (caddr_t)tpcb->tp_p_meas, sizeof (struct tp_pmeas) );
+		memset((caddr_t)tpcb->tp_p_meas, 0, sizeof (struct tp_pmeas) );
 		IFDEBUG(D_PERF_MEAS)
 			printf(
 			"tpcb 0x%x so 0x%x ref 0x%x tp_p_meas 0x%x tp_perf_on 0x%x\n", 

--- a/server/netiso/tp_timer.c
+++ b/server/netiso/tp_timer.c
@@ -109,7 +109,7 @@ tp_timerinit()
 	s = sizeof(*tp_ref) * tp_refinfo.tpr_size;
 	if ((tp_ref = (struct tp_ref *) malloc(s, M_PCB, M_NOWAIT)) == 0)
 		panic("tp_timerinit");
-	bzero((caddr_t)tp_ref, (unsigned) s);
+	memset((caddr_t)tp_ref, 0, (unsigned) s);
 	tp_refinfo.tpr_base = tp_ref;
 	tp_rttdiv = hz / PR_SLOWHZ;
 	tp_rttadd = (2 * tp_rttdiv) - 1;

--- a/server/netiso/tp_trace.c
+++ b/server/netiso/tp_trace.c
@@ -122,21 +122,19 @@ tpTrace(tpcb, event, arg, src, len, arg4, arg5)
 	tp->tpt_arg = arg;
 	if(tpcb)
 		tp->tpt_arg2 = tpcb->tp_lref;
-	bcopy( (caddr_t)&time, (caddr_t)&tp->tpt_time, sizeof(struct timeval) );
+	memcpy((caddr_t)&tp->tpt_time, (caddr_t)&time, sizeof(struct timeval) );
 
 	switch(event) {
 
 	case TPPTertpdu:
-		bcopy((caddr_t)src, (caddr_t)&tp->tpt_ertpdu,
-			(unsigned)MIN((int)len, sizeof(struct tp_Trace)));
+		memcpy((caddr_t)&tp->tpt_ertpdu, (caddr_t)src, (unsigned)MIN((int)len, sizeof(struct tp_Trace)));
 		break;
 
 	case TPPTusrreq:
 	case TPPTmisc:
 
 		/* arg is a string */
-		bcopy((caddr_t)arg, (caddr_t)tp->tpt_str, 
-			(unsigned)MIN(1+strlen((caddr_t) arg), TPTRACE_STRLEN));
+		memcpy((caddr_t)tp->tpt_str, (caddr_t)arg, (unsigned)MIN(1+strlen((caddr_t) arg), TPTRACE_STRLEN));
 		tp->tpt_m2 = src; 
 		tp->tpt_m3 = len;
 		tp->tpt_m4 = arg4;
@@ -158,17 +156,16 @@ tpTrace(tpcb, event, arg, src, len, arg4, arg5)
 		tp->tpt_m1 = arg5; 
 		break;
 	case TPPTparam:
-		bcopy((caddr_t)src, (caddr_t)&tp->tpt_param, sizeof(struct tp_param));
+		memcpy((caddr_t)&tp->tpt_param, (caddr_t)src, sizeof(struct tp_param));
 		break;
 	case TPPTref:
-		bcopy((caddr_t)src, (caddr_t)&tp->tpt_ref, sizeof(struct tp_ref));
+		memcpy((caddr_t)&tp->tpt_ref, (caddr_t)src, sizeof(struct tp_ref));
 		break;
 
 	case TPPTtpduin:
 	case TPPTtpduout:
 		tp->tpt_arg2 = arg4;
-		bcopy((caddr_t)src, (caddr_t)&tp->tpt_tpdu,
-		      (unsigned)MIN((int)len, sizeof(struct tp_Trace)));
+		memcpy((caddr_t)&tp->tpt_tpdu, (caddr_t)src, (unsigned)MIN((int)len, sizeof(struct tp_Trace)));
 		break;
 	}
 }

--- a/server/netiso/tp_usrreq.c
+++ b/server/netiso/tp_usrreq.c
@@ -230,7 +230,7 @@ restart:
 	/* Assuming at most one xpd tpdu is in the buffer at once */
 	while (n != MNULL) {
 		m->m_len += n->m_len;
-		bcopy(mtod(n, caddr_t), mtod(m, caddr_t), (unsigned)n->m_len);
+               memcpy(mtod(m, caddr_t), mtod(n, caddr_t), (unsigned)n->m_len);
 		m->m_data += n->m_len; /* so mtod() in bcopy() above gives right addr */
 		n = n->m_next;
 	}

--- a/server/netiso/tuba_subr.c
+++ b/server/netiso/tuba_subr.c
@@ -206,7 +206,7 @@ tuba_pcbconnect(inp, nam)
 	siso = isop->isop_laddr = &isop->isop_sladdr;
 	*siso = tuba_table[inp->inp_laddr.s_addr]->tc_siso;
 	siso->siso_tlen = sizeof(inp->inp_lport);
-	bcopy((caddr_t)&inp->inp_lport, TSEL(siso), sizeof(inp->inp_lport));
+	memcpy(TSEL(siso), (caddr_t)&inp->inp_lport, sizeof(inp->inp_lport));
 
 	/* hardwire in_pcbconnect() here without assigning route */
 	inp->inp_fport = sin->sin_port;
@@ -217,7 +217,7 @@ tuba_pcbconnect(inp, nam)
 	siso = mtod(nam, struct sockaddr_iso *);
 	*siso = tuba_table[inp->inp_faddr.s_addr]->tc_siso;
 	siso->siso_tlen = sizeof(inp->inp_fport);
-	bcopy((caddr_t)&inp->inp_fport, TSEL(siso), sizeof(inp->inp_fport));
+	memcpy(TSEL(siso), (caddr_t)&inp->inp_fport, sizeof(inp->inp_fport));
 
 	if ((error = iso_pcbconnect(isop, nam)) == 0)
 		tuba_refcnt(isop, 1);
@@ -303,8 +303,7 @@ tuba_tcpinput(m, src, dst)
 				return;
 			}
 		} else {
-			bcopy(mtod(m0, caddr_t) + sizeof(struct ip),
-			      mtod(m, caddr_t) + sizeof(struct ip),
+			memcpy(caddr_t) + sizeof(struct ip), mtod(m0, mtod(m, caddr_t) + sizeof(struct ip),
 			      sizeof(struct tcphdr));
 			m0->m_len -= sizeof(struct tcpiphdr);
 			m0->m_data += sizeof(struct tcpiphdr);

--- a/server/netiso/tuba_table.c
+++ b/server/netiso/tuba_table.c
@@ -98,9 +98,8 @@ tuba_lookup(siso, wait)
 	if ((tc = (struct tuba_cache *)malloc(sizeof(*tc), M_RTABLE, wait))
 		== NULL)
 		return (0);
-	bzero((caddr_t)tc, sizeof (*tc));
-	bcopy(siso->siso_data, tc->tc_siso.siso_data,
-		tc->tc_siso.siso_nlen =  siso->siso_nlen);
+	memset((caddr_t)tc, 0, sizeof (*tc));
+	memcpy(tc->tc_siso.siso_data, siso->siso_data, tc->tc_siso.siso_nlen =  siso->siso_nlen);
 	rn_insert(&tc->tc_siso.siso_addr, tuba_tree, &dupentry, tc->tc_nodes);
 	if (dupentry)
 		panic("tuba_lookup 1");
@@ -129,9 +128,9 @@ tuba_lookup(siso, wait)
 		free((caddr_t)tc, M_RTABLE);
 		return (0);
 	}
-	bzero((caddr_t)new, (unsigned)i);
+	memset((caddr_t)new, 0, (unsigned)i);
 	if (tuba_table) {
-		bcopy((caddr_t)tuba_table, (caddr_t)new, i >> 1);
+		memcpy((caddr_t)new, (caddr_t)tuba_table, i >> 1);
 		free((caddr_t)tuba_table, M_RTABLE);
 	}
 	tuba_table = new;

--- a/server/netiso/tuba_usrreq.c
+++ b/server/netiso/tuba_usrreq.c
@@ -172,7 +172,7 @@ tuba_usrreq(so, req, m, nam, control)
 		if ((error = iso_pcbbind(isop, nam)) || 
 		    (siso = isop->isop_laddr) == 0)
 			break;
-		bcopy(TSEL(siso), &inp->inp_lport, 2);
+		memcpy(&inp->inp_lport, TSEL(siso), 2);
 		if (siso->siso_nlen &&
 		    !(inp->inp_laddr.s_addr = tuba_lookup(siso, M_WAITOK)))
 			error = ENOBUFS;
@@ -186,7 +186,7 @@ tuba_usrreq(so, req, m, nam, control)
 		if (inp->inp_lport == 0 &&
 		    (error = iso_pcbbind(isop, (struct mbuf *)0)))
 			break;
-		bcopy(TSEL(isop->isop_laddr), &inp->inp_lport, 2);
+		memcpy(&inp->inp_lport, TSEL(isop->isop_laddr), 2);
 		if (req == PRU_LISTEN) {
 			tp->t_state = TCPS_LISTEN;
 			break;
@@ -213,7 +213,7 @@ tuba_usrreq(so, req, m, nam, control)
 			error = ENOBUFS;
 			break;
 		}
-		bcopy(TSEL(isop->isop_faddr), &inp->inp_fport, 2);
+		memcpy(&inp->inp_fport, TSEL(isop->isop_faddr), 2);
 		if (inp->inp_laddr.s_addr == 0 &&
 		     (inp->inp_laddr.s_addr = 
 			    tuba_lookup(isop->isop_laddr, M_WAITOK)) == 0)
@@ -252,7 +252,7 @@ tuba_usrreq(so, req, m, nam, control)
 	 * of the peer, storing through addr.
 	 */
 	case PRU_ACCEPT:
-		bcopy((caddr_t)isop->isop_faddr, mtod(nam, caddr_t),
+		memcpy(mtod(nam, (caddr_t)isop->isop_faddr, caddr_t),
 			nam->m_len = isop->isop_faddr->siso_len);
 		break;
 
@@ -278,13 +278,13 @@ tuba_usrreq(so, req, m, nam, control)
 
 	case PRU_SOCKADDR:
 		if (isop->isop_laddr)
-			bcopy((caddr_t)isop->isop_laddr, mtod(nam, caddr_t),
+			memcpy(mtod(nam, (caddr_t)isop->isop_laddr, caddr_t),
 				nam->m_len = isop->isop_laddr->siso_len);
 		break;
 
 	case PRU_PEERADDR:
 		if (isop->isop_faddr)
-			bcopy((caddr_t)isop->isop_faddr, mtod(nam, caddr_t),
+			memcpy(mtod(nam, (caddr_t)isop->isop_faddr, caddr_t),
 				nam->m_len = isop->isop_faddr->siso_len);
 		break;
 

--- a/server/netiso/xebec/procs.c
+++ b/server/netiso/xebec/procs.c
@@ -66,7 +66,7 @@ end_events() {
 	IFDEBUG(N)
 		fprintf(OUT, "bzero addr 0x%x part %d size %d\n",addr, part, size);
 	ENDDEBUG
-		bzero(addr, part);
+		memset(addr, 0, part);
 	IFDEBUG(N)
 		fprintf(OUT, "after bzero addr 0x%x part %d size %d\n",addr, part, size);
 	ENDDEBUG

--- a/server/netiso/xebec/sets.c
+++ b/server/netiso/xebec/sets.c
@@ -283,7 +283,7 @@ int keep;
 	ENDDEBUG
 	
 	onew = (struct Object *)Malloc(sizeof (struct Object));
-	bzero(onew, sizeof(struct Object));
+	memset(onew, 0, sizeof(struct Object));
 	onew->obj_name = adr;
 	onew->obj_kind = OBJ_SET;
 	onew->obj_type = type;
@@ -329,7 +329,7 @@ char *struc;
 		exit(-1);
 	} else {
 		onew = (struct Object *)Malloc(sizeof (struct Object));
-		bzero(onew, sizeof(struct Object));
+		memset(onew, 0, sizeof(struct Object));
 		onew->obj_name = stash(adr);
 		onew->obj_kind = OBJ_ITEM;
 		onew->obj_type =  type;
@@ -360,7 +360,7 @@ char *adr;
 		"Warning at line %d: set definition of %s causes definition of\n",
 			lineno, OBJ_NAME(o));
 		fprintf(stderr, "\t (previously undefined) member %s\n", adr);
-		bzero(onew, sizeof(struct Object));
+		memset(onew, 0, sizeof(struct Object));
 		onew->obj_name = stash(adr);
 		onew->obj_kind = OBJ_ITEM;
 		onew->obj_type = o->obj_type;
@@ -371,7 +371,7 @@ char *adr;
 			fprintf(stderr, "Sets cannot be members of sets; %s\n", adr);
 			exit(-1);
 		}
-		bcopy(oold, onew, sizeof(struct Object));
+		memcpy(onew, oold, sizeof(struct Object));
 		onew->obj_members = onew->obj_left = onew->obj_right = NULL;
 	}
 	onew->obj_members = o->obj_members;

--- a/server/netns/ns.c
+++ b/server/netns/ns.c
@@ -132,7 +132,7 @@ ns_control(so, cmd, data, ifp)
 				malloc(sizeof *ia, M_IFADDR, M_WAITOK);
 			if (oia == (struct ns_ifaddr *)NULL)
 				return (ENOBUFS);
-			bzero((caddr_t)oia, sizeof(*oia));
+			memset((caddr_t)oia, 0, sizeof(*oia));
 			if (ia = ns_ifaddr) {
 				for ( ; ia->ia_next; ia = ia->ia_next)
 					;

--- a/server/netns/ns_error.c
+++ b/server/netns/ns_error.c
@@ -145,7 +145,7 @@ ns_error(om, type, param)
 	ns_errstat.ns_es_outhist[ns_err_x(type)]++;
 	ep->ns_ep_errp.ns_err_num = htons((u_short)type);
 	ep->ns_ep_errp.ns_err_param = htons((u_short)param);
-	bcopy((caddr_t)oip, (caddr_t)&ep->ns_ep_errp.ns_err_idp, 42);
+	memcpy((caddr_t)&ep->ns_ep_errp.ns_err_idp, (caddr_t)oip, 42);
 	nip = &ep->ns_ep_idp;
 	nip->idp_len = sizeof(*ep);
 	nip->idp_len = htons((u_short)nip->idp_len);

--- a/server/netns/ns_input.c
+++ b/server/netns/ns_input.c
@@ -430,7 +430,7 @@ struct route *ro;
 	
 	struct sockaddr_ns *dst;
 
-	bzero((caddr_t)ro, sizeof (*ro));
+	memset((caddr_t)ro, 0, sizeof (*ro));
 	dst = (struct sockaddr_ns *)&ro->ro_dst;
 
 	dst->sns_len = sizeof(*dst);

--- a/server/netns/ns_ip.c
+++ b/server/netns/ns_ip.c
@@ -332,7 +332,7 @@ nsip_route(m)
 	/*
 	 * Now, determine if we can get to the destination
 	 */
-	bzero((caddr_t)&ro, sizeof (ro));
+	memset((caddr_t)&ro, 0, sizeof (ro));
 	ro.ro_dst = *(struct sockaddr *)ip_dst;
 	rtalloc(&ro);
 	if (ro.ro_rt == 0 || ro.ro_rt->rt_ifp == 0) {

--- a/server/netns/ns_output.c
+++ b/server/netns/ns_output.c
@@ -79,7 +79,7 @@ ns_output(m0, ro, flags)
 	 */
 	if (ro == 0) {
 		ro = &idproute;
-		bzero((caddr_t)ro, sizeof (*ro));
+		memset((caddr_t)ro, 0, sizeof (*ro));
 	}
 	dst = (struct sockaddr_ns *)&ro->ro_dst;
 	if (ro->ro_rt == 0) {

--- a/server/netns/ns_pcb.c
+++ b/server/netns/ns_pcb.c
@@ -247,7 +247,7 @@ ns_setsockaddr(nsp, nam)
 	
 	nam->m_len = sizeof (*sns);
 	sns = mtod(nam, struct sockaddr_ns *);
-	bzero((caddr_t)sns, sizeof (*sns));
+	memset((caddr_t)sns, 0, sizeof (*sns));
 	sns->sns_len = sizeof(*sns);
 	sns->sns_family = AF_NS;
 	sns->sns_addr = nsp->nsp_laddr;
@@ -261,7 +261,7 @@ ns_setpeeraddr(nsp, nam)
 	
 	nam->m_len = sizeof (*sns);
 	sns = mtod(nam, struct sockaddr_ns *);
-	bzero((caddr_t)sns, sizeof (*sns));
+	memset((caddr_t)sns, 0, sizeof (*sns));
 	sns->sns_len = sizeof(*sns);
 	sns->sns_family = AF_NS;
 	sns->sns_addr  = nsp->nsp_faddr;

--- a/server/netns/spp_debug.c
+++ b/server/netns/spp_debug.c
@@ -90,11 +90,11 @@ spp_trace(act, ostate, sp, si, req)
 	if (sp)
 		sd->sd_sp = *sp;
 	else
-		bzero((caddr_t)&sd->sd_sp, sizeof (*sp));
+		memset((caddr_t)&sd->sd_sp, 0, sizeof (*sp));
 	if (si)
 		sd->sd_si = *si;
 	else
-		bzero((caddr_t)&sd->sd_si, sizeof (*si));
+		memset((caddr_t)&sd->sd_si, 0, sizeof (*si));
 	sd->sd_req = req;
 	if (sppconsdebug == 0)
 		return;

--- a/server/nfs/nfs_bio.c
+++ b/server/nfs/nfs_bio.c
@@ -713,7 +713,7 @@ nfs_doio(bp, cr, p)
 				+ diff);
 			if (len > 0) {
 			    len = min(len, uiop->uio_resid);
-			    bzero((char *)bp->b_data + diff, len);
+			    memset((char *)bp->b_data + diff, 0, len);
 			    bp->b_validend = diff + len;
 			} else
 			    bp->b_validend = diff;

--- a/server/nfs/nfs_node.c
+++ b/server/nfs/nfs_node.c
@@ -109,7 +109,7 @@ nfs_nget(mntp, fhp, npp)
 loop:
 	for (np = *nhpp; np; np = np->n_forw) {
 		if (mntp != NFSTOV(np)->v_mount ||
-		    bcmp((caddr_t)fhp, (caddr_t)&np->n_fh, NFSX_FH))
+		    memcmp((caddr_t)fhp, (caddr_t)&np->n_fh, NFSX_FH))
 			continue;
 		vp = NFSTOV(np);
 		if (vget(vp, 1))
@@ -135,7 +135,7 @@ loop:
 	np->n_forw = nq;
 	np->n_back = nhpp;
 	*nhpp = np;
-	bcopy((caddr_t)fhp, (caddr_t)&np->n_fh, NFSX_FH);
+	memcpy((caddr_t)&np->n_fh, (caddr_t)fhp, NFSX_FH);
 	np->n_attrstamp = 0;
 	np->n_direofoffset = 0;
 	np->n_sillyrename = (struct sillyrename *)0;

--- a/server/nfs/nfs_nqlease.c
+++ b/server/nfs/nfs_nqlease.c
@@ -197,7 +197,7 @@ nqsrv_getlease(vp, duration, flags, nd, nam, cachablep, frev, cred)
 		for (lp = *lpp; lp; lp = lp->lc_fhnext)
 			if (fh.fh_fsid.val[0] == lp->lc_fsid.val[0] &&
 			    fh.fh_fsid.val[1] == lp->lc_fsid.val[1] &&
-			    !bcmp(fh.fh_fid.fid_data, lp->lc_fiddata,
+			    !memcmp(fh.fh_fid.fid_data, lp->lc_fiddata,
 				  fh.fh_fid.fid_len - sizeof (long))) {
 				/* Found it */
 				lp->lc_vp = vp;
@@ -244,7 +244,7 @@ nqsrv_getlease(vp, duration, flags, nd, nam, cachablep, frev, cred)
 				*lphp = (struct nqm *)
 					malloc(sizeof (struct nqm),
 						M_NQMHOST, M_WAITOK);
-				bzero((caddr_t)*lphp, sizeof (struct nqm));
+				memset((caddr_t)*lphp, 0, sizeof (struct nqm));
 				lph = (*lphp)->lpm_hosts;
 			}
 			nqsrv_addhost(lph, nd->nd_slp, nam);
@@ -289,13 +289,13 @@ doreply:
 		} while (nfsstats.srvnqnfs_leases > nqsrv_maxnumlease);
 	}
 	MALLOC(lp, struct nqlease *, sizeof (struct nqlease), M_NQLEASE, M_WAITOK);
-	bzero((caddr_t)lp, sizeof (struct nqlease));
+	memset((caddr_t)lp, 0, sizeof (struct nqlease));
 	if (flags & NQL_WRITE)
 		lp->lc_flag |= (LC_WRITE | LC_WRITTEN);
 	nqsrv_addhost(&lp->lc_host, nd->nd_slp, nam);
 	lp->lc_vp = vp;
 	lp->lc_fsid = fh.fh_fsid;
-	bcopy(fh.fh_fid.fid_data, lp->lc_fiddata, fh.fh_fid.fid_len - sizeof (long));
+	memcpy(lp->lc_fiddata, fh.fh_fid.fid_data, fh.fh_fid.fid_len - sizeof (long));
 	if (lq = *lpp)
 		lq->lc_fhprev = &lp->lc_fhnext;
 	lp->lc_fhnext = lq;
@@ -485,7 +485,7 @@ nqsrv_send_eviction(vp, lp, slp, nam, cred)
 			nfsm_reqhead((struct vnode *)0, NQNFSPROC_EVICTED,
 				NFSX_FH);
 			nfsm_build(cp, caddr_t, NFSX_FH);
-			bzero(cp, NFSX_FH);
+			memset(cp, 0, NFSX_FH);
 			fhp = (fhandle_t *)cp;
 			fhp->fh_fsid = vp->v_mount->mnt_stat.f_fsid;
 			VFS_VPTOFH(vp, &fhp->fh_fid);
@@ -756,7 +756,7 @@ nqnfsrv_vacated(nfsd, mrep, md, dpos, cred, nam, mrq)
 	     lp = lp->lc_fhnext)
 		if (fhp->fh_fsid.val[0] == lp->lc_fsid.val[0] &&
 		    fhp->fh_fsid.val[1] == lp->lc_fsid.val[1] &&
-		    !bcmp(fhp->fh_fid.fid_data, lp->lc_fiddata,
+		    !memcmp(fhp->fh_fid.fid_data, lp->lc_fiddata,
 			  MAXFIDSZ)) {
 			/* Found it */
 			tlp = lp;

--- a/server/nfs/nfs_serv.c
+++ b/server/nfs/nfs_serv.c
@@ -299,7 +299,7 @@ nfsrv_lookup(nfsd, mrep, md, dpos, cred, nam, mrq)
 	vrele(nd.ni_startdir);
 	FREE(nd.ni_cnd.cn_pnbuf, M_NAMEI);
 	vp = nd.ni_vp;
-	bzero((caddr_t)fhp, sizeof(nfh));
+	memset((caddr_t)fhp, 0, sizeof(nfh));
 	fhp->fh_fsid = vp->v_mount->mnt_stat.f_fsid;
 	if (error = VFS_VPTOFH(vp, &fhp->fh_fid)) {
 		vput(vp);
@@ -793,7 +793,7 @@ nfsrv_create(nfsd, mrep, md, dpos, cred, nam, mrq)
 			}
 		}
 	}
-	bzero((caddr_t)fhp, sizeof(nfh));
+	memset((caddr_t)fhp, 0, sizeof(nfh));
 	fhp->fh_fsid = vp->v_mount->mnt_stat.f_fsid;
 	if (error = VFS_VPTOFH(vp, &fhp->fh_fid)) {
 		vput(vp);
@@ -971,7 +971,7 @@ nfsrv_rename(nfsd, mrep, md, dpos, cred, nam, mrq)
 	 */
 	if (fvp == tvp && fromnd.ni_dvp == tdvp &&
 	    fromnd.ni_cnd.cn_namelen == tond.ni_cnd.cn_namelen &&
-	    !bcmp(fromnd.ni_cnd.cn_nameptr, tond.ni_cnd.cn_nameptr,
+	    !memcmp(fromnd.ni_cnd.cn_nameptr, tond.ni_cnd.cn_nameptr,
 	      fromnd.ni_cnd.cn_namelen))
 		error = -1;
 out:
@@ -1218,7 +1218,7 @@ nfsrv_mkdir(nfsd, mrep, md, dpos, cred, nam, mrq)
 	if (error = VOP_MKDIR(nd.ni_dvp, &nd.ni_vp, &nd.ni_cnd, vap))
 		nfsm_reply(0);
 	vp = nd.ni_vp;
-	bzero((caddr_t)fhp, sizeof(nfh));
+	memset((caddr_t)fhp, 0, sizeof(nfh));
 	fhp->fh_fsid = vp->v_mount->mnt_stat.f_fsid;
 	if (error = VFS_VPTOFH(vp, &fhp->fh_fid)) {
 		vput(vp);
@@ -1489,7 +1489,7 @@ again:
 					tsiz = be-bp;
 				else
 					tsiz = xfer;
-				bcopy(cp, bp, tsiz);
+				memcpy(bp, cp, tsiz);
 				bp += tsiz;
 				xfer -= tsiz;
 				if (xfer > 0)
@@ -1656,7 +1656,7 @@ again:
 			 */
 			if (VFS_VGET(vp->v_mount, dp->d_fileno, &nvp))
 				goto invalid;
-			bzero((caddr_t)&fl.fl_nfh, sizeof (nfsv2fh_t));
+			memset((caddr_t)&fl.fl_nfh, 0, sizeof (nfsv2fh_t));
 			fl.fl_nfh.fh_generic.fh_fsid =
 				nvp->v_mount->mnt_stat.f_fsid;
 			if (VFS_VPTOFH(nvp, &fl.fl_nfh.fh_generic.fh_fid)) {
@@ -1703,7 +1703,7 @@ again:
 					tsiz = be-bp;
 				else
 					tsiz = xfer;
-				bcopy(cp, bp, tsiz);
+				memcpy(bp, cp, tsiz);
 				bp += tsiz;
 				xfer -= tsiz;
 				if (xfer > 0)
@@ -1725,7 +1725,7 @@ again:
 					tsiz = be-bp;
 				else
 					tsiz = xfer;
-				bcopy(cp, bp, tsiz);
+				memcpy(bp, cp, tsiz);
 				bp += tsiz;
 				xfer -= tsiz;
 				if (xfer > 0)

--- a/server/nfs/nfs_socket.c
+++ b/server/nfs/nfs_socket.c
@@ -1530,7 +1530,7 @@ nfs_realign(m, hsiz)
 				}
 				siz = min(mlen, olen);
 				if (tcp != fcp)
-					bcopy(fcp, tcp, siz);
+					memcpy(tcp, fcp, siz);
 				mnew->m_len += siz;
 				mlen -= siz;
 				olen -= siz;
@@ -1697,7 +1697,7 @@ nfsrv_getstream(slp, waitflag)
 		}
 		m = slp->ns_raw;
 		if (m->m_len >= NFSX_UNSIGNED) {
-			bcopy(mtod(m, caddr_t), (caddr_t)&recmark, NFSX_UNSIGNED);
+			memcpy(caddr_t), mtod(m, (caddr_t)&recmark, NFSX_UNSIGNED);
 			m->m_data += NFSX_UNSIGNED;
 			m->m_len -= NFSX_UNSIGNED;
 		} else {

--- a/server/nfs/nfs_srvcache.c
+++ b/server/nfs/nfs_srvcache.c
@@ -222,7 +222,7 @@ loop:
 	if (numnfsrvcache < desirednfsrvcache) {
 		rp = (struct nfsrvcache *)malloc((u_long)sizeof *rp,
 		    M_NFSD, M_WAITOK);
-		bzero((char *)rp, sizeof *rp);
+		memset((char *)rp, 0, sizeof *rp);
 		numnfsrvcache++;
 		rp->rc_flag = RC_LOCKED;
 	} else {
@@ -341,7 +341,7 @@ nfsrv_cleancache()
 		nextrp = rp->rc_next;
 		free(rp, M_NFSD);
 	}
-	bzero((char *)rheadhtbl, (rheadhash + 1) * sizeof(void *));
+	memset((char *)rheadhtbl, 0, (rheadhash + 1) * sizeof(void *));
 	nfsrvlruhead = NULL;
 	nfsrvlrutail = &nfsrvlruhead;
 	numnfsrvcache = 0;

--- a/server/nfs/nfs_subs.c
+++ b/server/nfs/nfs_subs.c
@@ -237,7 +237,7 @@ nfsm_rpchead(cr, nqnfs, procid, auth_type, auth_len, auth_str, mrest,
 				bpos = mtod(mb, caddr_t);
 			}
 			i = min(siz, M_TRAILINGSPACE(mb));
-			bcopy(auth_str, bpos, i);
+			memcpy(bpos, auth_str, i);
 			mb->m_len += i;
 			auth_str += i;
 			bpos += i;
@@ -304,7 +304,7 @@ nfsm_mbuftouio(mrep, uiop, siz, dpos)
 			else
 #endif
 			if (uiop->uio_segflg == UIO_SYSSPACE)
-				bcopy(mbufcp, uiocp, xfer);
+				memcpy(uiocp, mbufcp, xfer);
 			else
 				copyout(mbufcp, uiocp, xfer);
 			left -= xfer;
@@ -383,7 +383,7 @@ nfsm_uiotombuf(uiop, mq, siz, bpos)
 			else
 #endif
 			if (uiop->uio_segflg == UIO_SYSSPACE)
-				bcopy(uiocp, mtod(mp, caddr_t)+mp->m_len, xfer);
+				memcpy(mtod(mp, uiocp, caddr_t)+mp->m_len, xfer);
 			else
 				copyin(uiocp, mtod(mp, caddr_t)+mp->m_len, xfer);
 			mp->m_len += xfer;
@@ -457,7 +457,7 @@ nfsm_disct(mdp, dposp, siz, left, cp2)
 		mp->m_len -= left;
 		mp = mp2;
 		*cp2 = p = mtod(mp, caddr_t);
-		bcopy(*dposp, p, left);		/* Copy what was left */
+		memcpy(p, *dposp, left);		/* Copy what was left */
 		siz2 = siz-left;
 		p += left;
 		mp2 = mp->m_next;
@@ -467,7 +467,7 @@ nfsm_disct(mdp, dposp, siz, left, cp2)
 				return (EBADRPC);
 			xfer = (siz2 > mp2->m_len) ? mp2->m_len : siz2;
 			if (xfer > 0) {
-				bcopy(mtod(mp2, caddr_t), p, xfer);
+				memcpy(caddr_t), mtod(mp2, p, xfer);
 				NFSMADV(mp2, xfer);
 				mp2->m_len -= xfer;
 				p += xfer;
@@ -533,7 +533,7 @@ nfsm_strtmbuf(mb, bpos, cp, siz)
 		left -= NFSX_UNSIGNED;
 		m2->m_len += NFSX_UNSIGNED;
 		if (left > 0) {
-			bcopy(cp, (caddr_t) tl, left);
+			memcpy((caddr_t) tl, cp, left);
 			siz -= left;
 			cp += left;
 			m2->m_len += left;
@@ -564,7 +564,7 @@ nfsm_strtmbuf(mb, bpos, cp, siz)
 		} else {
 			xfer = len = m1->m_len;
 		}
-		bcopy(cp, (caddr_t) tl, xfer);
+		memcpy((caddr_t) tl, cp, xfer);
 		m1->m_len = len+tlen;
 		siz -= xfer;
 		cp += xfer;
@@ -780,7 +780,7 @@ nfs_loadattrcache(vpp, mdp, dposp, vaper)
 	*dposp = dpos;
 	*mdp = md;
 	if (vaper != NULL) {
-		bcopy((caddr_t)vap, (caddr_t)vaper, sizeof(*vap));
+		memcpy((caddr_t)vaper, (caddr_t)vap, sizeof(*vap));
 #ifdef notdef
 		if ((np->n_flag & NMODIFIED) && np->n_size > vap->va_size)
 		if (np->n_size > vap->va_size)
@@ -840,7 +840,7 @@ nfs_getattrcache(vp, vaper)
 		} else
 			np->n_size = vap->va_size;
 	}
-	bcopy((caddr_t)vap, (caddr_t)vaper, sizeof(struct vattr));
+	memcpy((caddr_t)vaper, (caddr_t)vap, sizeof(struct vattr));
 #ifdef notdef
 	if ((np->n_flag & NMODIFIED) == 0) {
 		np->n_size = vaper->va_size;

--- a/server/nfs/nfs_syscalls.c
+++ b/server/nfs/nfs_syscalls.c
@@ -124,7 +124,7 @@ getfh(p, uap, retval)
 	if (error = namei(&nd))
 		return (error);
 	vp = nd.ni_vp;
-	bzero((caddr_t)&fh, sizeof(fh));
+	memset((caddr_t)&fh, 0, sizeof(fh));
 	fh.fh_fsid = vp->v_mount->mnt_stat.f_fsid;
 	error = VFS_VPTOFH(vp, &fh.fh_fid);
 	vput(vp);
@@ -344,7 +344,7 @@ nfssvc_addsock(fp, mynam)
 	else {
 		slp = (struct nfssvc_sock *)
 			malloc(sizeof (struct nfssvc_sock), M_NFSSVC, M_WAITOK);
-		bzero((caddr_t)slp, sizeof (struct nfssvc_sock));
+		memset((caddr_t)slp, 0, sizeof (struct nfssvc_sock));
 		slp->ns_prev = nfssvc_sockhead.ns_prev;
 		slp->ns_prev->ns_next = slp;
 		slp->ns_next = &nfssvc_sockhead;
@@ -390,7 +390,7 @@ nfssvc_nfsd(nsd, argp, p)
 	if (nd == (struct nfsd *)0) {
 		nsd->nsd_nfsd = nd = (struct nfsd *)
 			malloc(sizeof (struct nfsd), M_NFSD, M_WAITOK);
-		bzero((caddr_t)nd, sizeof (struct nfsd));
+		memset((caddr_t)nd, 0, sizeof (struct nfsd));
 		nd->nd_procp = p;
 		nd->nd_cr.cr_ref = 1;
 		insque(nd, &nfsd_head);
@@ -817,10 +817,10 @@ nfsrv_init(terminating)
 	}
 	nfs_udpsock = (struct nfssvc_sock *)
 	    malloc(sizeof (struct nfssvc_sock), M_NFSSVC, M_WAITOK);
-	bzero((caddr_t)nfs_udpsock, sizeof (struct nfssvc_sock));
+	memset((caddr_t)nfs_udpsock, 0, sizeof (struct nfssvc_sock));
 	nfs_cltpsock = (struct nfssvc_sock *)
 	    malloc(sizeof (struct nfssvc_sock), M_NFSSVC, M_WAITOK);
-	bzero((caddr_t)nfs_cltpsock, sizeof (struct nfssvc_sock));
+	memset((caddr_t)nfs_cltpsock, 0, sizeof (struct nfssvc_sock));
 	nfssvc_sockhead.ns_next = nfs_udpsock;
 	nfs_udpsock->ns_next = nfs_cltpsock;
 	nfs_cltpsock->ns_next = &nfssvc_sockhead;

--- a/server/nfs/nfs_vnops.c
+++ b/server/nfs/nfs_vnops.c
@@ -694,7 +694,7 @@ nfsmout:
 	 * Handle RENAME case...
 	 */
 	if (cnp->cn_nameiop == RENAME && wantparent && (flags & ISLASTCN)) {
-		if (!bcmp(np->n_fh.fh_bytes, (caddr_t)fhp, NFSX_FH)) {
+		if (!memcmp(np->n_fh.fh_bytes, (caddr_t)fhp, NFSX_FH)) {
 			m_freem(mrep);
 			return (EISDIR);
 		}
@@ -715,7 +715,7 @@ nfsmout:
 		return (0);
 	}
 
-	if (!bcmp(np->n_fh.fh_bytes, (caddr_t)fhp, NFSX_FH)) {
+	if (!memcmp(np->n_fh.fh_bytes, (caddr_t)fhp, NFSX_FH)) {
 		VREF(dvp);
 		newvp = dvp;
 	} else {
@@ -1790,7 +1790,7 @@ nfs_readdirlookrpc(vp, uiop, cred)
 				fxdr_hyper(tl, &frev);
 			}
 			nfsm_dissect(fhp, nfsv2fh_t *, NFSX_FH);
-			if (!bcmp(VTONFS(vp)->n_fh.fh_bytes, (caddr_t)fhp, NFSX_FH)) {
+			if (!memcmp(VTONFS(vp)->n_fh.fh_bytes, (caddr_t)fhp, NFSX_FH)) {
 				VREF(vp);
 				newvp = vp;
 				np = VTONFS(vp);
@@ -1928,7 +1928,7 @@ nfs_sillyrename(dvp, vp, cnp)
 
 	/* Fudge together a funny name */
 	pid = cnp->cn_proc->p_pid;
-	bcopy(".nfsAxxxx4.4", sp->s_name, 13);
+	memcpy(sp->s_name, ".nfsAxxxx4.4", 13);
 	sp->s_namlen = 12;
 	sp->s_name[8] = hextoasc[pid & 0xf];
 	sp->s_name[7] = hextoasc[(pid >> 4) & 0xf];
@@ -1993,7 +1993,7 @@ nfs_lookitup(sp, fhp, procp)
 		if (isnq)
 			nfsm_dissect(tl, u_long *, NFSX_UNSIGNED);
 		nfsm_dissect(cp, caddr_t, NFSX_FH);
-		bcopy(cp, (caddr_t)fhp, NFSX_FH);
+		memcpy((caddr_t)fhp, cp, NFSX_FH);
 	}
 	nfsm_reqdone;
 	return (error);

--- a/server/nfs/nfsm_subs.h
+++ b/server/nfs/nfsm_subs.h
@@ -100,11 +100,11 @@ extern struct mbuf *nfsm_reqh();
 
 #define nfsm_fhtom(v) \
 		nfsm_build(cp,caddr_t,NFSX_FH); \
-		bcopy((caddr_t)&(VTONFS(v)->n_fh), cp, NFSX_FH)
+		memcpy(cp, (caddr_t)&(VTONFS(v)->n_fh), NFSX_FH)
 
 #define nfsm_srvfhtom(f) \
 		nfsm_build(cp,caddr_t,NFSX_FH); \
-		bcopy((caddr_t)(f), cp, NFSX_FH)
+		memcpy(cp, (caddr_t)(f), NFSX_FH)
 
 #define nfsm_mtofh(d,v) \
 		{ struct nfsnode *np; nfsv2fh_t *fhp; \
@@ -177,7 +177,7 @@ extern struct mbuf *nfsm_reqh();
 			nfsm_build(tl,u_long *,t2); \
 			*tl++ = txdr_unsigned(s); \
 			*(tl+((t2>>2)-2)) = 0; \
-			bcopy((caddr_t)(a), (caddr_t)tl, (s)); \
+			memcpy((caddr_t)tl, (caddr_t)(a), (s)); \
 		} else if (error = nfsm_strtmbuf(&mb, &bpos, (a), (s))) { \
 			m_freem(mreq); \
 			goto nfsmout; \
@@ -213,7 +213,7 @@ extern struct mbuf *nfsm_reqh();
 
 #define nfsm_srvmtofh(f) \
 		nfsm_dissect(tl, u_long *, NFSX_FH); \
-		bcopy((caddr_t)tl, (caddr_t)f, NFSX_FH)
+		memcpy((caddr_t)f, (caddr_t)tl, NFSX_FH)
 
 #define	nfsm_clget \
 		if (bp >= be) { \

--- a/server/parisc/mem.c
+++ b/server/parisc/mem.c
@@ -177,7 +177,7 @@ memrw(dev_t dev, struct uio *uio, int rw)
 				break;
 			}
 			if (!didzero) {
-				bzero(zbuf, ZBUFSIZE);
+				memset(zbuf, 0, ZBUFSIZE);
 				didzero = 1;
 			}
 			c = min(iov->iov_len, ZBUFSIZE);

--- a/server/parisc/serv_machdep.c
+++ b/server/parisc/serv_machdep.c
@@ -119,7 +119,7 @@ void set_emulator_state(
 	struct parisc_thread_state	ts;
 	unsigned int			count;
 
-	bzero((char *)&ts, sizeof(ts));
+	memset((char *)&ts, 0, sizeof(ts));
 	count = PARISC_THREAD_STATE_COUNT;
 	(void) thread_get_state(p->p_thread,
 				PARISC_THREAD_STATE,

--- a/server/parisc/vm_machdep.c
+++ b/server/parisc/vm_machdep.c
@@ -65,7 +65,7 @@ fake_bsd_u(bup, p, thread)
 	struct proc		 *p;
 	register thread_t	 thread;
 {
-	bzero((caddr_t) bup, sizeof(struct bsd_user));
+	memset((caddr_t) bup, 0, sizeof(struct bsd_user));
 	
 	bup->bsdu_pcb.pcb_pgsz = NBPG;
 
@@ -220,7 +220,7 @@ pagemove(from, to, size)
 	 */
 
 	if (dobcopy) {
-		bcopy(from, to, size);
+		memcpy(to, from, size);
 		return;
 	}
 	kr = vm_write(mach_task_self(), (vm_offset_t) to,

--- a/server/serv/bsd_server_side.c
+++ b/server/serv/bsd_server_side.c
@@ -1190,7 +1190,7 @@ bsd_set_atexpansion(
 
 	TRACE(("\n[%d] bsd_set_atexpansion", p->p_pid));
 
-	if ((what_count < 4) || bcmp("@bin", what_to_expand, 4)) {
+	if ((what_count < 4) || memcmp("@bin", what_to_expand, 4)) {
 		mutex_unlock(&p->p_lock);
 		return EOPNOTSUPP;
 	}

--- a/server/serv/cmu_syscalls.c
+++ b/server/serv/cmu_syscalls.c
@@ -224,13 +224,9 @@ int table(cp, args, retval)
 					 (host_info_t)&load_info,
 					 (mach_msg_type_number_t *)&count);
 			/* XXX Memory leak ? */
-			bcopy((caddr_t)load_info.avenrun,
-			      (caddr_t)&tl.tl_avenrun,
-			      sizeof(tl.tl_avenrun));
+			memcpy((caddr_t)&tl.tl_avenrun, (caddr_t)load_info.avenrun, sizeof(tl.tl_avenrun));
 			tl.tl_lscale = 1000;/*XXXXXXX*/
-			bcopy((caddr_t)load_info.mach_factor,
-			      (caddr_t)&tl.tl_mach_factor,
-			      sizeof(tl.tl_mach_factor));
+			memcpy((caddr_t)&tl.tl_mach_factor, (caddr_t)load_info.mach_factor, sizeof(tl.tl_mach_factor));
 			data = (caddr_t)&tl;
 			size = sizeof (tl);
 			break;
@@ -411,10 +407,10 @@ int table(cp, args, retval)
 			    && (error = suser(cp->p_ucred, &cp->p_acflag)))
 				return (error);
 			if (p == (struct proc *)0) {
-			    bzero((caddr_t)&tp, sizeof(tp));
+			    memset((caddr_t)&tp, 0, sizeof(tp));
 			    tp.pi_status = PI_EMPTY;
 			} else if ((p->p_stat == 0) || (p->p_stat == SIDL)) {
-			    bzero((caddr_t)&tp, sizeof(tp));
+			    memset((caddr_t)&tp, 0, sizeof(tp));
 			    tp.pi_status = PI_EMPTY;
 			} else {
 			    mutex_lock(&p->p_lock);
@@ -466,7 +462,7 @@ int table(cp, args, retval)
                                         tp.pi_tpgrp = 0;
                                     }
                                 }
-				bcopy(p->p_comm, tp.pi_comm, PI_COMLEN);
+				memcpy(tp.pi_comm, p->p_comm, PI_COMLEN);
 				tp.pi_comm[PI_COMLEN] = '\0';
 
 				if (p->p_flag & P_WEXIT)
@@ -540,7 +536,7 @@ int table(cp, args, retval)
 
 			        error = copyin(uap->addr, buff, size);
 				if (error == 0)
-					bcopy(buff, data, size);
+					memcpy(data, buff, size);
 			}
 			else {
 				error = copyout(data, uap->addr, size);

--- a/server/serv/ether_io.c
+++ b/server/serv/ether_io.c
@@ -426,9 +426,7 @@ mach_error_t ether_ioctl(
 			if (ns_nullhost(*ina))
 			    ina->x_host = *(union ns_host *)es->es_addr;
 			else {
-			    bcopy(ina->x_host.c_host,
-				  es->es_addr,
-				  sizeof(es->es_addr));
+			    memcpy(es->es_addr, ina->x_host.c_host, sizeof(es->es_addr));
 			    /*
 			     * Tell hardware to change address XXX
 			     */
@@ -511,8 +509,8 @@ iface_find(char *name)
 		extern int tcp_recvspace;
 
 		if (tcp_recvspace != 0x300 &&
-		    (!bcmp(name, "de", 2) ||
-		     !bcmp(name, "et", 2)))
+		    (!memcmp(name, "de", 2) ||
+		     !memcmp(name, "et", 2)))
 			tcp_recvspace = 0x300;
 	}
 #endif	/* i386 */
@@ -573,7 +571,7 @@ iface_find(char *name)
 	 * Allocate an Ethernet interface structure.
 	 */
 	es = (struct ether_softc *)malloc(sizeof(struct ether_softc));
-	bzero((caddr_t) es, sizeof(struct ether_softc));
+	memset((caddr_t) es, 0, sizeof(struct ether_softc));
 
 	ifp = &es->es_if;
 
@@ -604,7 +602,7 @@ iface_find(char *name)
 	ifp->if_start =		ether_start;
 	ifp->if_ioctl =		ether_ioctl;
 
-	bcopy(if_addr, es->es_addr, sizeof(es->es_addr));
+	memcpy(es->es_addr, if_addr, sizeof(es->es_addr));
 
 	es->es_port = if_port;
 	es->es_reply_port = reply_port;

--- a/server/serv/gprof_support.c
+++ b/server/serv/gprof_support.c
@@ -369,7 +369,7 @@ gprof_start_profiling()
 	 * (c) (re)start pc sampling
 	 */
 	
-	bzero(gprof_pchist, gprof_pchist_size * sizeof(CHUNK));
+	memset(gprof_pchist, 0, gprof_pchist_size * sizeof(CHUNK));
 
 	for (i = 0; i < gprof_pchist_size; i++) {
 		carc = gprof_calls[i];
@@ -487,8 +487,7 @@ bsd_mon_dump(mach_port_t proc_port, boolean_t *intr, char **mon_data, int *mon_d
 		+ gprof_pchist_size * sizeof(CHUNK);
 
 	hist = (CHUNK *) (gh + 1);
-	bcopy((char *)gprof_pchist, (char *)hist,
-	      gprof_pchist_size * sizeof(CHUNK));
+	memcpy((char *)hist, (char *)gprof_pchist, gprof_pchist_size * sizeof(CHUNK));
 
  	hist += gprof_pchist_size;
 	{
@@ -504,7 +503,7 @@ bsd_mon_dump(mach_port_t proc_port, boolean_t *intr, char **mon_data, int *mon_d
 				 * We have to use bcopy since gc might
 				 * not be word-aligned.
 				 */
-				bcopy(ca, gc, sizeof(struct gprof_call));
+				memcpy(gc, ca, sizeof(struct gprof_call));
 				gc++;
 			}
 	}

--- a/server/serv/select.c
+++ b/server/serv/select.c
@@ -116,14 +116,14 @@ mach_error_t s_select(
 
 	assert(pk->k_p == p);
 
-	bzero((caddr_t)obits, sizeof(obits));
+	memset((caddr_t)obits, 0, sizeof(obits));
 	if (nd > FD_SETSIZE)
 		return (EINVAL);
 	if (nd > p->p_fd->fd_nfiles)
 		nd = p->p_fd->fd_nfiles;	/* forgiving; slightly wrong */
 
 	if (tv) {
-		bcopy((void *) tv, (void *) &atv, sizeof(atv));
+		memcpy((void *) &atv, (void *) tv, sizeof(atv));
 
 		if (itimerfix(&atv)) {
 			error = EINVAL;
@@ -177,7 +177,7 @@ done:
 		error = 0;
 #define	putbits(name, x) \
 	if (name) \
-	    bcopy((void *) &obits[x], (void *) name, sizeof(fd_set));
+	    memcpy((void *) name, (void *) &obits[x], sizeof(fd_set));
 
 	if (error == 0) {
 		putbits(in, 0);

--- a/server/serv/serv_fork.c
+++ b/server/serv/serv_fork.c
@@ -226,7 +226,7 @@ void proc_allocate(np)
 		    panic("proc_allocate");
 		*np = (struct proc *) malloc(sizeof(struct proc));
 		assert(*np);
-		bzero(*np, sizeof(struct proc));
+		memset(*np, 0, sizeof(struct proc));
 #if MAP_UAREA
 		alloc_mapped_uarea(*np);
 #endif
@@ -354,10 +354,8 @@ again:
 	 * Start by zeroing the section of proc that is zero-initialized,
 	 * then copy the section that is copied directly from the parent.
 	 */
-	bzero(&p2->p_startzero,
-	    (unsigned) ((caddr_t)&p2->p_endzero - (caddr_t)&p2->p_startzero));
-	bcopy(&p1->p_startcopy, &p2->p_startcopy,
-	    (unsigned) ((caddr_t)&p2->p_endcopy - (caddr_t)&p2->p_startcopy));
+	memset(&p2->p_startzero, 0, (unsigned) ((caddr_t)&p2->p_endzero - (caddr_t)&p2->p_startzero));
+	memcpy(&p2->p_startcopy, &p1->p_startcopy, (unsigned) ((caddr_t)&p2->p_endcopy - (caddr_t)&p2->p_startcopy));
 
 	p2->p_ref = 0;
 	p2->p_servers_count = 0;
@@ -407,8 +405,8 @@ again:
 	    panic("kern_fork");
 	    return 0;
 	}
-	bcopy(p1->p_shared_ro,p2->p_shared_ro,sizeof(struct ushared_ro));
-	bcopy(p1->p_shared_rw,p2->p_shared_rw,sizeof(struct ushared_rw));
+	memcpy(p2->p_shared_ro, p1->p_shared_ro, sizeof(struct ushared_ro));
+	memcpy(p2->p_shared_rw, p1->p_shared_rw, sizeof(struct ushared_rw));
 	p2->p_shared_rw->us_inuse = 0;
 	p2->p_shared_rw->us_debug = 0;
 	share_lock_init(&p2->p_shared_rw->us_lock);
@@ -431,7 +429,7 @@ again:
 	 */
 	MALLOC(p2->p_cred, struct pcred *, sizeof(struct pcred),
 	    M_SUBPROC, M_WAITOK);
-	bcopy(p1->p_cred, p2->p_cred, sizeof(*p2->p_cred));
+	memcpy(p2->p_cred, p1->p_cred, sizeof(*p2->p_cred));
 	p2->p_cred->p_refcnt = 1;
 	crhold(p1->p_ucred);
 
@@ -451,7 +449,7 @@ again:
 	 */
 #if	MAP_UAREA
 	p2->p_limit = &p2->p_shared_ro->us_limit;
-	bcopy(p1->p_limit, p2->p_limit, sizeof(*p2->p_limit));
+	memcpy(p2->p_limit, p1->p_limit, sizeof(*p2->p_limit));
 #else
 	if (p1->p_limit->p_lflags & PL_SHAREMOD)
 		p2->p_limit = limcopy(p1->p_limit);

--- a/server/serv/serv_syscalls.c
+++ b/server/serv/serv_syscalls.c
@@ -239,7 +239,7 @@ bsd_pid_by_task(
 	    len = strlen(sp->p_comm);
 	    if (*commlen < len)
 		len = *commlen;
-	    bcopy(sp->p_comm, comm, len);
+	    memcpy(comm, sp->p_comm, len);
 	    *commlen = len;
 	    /* get rid of the send right (consume on success) */
 	    (void) mach_port_deallocate(mach_task_self(), task);

--- a/server/serv/server_init.c
+++ b/server/serv/server_init.c
@@ -455,14 +455,14 @@ void parse_arguments(
 	} else
 		strcpy(server_dir, argv[1]);
 
-	if (bcmp(server_dir, dev_prefix, strlen(dev_prefix))) {
+	if (memcmp(server_dir, dev_prefix, strlen(dev_prefix))) {
 		dprintf("(lites): server_dir(%s) ignored.  It does not start with %s\r\n",
 			server_dir, dev_prefix);
 		dprintf("(lites): TILT TILT!\r\n");
 	} else {
 		int len = strlen(rootname);
 
-		if (bcmp(server_dir+5, rootname, len)) {
+		if (memcmp(server_dir+5, rootname, len)) {
 			char *cp = server_dir+5;
 			while (*cp++ != '/') ;
 			len = cp - (server_dir + 5) - 1;

--- a/server/serv/tape_io.c
+++ b/server/serv/tape_io.c
@@ -145,7 +145,7 @@ tape_open(dev_t dev, int flag, int devtype, struct proc *p)
   
   if (TAPE_REWINDS(dev)) {
     struct tape_status ts;
-    bzero(&ts, sizeof(ts));
+    memset(&ts, 0, sizeof(ts));
     ts.flags = TAPE_FLG_REWIND;
     (void) device_set_status(device_port,
 			     TAPE_STATUS,

--- a/server/serv/ux_syscall.c
+++ b/server/serv/ux_syscall.c
@@ -328,12 +328,12 @@ rpsleep(int (*rsleep)(), int arg1, int arg2, char *mesg1, char *mesg2)
 	uprintf("[%s: %s%s, pausing ...]\r\n", u.u_comm, mesg1, mesg2);
     }
 
-    bcopy((caddr_t)&u.u_qsave, (caddr_t)&lsave, sizeof(lsave));
+    memcpy((caddr_t)&lsave, (caddr_t)&u.u_qsave, sizeof(lsave));
     if (setjmp(&u.u_qsave) == 0)
 	(*rsleep)(arg1, arg2);
     else
 	ret = FALSE;
-    bcopy((caddr_t)&lsave, (caddr_t)&u.u_qsave, sizeof(lsave));
+    memcpy((caddr_t)&u.u_qsave, (caddr_t)&lsave, sizeof(lsave));
 
     if ((u.u_rpswhich&URPW_NOTIFY) == 0)
 	rpcont();

--- a/server/serv/vm_glue.c
+++ b/server/serv/vm_glue.c
@@ -87,7 +87,7 @@ static struct vmspace *vmspace_fork(struct vmspace *ovs, struct proc *p2)
 #else
 	vs = &p2->p_realvmspace;
 #endif
-	bcopy(ovs, vs, sizeof(*vs));
+	memcpy(vs, ovs, sizeof(*vs));
 	vs->vm_refcnt = 1;
 	vs->vm_shm = 0;
 	return vs;
@@ -134,11 +134,9 @@ vm_fork(p1, p2, isvfork)
 	p2->p_stats = &up->u_stats;
 	p2->p_sigacts = &up->u_sigacts;
 	up->u_sigacts = *p1->p_sigacts;
-	bzero(&up->u_stats.pstat_startzero,
-	    (unsigned) ((caddr_t)&up->u_stats.pstat_endzero -
+	memset(&up->u_stats.pstat_startzero, 0, (unsigned) ((caddr_t)&up->u_stats.pstat_endzero -
 	    (caddr_t)&up->u_stats.pstat_startzero));
-	bcopy(&p1->p_stats->pstat_startcopy, &up->u_stats.pstat_startcopy,
-	    ((caddr_t)&up->u_stats.pstat_endcopy -
+	memcpy(&up->u_stats.pstat_startcopy, &p1->p_stats->pstat_startcopy, ((caddr_t)&up->u_stats.pstat_endcopy -
 	     (caddr_t)&up->u_stats.pstat_startcopy));
 
 #ifdef LITES

--- a/server/serv/zalloc.c
+++ b/server/serv/zalloc.c
@@ -371,7 +371,7 @@ kern_return_t bsd_zone_info(
 		used = max_zones * sizeof *names;
 
 		if (used != names_size)
-			bzero((char *) (names_addr + used), names_size - used);
+			memset((char *) (names_addr + used), 0, names_size - used);
 
 		kr = vm_map_copyin(ipc_kernel_map, names_addr, names_size,
 				   TRUE, &copy);
@@ -390,7 +390,7 @@ kern_return_t bsd_zone_info(
 		used = max_zones * sizeof *info;
 
 		if (used != info_size)
-			bzero((char *) (info_addr + used), info_size - used);
+			memset((char *) (info_addr + used), 0, info_size - used);
 
 		kr = vm_map_copyin(ipc_kernel_map, info_addr, info_size,
 				   TRUE, &copy);

--- a/server/ufs/ext2fs/ext2_inode.c
+++ b/server/ufs/ext2fs/ext2_inode.c
@@ -183,7 +183,7 @@ printf("ext2_truncate called %d to %d\n", VTOI(ovp)->i_number, ap->a_length);
 		if (length != 0)
 			panic("ext2_truncate: partial truncate of symlink");
 #endif
-		bzero((char *)&oip->i_shortlink, (u_int)oip->i_size);
+		memset((char *)&oip->i_shortlink, 0, (u_int)oip->i_size);
 		oip->i_size = 0;
 		oip->i_flag |= IN_CHANGE | IN_UPDATE;
 		return (VOP_UPDATE(ovp, &tv, &tv, 1));
@@ -245,7 +245,7 @@ printf("ext2_truncate called %d to %d\n", VTOI(ovp)->i_number, ap->a_length);
 		oip->i_size = length;
 		size = blksize(fs, oip, lbn);
 		(void) vnode_pager_uncache(ovp);
-		bzero((char *)bp->b_data + offset, (u_int)(size - offset));
+		memset((char *)bp->b_data + offset, 0, (u_int)(size - offset));
 		allocbuf(bp, size);
 		if (aflags & IO_SYNC)
 			bwrite(bp);
@@ -269,7 +269,7 @@ printf("ext2_truncate called %d to %d\n", VTOI(ovp)->i_number, ap->a_length);
 	 * will be returned to the free list.  lastiblock values are also
 	 * normalized to -1 for calls to ext2_indirtrunc below.
 	 */
-	bcopy((caddr_t)&oip->i_db[0], (caddr_t)oldblks, sizeof oldblks);
+	memcpy((caddr_t)oldblks, (caddr_t)&oip->i_db[0], sizeof oldblks);
 	for (level = TRIPLE; level >= SINGLE; level--)
 		if (lastiblock[level] < 0) {
 			oip->i_ib[level] = 0;
@@ -286,8 +286,8 @@ printf("ext2_truncate called %d to %d\n", VTOI(ovp)->i_number, ap->a_length);
 	 * Note that we save the new block configuration so we can check it
 	 * when we are done.
 	 */
-	bcopy((caddr_t)&oip->i_db[0], (caddr_t)newblks, sizeof newblks);
-	bcopy((caddr_t)oldblks, (caddr_t)&oip->i_db[0], sizeof oldblks);
+	memcpy((caddr_t)newblks, (caddr_t)&oip->i_db[0], sizeof newblks);
+	memcpy((caddr_t)&oip->i_db[0], (caddr_t)oldblks, sizeof oldblks);
 	oip->i_size = osize;
 	vflags = ((length > 0) ? V_SAVE : 0) | V_SAVEMETA;
 	allerror = vinvalbuf(ovp, vflags, ap->a_cred, ap->a_p, 0, 0);
@@ -458,9 +458,8 @@ ext2_indirtrunc(ip, lbn, dbn, lastbn, level, countp)
 
 	bap = (daddr_t *)bp->b_data;
 	MALLOC(copy, daddr_t *, fs->s_blocksize, M_TEMP, M_WAITOK);
-	bcopy((caddr_t)bap, (caddr_t)copy, (u_int)fs->s_blocksize);
-	bzero((caddr_t)&bap[last + 1],
-	  (u_int)(NINDIR(fs) - (last + 1)) * sizeof (daddr_t));
+	memcpy((caddr_t)copy, (caddr_t)bap, (u_int)fs->s_blocksize);
+	memset((caddr_t)&bap[last + 1], 0, (u_int)(NINDIR(fs) - (last + 1)) * sizeof (daddr_t));
 	if (last == -1)
 		bp->b_flags |= B_INVAL;
 	error = bwrite(bp);

--- a/server/ufs/ext2fs/ext2_lookup.c
+++ b/server/ufs/ext2fs/ext2_lookup.c
@@ -100,7 +100,7 @@ ext2_dirconv2ffs( e2dir, ffsdir)
 {
 	struct dirent 	de;
 
-	bzero(&de, sizeof(struct dirent));
+	memset(&de, 0, sizeof(struct dirent));
 	de.d_fileno = e2dir->inode;
 	de.d_namlen = e2dir->name_len;
 
@@ -116,7 +116,7 @@ ext2_dirconv2ffs( e2dir, ffsdir)
 	   we think is right
 	 */
 	de.d_reclen = (de.d_namlen+8+1+3) & ~3;
-	bcopy(&de, ffsdir, de.d_reclen);
+	memcpy(ffsdir, &de, de.d_reclen);
 #endif
 
 #if 0
@@ -468,7 +468,7 @@ searchloop:
 		if (ep->inode) {
 			namlen = ep->name_len;
 			if (namlen == cnp->cn_namelen &&
-			    !bcmp(cnp->cn_nameptr, ep->name,
+			    !memcmp(cnp->cn_nameptr, ep->name,
 				(unsigned)namlen)) {
 				/*
 				 * Save directory entry's inode number and
@@ -783,7 +783,7 @@ ext2_direnter(ip, dvp, cnp)
 	dp = VTOI(dvp);
 	newdir.inode = ip->i_number;
 	newdir.name_len = cnp->cn_namelen;
-	bcopy(cnp->cn_nameptr, newdir.name, (unsigned)cnp->cn_namelen + 1);
+	memcpy(newdir.name, cnp->cn_nameptr, (unsigned)cnp->cn_namelen + 1);
 	newentrysize = EXT2_DIR_REC_LEN(newdir.name_len);
 	if (dp->i_count == 0) {
 		/*
@@ -862,7 +862,7 @@ ext2_direnter(ip, dvp, cnp)
 		dsize = EXT2_DIR_REC_LEN(ep->name_len);
 		spacefree += nep->rec_len - dsize;
 		loc += nep->rec_len;
-		bcopy((caddr_t)nep, (caddr_t)ep, dsize);
+		memcpy((caddr_t)ep, (caddr_t)nep, dsize);
 	}
 	/*
 	 * Update the pointer fields in the previous entry (if any),
@@ -879,7 +879,7 @@ ext2_direnter(ip, dvp, cnp)
 		ep->rec_len = dsize;
 		ep = (struct ext2_dir_entry *)((char *)ep + dsize);
 	}
-	bcopy((caddr_t)&newdir, (caddr_t)ep, (u_int)newentrysize);
+	memcpy((caddr_t)ep, (caddr_t)&newdir, (u_int)newentrysize);
 	error = VOP_BWRITE(bp);
 	dp->i_flag |= IN_CHANGE | IN_UPDATE;
 	if (!error && dp->i_endoff && dp->i_endoff < dp->i_size)

--- a/server/ufs/ffs/ffs_alloc.c
+++ b/server/ufs/ffs/ffs_alloc.c
@@ -206,7 +206,7 @@ ffs_realloccg(ip, lbprev, bpref, osize, nsize, cred, bpp)
 		ip->i_flag |= IN_CHANGE | IN_UPDATE;
 		allocbuf(bp, nsize);
 		bp->b_flags |= B_DONE;
-		bzero((char *)bp->b_data + osize, (u_int)nsize - osize);
+		memset((char *)bp->b_data + osize, 0, (u_int)nsize - osize);
 		*bpp = bp;
 		return (0);
 	}
@@ -272,7 +272,7 @@ ffs_realloccg(ip, lbprev, bpref, osize, nsize, cred, bpp)
 		ip->i_flag |= IN_CHANGE | IN_UPDATE;
 		allocbuf(bp, nsize);
 		bp->b_flags |= B_DONE;
-		bzero((char *)bp->b_data + osize, (u_int)nsize - osize);
+		memset((char *)bp->b_data + osize, 0, (u_int)nsize - osize);
 		*bpp = bp;
 		return (0);
 	}

--- a/server/ufs/ffs/ffs_inode.c
+++ b/server/ufs/ffs/ffs_inode.c
@@ -182,7 +182,7 @@ ffs_truncate(ap)
 		if (length != 0)
 			panic("ffs_truncate: partial truncate of symlink");
 #endif
-		bzero((char *)&oip->i_shortlink, (u_int)oip->i_size);
+		memset((char *)&oip->i_shortlink, 0, (u_int)oip->i_size);
 		oip->i_size = 0;
 		oip->i_flag |= IN_CHANGE | IN_UPDATE;
 		return (VOP_UPDATE(ovp, &tv, &tv, 1));
@@ -242,7 +242,7 @@ ffs_truncate(ap)
 		oip->i_size = length;
 		size = blksize(fs, oip, lbn);
 		(void) vnode_pager_uncache(ovp);
-		bzero((char *)bp->b_data + offset, (u_int)(size - offset));
+		memset((char *)bp->b_data + offset, 0, (u_int)(size - offset));
 		allocbuf(bp, size);
 		if (aflags & IO_SYNC)
 			bwrite(bp);
@@ -266,7 +266,7 @@ ffs_truncate(ap)
 	 * will be returned to the free list.  lastiblock values are also
 	 * normalized to -1 for calls to ffs_indirtrunc below.
 	 */
-	bcopy((caddr_t)&oip->i_db[0], (caddr_t)oldblks, sizeof oldblks);
+	memcpy((caddr_t)oldblks, (caddr_t)&oip->i_db[0], sizeof oldblks);
 	for (level = TRIPLE; level >= SINGLE; level--)
 		if (lastiblock[level] < 0) {
 			oip->i_ib[level] = 0;
@@ -283,8 +283,8 @@ ffs_truncate(ap)
 	 * Note that we save the new block configuration so we can check it
 	 * when we are done.
 	 */
-	bcopy((caddr_t)&oip->i_db[0], (caddr_t)newblks, sizeof newblks);
-	bcopy((caddr_t)oldblks, (caddr_t)&oip->i_db[0], sizeof oldblks);
+	memcpy((caddr_t)newblks, (caddr_t)&oip->i_db[0], sizeof newblks);
+	memcpy((caddr_t)&oip->i_db[0], (caddr_t)oldblks, sizeof oldblks);
 	oip->i_size = osize;
 	vflags = ((length > 0) ? V_SAVE : 0) | V_SAVEMETA;
 	allerror = vinvalbuf(ovp, vflags, ap->a_cred, ap->a_p, 0, 0);
@@ -454,9 +454,8 @@ ffs_indirtrunc(ip, lbn, dbn, lastbn, level, countp)
 
 	bap = (daddr_t *)bp->b_data;
 	MALLOC(copy, daddr_t *, fs->fs_bsize, M_TEMP, M_WAITOK);
-	bcopy((caddr_t)bap, (caddr_t)copy, (u_int)fs->fs_bsize);
-	bzero((caddr_t)&bap[last + 1],
-	  (u_int)(NINDIR(fs) - (last + 1)) * sizeof (daddr_t));
+	memcpy((caddr_t)copy, (caddr_t)bap, (u_int)fs->fs_bsize);
+	memset((caddr_t)&bap[last + 1], 0, (u_int)(NINDIR(fs) - (last + 1)) * sizeof (daddr_t));
 	if (last == -1)
 		bp->b_flags |= B_INVAL;
 	error = bwrite(bp);

--- a/server/ufs/lfs/lfs_alloc.c
+++ b/server/ufs/lfs/lfs_alloc.c
@@ -125,7 +125,7 @@ lfs_valloc(ap)
 
 	ip = VTOI(vp);
 	/* Zero out the direct and indirect block addresses. */
-	bzero(&ip->i_din, sizeof(struct dinode));
+	memset(&ip->i_din, 0, sizeof(struct dinode));
 	ip->i_din.di_inumber = new_ino;
 
 	/* Set a new generation number for this inode. */

--- a/server/ufs/lfs/lfs_inode.c
+++ b/server/ufs/lfs/lfs_inode.c
@@ -177,7 +177,7 @@ lfs_truncate(ap)
 		if (length != 0)
 			panic("lfs_truncate: partial truncate of symlink");
 #endif
-		bzero((char *)&ip->i_shortlink, (u_int)ip->i_size);
+		memset((char *)&ip->i_shortlink, 0, (u_int)ip->i_size);
 		ip->i_size = 0;
 		ip->i_flag |= IN_CHANGE | IN_UPDATE;
 		return (VOP_UPDATE(vp, &tv, &tv, 0));
@@ -220,7 +220,7 @@ lfs_truncate(ap)
 		ip->i_size = length;
 		size = blksize(fs);
 		(void)vnode_pager_uncache(vp);
-		bzero((char *)bp->b_data + offset, (u_int)(size - offset));
+		memset((char *)bp->b_data + offset, 0, (u_int)(size - offset));
 		allocbuf(bp, size);
 		if (e1 = VOP_BWRITE(bp))
 			return (e1);
@@ -274,9 +274,9 @@ lfs_truncate(ap)
 				if (inp->in_off == 0)
 					brelse (bp);
 				else {
-					bzero((daddr_t *)bp->b_data +
-					    inp->in_off, fs->lfs_bsize - 
-					    inp->in_off * sizeof(daddr_t));
+                                        memset((daddr_t *)bp->b_data +
+                                            inp->in_off, 0, fs->lfs_bsize -
+                                            inp->in_off * sizeof(daddr_t));
 					if (e1 = VOP_BWRITE(bp)) 
 						return (e1);
 				}

--- a/server/ufs/lfs/lfs_segment.c
+++ b/server/ufs/lfs/lfs_segment.c
@@ -682,7 +682,7 @@ lfs_initseg(fs)
 	*sp->cbpp = lfs_newbuf(VTOI(fs->lfs_ivnode)->i_devvp, fs->lfs_offset,
 	     LFS_SUMMARY_SIZE);
 	sp->segsum = (*sp->cbpp)->b_data;
-	bzero(sp->segsum, LFS_SUMMARY_SIZE);
+	memset(sp->segsum, 0, LFS_SUMMARY_SIZE);
 	sp->start_bpp = ++sp->cbpp;
 	fs->lfs_offset += LFS_SUMMARY_SIZE / DEV_BSIZE;
 
@@ -857,7 +857,7 @@ lfs_writeseg(fs, sp)
 				if (copyin(bp->b_saveaddr, p, bp->b_bcount))
 					panic("lfs_writeseg: copyin failed");
 			} else
-				bcopy(bp->b_data, p, bp->b_bcount);
+				memcpy(p, bp->b_data, bp->b_bcount);
 			p += bp->b_bcount;
 			if (bp->b_flags & B_LOCKED)
 				--locked_queue_count;
@@ -1006,7 +1006,7 @@ lfs_newbuf(vp, daddr, size)
 
 	nbytes = roundup(size, DEV_BSIZE);
 	bp = malloc(sizeof(struct buf), M_SEGMENT, M_WAITOK);
-	bzero(bp, sizeof(struct buf));
+	memset(bp, 0, sizeof(struct buf));
 	if (nbytes)
 		bp->b_data = malloc(nbytes, M_SEGMENT, M_WAITOK);
 	bgetvp(vp, bp);

--- a/server/ufs/lfs/lfs_vfsops.c
+++ b/server/ufs/lfs/lfs_vfsops.c
@@ -164,21 +164,19 @@ lfs_mount(mp, path, data, ndp, p)
 	fs = ump->um_lfs;					/* LFS */
 #ifdef NOTLFS							/* LFS */
 	(void) copyinstr(path, fs->fs_fsmnt, sizeof(fs->fs_fsmnt) - 1, &size);
-	bzero(fs->fs_fsmnt + size, sizeof(fs->fs_fsmnt) - size);
-	bcopy((caddr_t)fs->fs_fsmnt, (caddr_t)mp->mnt_stat.f_mntonname,
-	    MNAMELEN);
+	memset(fs->fs_fsmnt + size, 0, sizeof(fs->fs_fsmnt) - size);
+	memcpy((caddr_t)mp->mnt_stat.f_mntonname, (caddr_t)fs->fs_fsmnt, MNAMELEN);
 	(void) copyinstr(args.fspec, mp->mnt_stat.f_mntfromname, MNAMELEN - 1,
 	    &size);
-	bzero(mp->mnt_stat.f_mntfromname + size, MNAMELEN - size);
+	memset(mp->mnt_stat.f_mntfromname + size, 0, MNAMELEN - size);
 	(void) ufs_statfs(mp, &mp->mnt_stat, p);
 #else
 	(void)copyinstr(path, fs->lfs_fsmnt, sizeof(fs->lfs_fsmnt) - 1, &size);
-	bzero(fs->lfs_fsmnt + size, sizeof(fs->lfs_fsmnt) - size);
-	bcopy((caddr_t)fs->lfs_fsmnt, (caddr_t)mp->mnt_stat.f_mntonname,
-	    MNAMELEN);
+	memset(fs->lfs_fsmnt + size, 0, sizeof(fs->lfs_fsmnt) - size);
+	memcpy((caddr_t)mp->mnt_stat.f_mntonname, (caddr_t)fs->lfs_fsmnt, MNAMELEN);
 	(void) copyinstr(args.fspec, mp->mnt_stat.f_mntfromname, MNAMELEN - 1,
 	    &size);
-	bzero(mp->mnt_stat.f_mntfromname + size, MNAMELEN - size);
+	memset(mp->mnt_stat.f_mntfromname + size, 0, MNAMELEN - size);
 	(void) lfs_statfs(mp, &mp->mnt_stat, p);
 #endif
 	return (0);
@@ -251,7 +249,7 @@ lfs_mountfs(devvp, mp, p)
 	/* Allocate the mount structure, copy the superblock into it. */
 	ump = (struct ufsmount *)malloc(sizeof *ump, M_UFSMNT, M_WAITOK);
 	fs = ump->um_lfs = malloc(sizeof(struct lfs), M_UFSMNT, M_WAITOK);
-	bcopy(bp->b_data, fs, sizeof(struct lfs));
+	memcpy(fs, bp->b_data, sizeof(struct lfs));
 	if (sizeof(struct lfs) < LFS_SBPAD)			/* XXX why? */
 		bp->b_flags |= B_INVAL;
 	brelse(bp);
@@ -397,10 +395,8 @@ lfs_statfs(mp, sbp, p)
 	sbp->f_files = fs->lfs_nfiles;
 	sbp->f_ffree = sbp->f_bfree * INOPB(fs);
 	if (sbp != &mp->mnt_stat) {
-		bcopy((caddr_t)mp->mnt_stat.f_mntonname,
-			(caddr_t)&sbp->f_mntonname[0], MNAMELEN);
-		bcopy((caddr_t)mp->mnt_stat.f_mntfromname,
-			(caddr_t)&sbp->f_mntfromname[0], MNAMELEN);
+		memcpy((caddr_t)&sbp->f_mntonname[0], (caddr_t)mp->mnt_stat.f_mntonname, MNAMELEN);
+		memcpy((caddr_t)&sbp->f_mntfromname[0], (caddr_t)mp->mnt_stat.f_mntfromname, MNAMELEN);
 	}
 	strncpy(sbp->f_fstypename, mp->mnt_op->vfs_name, MFSNAMELEN);
 	return (0);

--- a/server/ufs/mfs/mfs_vfsops.c
+++ b/server/ufs/mfs/mfs_vfsops.c
@@ -105,7 +105,7 @@ mfs_mountroot()
 		panic("mfs_mountroot: can't setup bdevvp's");
 
 	mp = malloc((u_long)sizeof(struct mount), M_MOUNT, M_WAITOK);
-	bzero((char *)mp, (u_long)sizeof(struct mount));
+	memset((char *)mp, 0, (u_long)sizeof(struct mount));
 	mp->mnt_op = &mfs_vfsops;
 	mp->mnt_flag = MNT_RDONLY;
 	mfsp = malloc(sizeof *mfsp, M_MFSNODE, M_WAITOK);
@@ -133,13 +133,12 @@ mfs_mountroot()
 	mp->mnt_vnodecovered = NULLVP;
 	ump = VFSTOUFS(mp);
 	fs = ump->um_fs;
-	bzero(fs->fs_fsmnt, sizeof(fs->fs_fsmnt));
+	memset(fs->fs_fsmnt, 0, sizeof(fs->fs_fsmnt));
 	fs->fs_fsmnt[0] = '/';
-	bcopy((caddr_t)fs->fs_fsmnt, (caddr_t)mp->mnt_stat.f_mntonname,
-	    MNAMELEN);
+	memcpy((caddr_t)mp->mnt_stat.f_mntonname, (caddr_t)fs->fs_fsmnt, MNAMELEN);
 	(void) copystr(ROOTNAME, mp->mnt_stat.f_mntfromname, MNAMELEN - 1,
 	    &size);
-	bzero(mp->mnt_stat.f_mntfromname + size, MNAMELEN - size);
+	memset(mp->mnt_stat.f_mntfromname + size, 0, MNAMELEN - size);
 	(void)ffs_statfs(mp, &mp->mnt_stat, p);
 	vfs_unlock(mp);
 	inittodr((time_t)0);
@@ -240,12 +239,11 @@ mfs_mount(mp, path, data, ndp, p)
 	ump = VFSTOUFS(mp);
 	fs = ump->um_fs;
 	(void) copyinstr(path, fs->fs_fsmnt, sizeof(fs->fs_fsmnt) - 1, &size);
-	bzero(fs->fs_fsmnt + size, sizeof(fs->fs_fsmnt) - size);
-	bcopy((caddr_t)fs->fs_fsmnt, (caddr_t)mp->mnt_stat.f_mntonname,
-		MNAMELEN);
+	memset(fs->fs_fsmnt + size, 0, sizeof(fs->fs_fsmnt) - size);
+	memcpy((caddr_t)mp->mnt_stat.f_mntonname, (caddr_t)fs->fs_fsmnt, MNAMELEN);
 	(void) copyinstr(args.fspec, mp->mnt_stat.f_mntfromname, MNAMELEN - 1,
 		&size);
-	bzero(mp->mnt_stat.f_mntfromname + size, MNAMELEN - size);
+	memset(mp->mnt_stat.f_mntfromname + size, 0, MNAMELEN - size);
 	(void) mfs_statfs(mp, &mp->mnt_stat, p);
 	return (0);
 }

--- a/server/ufs/mfs/mfs_vnops.c
+++ b/server/ufs/mfs/mfs_vnops.c
@@ -169,9 +169,9 @@ mfs_strategy(ap)
 
 		base = mfsp->mfs_baseoff + (bp->b_blkno << DEV_BSHIFT);
 		if (bp->b_flags & B_READ)
-			bcopy(base, bp->b_data, bp->b_bcount);
+			memcpy(bp->b_data, base, bp->b_bcount);
 		else
-			bcopy(bp->b_data, base, bp->b_bcount);
+			memcpy(base, bp->b_data, bp->b_bcount);
 		biodone(bp);
 	} else if (mfsp->mfs_pid == p->p_pid) {
 		mfs_doio(bp, mfsp->mfs_baseoff);

--- a/server/ufs/minixfs/minixfs_lookup.c
+++ b/server/ufs/minixfs/minixfs_lookup.c
@@ -372,7 +372,7 @@ searchloop:
 */
 			namlen = dentryrovidnamelen;
 			if (namlen == cnp->cn_namelen &&
-			    !bcmp(cnp->cn_nameptr, ep->name,
+			    !memcmp(cnp->cn_nameptr, ep->name,
 				(unsigned)namlen)) {
 				/*
 				 * Save directory entry's inode number and
@@ -718,7 +718,7 @@ minixfs_direnter(ip, dvp, cnp)
 	dp = VTOI(dvp);
 	newdir.d_ino = ip->i_number;
 	newdir.d_namlen = cnp->cn_namelen;
-	bcopy(cnp->cn_nameptr, newdir.d_name, (unsigned)cnp->cn_namelen + 1);
+	memcpy(newdir.d_name, cnp->cn_nameptr, (unsigned)cnp->cn_namelen + 1);
 	if (dvp->v_mount->mnt_maxsymlinklen > 0)
 		newdir.d_type = IFTODT(ip->i_mode);
 	else {
@@ -807,7 +807,7 @@ minixfs_direnter(ip, dvp, cnp)
 		dsize = DIRSIZ(FSFMT(dvp), nep);
 		spacefree += nep->d_reclen - dsize;
 		loc += nep->d_reclen;
-		bcopy((caddr_t)nep, (caddr_t)ep, dsize);
+		memcpy((caddr_t)ep, (caddr_t)nep, dsize);
 	}
 	/*
 	 * Update the pointer fields in the previous entry (if any),
@@ -824,7 +824,7 @@ minixfs_direnter(ip, dvp, cnp)
 		ep->d_reclen = dsize;
 		ep = (struct direct *)((char *)ep + dsize);
 	}
-	bcopy((caddr_t)&newdir, (caddr_t)ep, (u_int)newentrysize);
+	memcpy((caddr_t)ep, (caddr_t)&newdir, (u_int)newentrysize);
 	error = VOP_BWRITE(bp);
 	dp->i_flag |= IN_CHANGE | IN_UPDATE;
 	if (!error && dp->i_endoff && dp->i_endoff < dp->i_size)

--- a/server/ufs/minixfs/minixfs_vfsops.c
+++ b/server/ufs/minixfs/minixfs_vfsops.c
@@ -120,7 +120,7 @@ minixfs_mountroot()
 		panic("minixs_mountroot: can't setup bdevvp's");
 
 	mp = bsd_malloc((u_long)sizeof(struct mount), M_MOUNT, M_WAITOK);
-	bzero((char *)mp, (u_long)sizeof(struct mount));
+	memset((char *)mp, 0, (u_long)sizeof(struct mount));
 	mp->mnt_op = &minixfs_vfsops;
 	mp->mnt_flag = MNT_RDONLY;
 	if (error = minixfs_mountfs(rootvp, mp, p)) {
@@ -141,13 +141,12 @@ minixfs_mountroot()
 	fs 
             =
         ump->um_minixfs;
-	bzero(fs->fs_fsmnt, sizeof(fs->fs_fsmnt));
+	memset(fs->fs_fsmnt, 0, sizeof(fs->fs_fsmnt));
 	fs->fs_fsmnt[0] = '/';
-	bcopy((caddr_t)fs->fs_fsmnt, (caddr_t)mp->mnt_stat.f_mntonname,
-	    MNAMELEN);
+	memcpy((caddr_t)mp->mnt_stat.f_mntonname, (caddr_t)fs->fs_fsmnt, MNAMELEN);
 	(void) copystr(ROOTNAME, mp->mnt_stat.f_mntfromname, MNAMELEN - 1,
 	    &size);
-	bzero(mp->mnt_stat.f_mntfromname + size, MNAMELEN - size);
+	memset(mp->mnt_stat.f_mntfromname + size, 0, MNAMELEN - size);
 	(void)minixfs_statfs(mp, &mp->mnt_stat, p);
 	vfs_unlock(mp);
 	/* inittodr(fs->fs_time); XXX: we need this too */
@@ -271,7 +270,7 @@ minixfs_vget(mp, ino, vpp)
  * Dont forget, that the MINIX fs's inode size is less than
  * the inode size of the FFS/LFS!
  */
-	bzero((caddr_t)ip, sizeof(struct inode));
+	memset((caddr_t)ip, 0, sizeof(struct inode));
 	vp->v_data = ip;
 	ip->i_vnode = vp;
 	ip->i_fs = fs = ump->um_fs;
@@ -303,7 +302,7 @@ minixfs_vget(mp, ino, vpp)
 		*vpp = NULL;
 		return (error);
 	}
-	bcopy((struct minix_inode *)bp->b_data + minix_itoo(fs, ino), &ip->i_din, sizeof(struct minix_inode));
+	memcpy(ino), (struct minix_inode *)bp->b_data + minix_itoo(fs, &ip->i_din, sizeof(struct minix_inode));
 	brelse(bp);
 
 	/*
@@ -453,12 +452,11 @@ minixfs_mount(mp, path, data, ndp, p)
 	ump = VFSTOUFS(mp);
 	fs = ump->um_fs;
 	(void) copyinstr(path, fs->fs_fsmnt, sizeof(fs->fs_fsmnt) - 1, &size);
-	bzero(fs->fs_fsmnt + size, sizeof(fs->fs_fsmnt) - size);
-	bcopy((caddr_t)fs->fs_fsmnt, (caddr_t)mp->mnt_stat.f_mntonname,
-	    MNAMELEN);
+	memset(fs->fs_fsmnt + size, 0, sizeof(fs->fs_fsmnt) - size);
+	memcpy((caddr_t)mp->mnt_stat.f_mntonname, (caddr_t)fs->fs_fsmnt, MNAMELEN);
 	(void) copyinstr(args.fspec, mp->mnt_stat.f_mntfromname, MNAMELEN - 1, 
 	    &size);
-	bzero(mp->mnt_stat.f_mntfromname + size, MNAMELEN - size);
+	memset(mp->mnt_stat.f_mntfromname + size, 0, MNAMELEN - size);
 	(void)minixfs_statfs(mp, &mp->mnt_stat, p);
 	return (0);
 }
@@ -522,13 +520,13 @@ minixfs_mountfs(devvp, mp, p)
 		goto out;
 	}
 	ump = bsd_malloc(sizeof *ump, M_UFSMNT, M_WAITOK);
-	bzero((caddr_t)ump, sizeof *ump);
+	memset((caddr_t)ump, 0, sizeof *ump);
 	ump->um_minixfs = bsd_malloc((u_long)sizeof(*es), M_UFSMNT,
 	    M_WAITOK);
 
 	/* XXX convert es to fs */
 }
-	bcopy(bp->b_data, ump->um_fs, (u_int)(sizeof(*es /* minix_super_block */)));
+	memcpy(ump->um_fs, bp->b_data, (u_int)(sizeof(*es /* minix_super_block */)));
 	brelse(bp);
 	bp = NULL;
 	es = ump->um_fs; /*  we copied it with bcopy */
@@ -626,10 +624,8 @@ minixfs_statfs(mp, sbp, p)
 	sbp->f_files =  fs->s_ninodes - MINIX_ROOTINO; /* NEED MINIX */
 	sbp->f_ffree = 0; /* free file inodes in fs */
 	if (sbp != &mp->mnt_stat) {
-		bcopy((caddr_t)mp->mnt_stat.f_mntonname,
-			(caddr_t)&sbp->f_mntonname[0], MNAMELEN);
-		bcopy((caddr_t)mp->mnt_stat.f_mntfromname,
-			(caddr_t)&sbp->f_mntfromname[0], MNAMELEN);
+		memcpy((caddr_t)&sbp->f_mntonname[0], (caddr_t)mp->mnt_stat.f_mntonname, MNAMELEN);
+		memcpy((caddr_t)&sbp->f_mntfromname[0], (caddr_t)mp->mnt_stat.f_mntfromname, MNAMELEN);
 	}
 	strncpy(sbp->f_fstypename, mp->mnt_op->vfs_name, MFSNAMELEN);	
 	return (0);
@@ -731,7 +727,7 @@ minixfs_sbupdate(mp, waitfor)
 	int i, size, error = 0;
 
 	bp = getblk(mp->um_devvp, MINIX_SUPER_BLOCK, MINIX_BLOCK_SIZE, 0, 0);
-	bcopy((caddr_t)fs, bp->b_data, sizeof(struct minix_super_block));
+	memcpy(bp->b_data, (caddr_t)fs, sizeof(struct minix_super_block));
 	if (waitfor == MNT_WAIT)
 		error = bwrite(bp);
 	else

--- a/server/ufs/ufs/ufs_lockf.c
+++ b/server/ufs/ufs/ufs_lockf.c
@@ -631,7 +631,7 @@ lf_split(lock1, lock2)
 	 * the encompassing lock
 	 */
 	MALLOC(splitlock, struct lockf *, sizeof *splitlock, M_LOCKF, M_WAITOK);
-	bcopy((caddr_t)lock1, (caddr_t)splitlock, sizeof *splitlock);
+	memcpy((caddr_t)splitlock, (caddr_t)lock1, sizeof *splitlock);
 	splitlock->lf_start = lock2->lf_end + 1;
 	splitlock->lf_block = NOLOCKF;
 	lock1->lf_end = lock2->lf_start - 1;

--- a/server/ufs/ufs/ufs_lookup.c
+++ b/server/ufs/ufs/ufs_lookup.c
@@ -335,7 +335,7 @@ searchloop:
 				namlen = ep->d_namlen;
 #			endif
 			if (namlen == cnp->cn_namelen &&
-			    !bcmp(cnp->cn_nameptr, ep->d_name,
+			    !memcmp(cnp->cn_nameptr, ep->d_name,
 				(unsigned)namlen)) {
 				/*
 				 * Save directory entry's inode number and
@@ -663,7 +663,7 @@ ufs_direnter(ip, dvp, cnp)
 	dp = VTOI(dvp);
 	newdir.d_ino = ip->i_number;
 	newdir.d_namlen = cnp->cn_namelen;
-	bcopy(cnp->cn_nameptr, newdir.d_name, (unsigned)cnp->cn_namelen + 1);
+	memcpy(newdir.d_name, cnp->cn_nameptr, (unsigned)cnp->cn_namelen + 1);
 	if (dvp->v_mount->mnt_maxsymlinklen > 0)
 		newdir.d_type = IFTODT(ip->i_mode);
 	else {
@@ -752,7 +752,7 @@ ufs_direnter(ip, dvp, cnp)
 		dsize = DIRSIZ(FSFMT(dvp), nep);
 		spacefree += nep->d_reclen - dsize;
 		loc += nep->d_reclen;
-		bcopy((caddr_t)nep, (caddr_t)ep, dsize);
+		memcpy((caddr_t)ep, (caddr_t)nep, dsize);
 	}
 	/*
 	 * Update the pointer fields in the previous entry (if any),
@@ -769,7 +769,7 @@ ufs_direnter(ip, dvp, cnp)
 		ep->d_reclen = dsize;
 		ep = (struct direct *)((char *)ep + dsize);
 	}
-	bcopy((caddr_t)&newdir, (caddr_t)ep, (u_int)newentrysize);
+	memcpy((caddr_t)ep, (caddr_t)&newdir, (u_int)newentrysize);
 	error = VOP_BWRITE(bp);
 	dp->i_flag |= IN_CHANGE | IN_UPDATE;
 	if (!error && dp->i_endoff && dp->i_endoff < dp->i_size)

--- a/server/ufs/ufs/ufs_quota.c
+++ b/server/ufs/ufs/ufs_quota.c
@@ -741,7 +741,7 @@ dqget(vp, id, ump, type, dqp)
 		desireddquot += DQUOTINC;
 	if (numdquot < desireddquot) {
 		dq = (struct dquot *)malloc(sizeof *dq, M_DQUOT, M_WAITOK);
-		bzero((char *)dq, sizeof *dq);
+		memset((char *)dq, 0, sizeof *dq);
 		numdquot++;
 	} else {
 		if ((dq = dqfreel) == NULL) {
@@ -788,7 +788,7 @@ dqget(vp, id, ump, type, dqp)
 	auio.uio_procp = (struct proc *)0;
 	error = VOP_READ(dqvp, &auio, 0, ump->um_cred[type]);
 	if (auio.uio_resid == sizeof(struct dqblk) && error == 0)
-		bzero((caddr_t)&dq->dq_dqb, sizeof(struct dqblk));
+		memset((caddr_t)&dq->dq_dqb, 0, sizeof(struct dqblk));
 	if (vp != dqvp)
 		VOP_UNLOCK(dqvp);
 	if (dq->dq_flags & DQ_WANT)

--- a/server/ufs/ufs/ufs_vnops.c
+++ b/server/ufs/ufs/ufs_vnops.c
@@ -1584,7 +1584,7 @@ ufs_symlink(ap)
 	len = strlen(ap->a_target);
 	if (len < vp->v_mount->mnt_maxsymlinklen) {
 		ip = VTOI(vp);
-		bcopy(ap->a_target, (char *)ip->i_shortlink, len);
+		memcpy((char *)ip->i_shortlink, ap->a_target, len);
 		ip->i_size = len;
 		ip->i_flag |= IN_CHANGE | IN_UPDATE;
 	} else

--- a/server/x86_64/serv_machdep.c
+++ b/server/x86_64/serv_machdep.c
@@ -307,7 +307,7 @@ void pagemove(
 	kern_return_t kr = KERN_SUCCESS;
 
 	if(size % PAGE_SIZE || (int)from % PAGE_SIZE) 
-		bcopy(from, to, size);
+		memcpy(to, from, size);
 	else
 		kr = vm_write(mach_task_self(), (vm_offset_t) to,
 		      (vm_offset_t) from, size);


### PR DESCRIPTION
## Summary
- convert legacy `bzero`, `bcopy` and `bcmp` calls in `server/` to their C standard equivalents
- extend environment `setup.sh` with retry logic and cross-toolchain packages

## Testing
- `make -f Makefile.new ARCH=x86_64` *(fails: Mach headers not found)*