### PR TITLE
Replace BSD bstring calls with mem* equivalents

### DIFF
--- a/include/mach 2/sa/string.h
+++ b/include/mach 2/sa/string.h
@@ -48,8 +48,6 @@ __DECL(void *,memcpy(void *to, const void *from, unsigned int n));
 #endif
 __DECL(void *,memset(void *to, int ch, unsigned int n));
 
-__DECL(void,bcopy(const void *from, void *to, unsigned int n));
-__DECL(void,bzero(void *to, unsigned int n));
 
 __END_DECLS
 

--- a/include/string.h
+++ b/include/string.h
@@ -73,9 +73,6 @@ size_t	 strxfrm (char *, const char *, size_t);
 
 /* Nonstandard routines */
 #ifndef _ANSI_SOURCE
-int	 bcmp (const void *, const void *, size_t);
-void	 bcopy (const void *, void *, size_t);
-void	 bzero (void *, size_t);
 int	 ffs (int);
 char	*index (const char *, int);
 void	*memccpy (void *, const void *, int, size_t);

--- a/include/sys/systm.h
+++ b/include/sys/systm.h
@@ -122,9 +122,7 @@ void	printf (const char *, ...);
 int	sprintf (char *buf, const char *, ...);
 void	ttyprintf (struct tty *, const char *, ...);
 
-void	bcopy (const void *from, void *to, size_t len);
 void	ovbcopy (const void *from, void *to, u_int len);
-void	bzero (void *buf, size_t len);
 
 int	copystr (void *kfaddr, void *kdaddr, u_int len, u_int *done);
 int	copyinstr (void *udaddr, void *kaddr, u_int len, u_int *done);

--- a/protocols/arp/arp.c
+++ b/protocols/arp/arp.c
@@ -489,11 +489,11 @@ arpHdrStore(hdr, netHdr, len, arg)
     
     xTrace0(arpp, 5, "Entering arpHdrStore");
     xAssert( len == sizeof(ArpHdr) );
-    bcopy( hdr, (char *)&tmpHdr, sizeof(ArpHdr) );
+    memcpy((char *)&tmpHdr, hdr, sizeof(ArpHdr) );
     tmpHdr.arp_hrd = htons(tmpHdr.arp_hrd);
     tmpHdr.arp_prot = htons(tmpHdr.arp_prot);
     tmpHdr.arp_op = htons(tmpHdr.arp_op);
-    bcopy( (char *)&tmpHdr, netHdr, sizeof(ArpHdr) );
+    memcpy(netHdr, (char *)&tmpHdr, sizeof(ArpHdr) );
     xTrace0(arpp, 7, "leaving arpHdrStore");
 }
 
@@ -508,7 +508,7 @@ arpHdrLoad(hdr, netHdr, len, arg)
     xAssert( len == sizeof(ArpHdr) );
 
     xTrace0(arpp, 5, "Entering arpHdrLoad");
-    bcopy( netHdr, hdr, sizeof(ArpHdr) );
+    memcpy(hdr, netHdr, sizeof(ArpHdr) );
     ((ArpHdr *)hdr)->arp_hrd = ntohs(((ArpHdr *)hdr)->arp_hrd);
     ((ArpHdr *)hdr)->arp_prot = ntohs(((ArpHdr *)hdr)->arp_prot);
     ((ArpHdr *)hdr)->arp_op = ntohs(((ArpHdr *)hdr)->arp_op);
@@ -522,7 +522,7 @@ newWait(w, self)
     ArpWait 	*w;
     XObj	self;
 {
-    bzero((char *)w, sizeof(ArpWait));
+    memset((char *)w, 0, sizeof(ArpWait));
     semInit(&w->s, 0);
     w->self = self;
 }

--- a/protocols/arp/arp_rom.c
+++ b/protocols/arp/arp_rom.c
@@ -78,7 +78,7 @@ loadEntry( self, str, nFields, line, arg )
 		xTraceP0(self, TR_ERRORS, "llp couldn't translate rom entry");
 		return XK_FAILURE;
 	    }
-	    bcopy((char *)&buf.ethHost, (char *)&ethHost, sizeof(ETHhost));
+	    memcpy((char *)&ethHost, (char *)&buf.ethHost, sizeof(ETHhost));
 	    nextField = 4;
 	}
     }

--- a/protocols/arp/arp_table.c
+++ b/protocols/arp/arp_table.c
@@ -79,7 +79,7 @@ arpTableInit()
     int 	i;
 
     tbl = (ArpTbl)xMalloc(ARP_TAB * sizeof(ArpEnt));
-    bzero((char *)tbl, ARP_TAB * sizeof(ArpEnt));
+    memset((char *)tbl, 0, ARP_TAB * sizeof(ArpEnt));
     for (i=0; i < ARP_TAB; i++) {
 	e = &tbl[i];
 	e->status = ARP_FREE;
@@ -300,7 +300,7 @@ arpSaveBinding( tbl, ip, eth )
 	 */
 	ArpEnt	*t = &tbl[ipPos];
 
-	if ( bcmp((char *)&t->arp_Ead, (char *)eth, sizeof(ETHhost)) == 0 ) {
+	if ( memcmp((char *)&t->arp_Ead, (char *)eth, sizeof(ETHhost)) == 0 ) {
 	    if ( t->status == ARP_RSLVD ) {
 		xTrace0(arpp, 3, "arpSaveBinding: already had this binding");
 		return;
@@ -412,7 +412,7 @@ ipToIndex( tbl, h )
 
     for (i=0; i<ARP_TAB; i++) {
 	if (tbl[i].status != ARP_FREE &&
-	    ! bcmp((char *)h, (char *)&tbl[i].arp_Iad, sizeof(IPhost))) {
+	    ! memcmp((char *)h, (char *)&tbl[i].arp_Iad, sizeof(IPhost))) {
 	    return(i);
 	}
     }
@@ -433,7 +433,7 @@ ethToIndex( tbl, h )
     
     for (i=0; i<ARP_TAB; i++) {
 	if (tbl[i].status != ARP_FREE &&
-	    ! bcmp((char *)h, (char *)&tbl[i].arp_Ead,
+	    ! memcmp((char *)h, (char *)&tbl[i].arp_Ead,
 		   sizeof(ETHhost))) {
 	    return(i);
 	}

--- a/protocols/bid/bid.c
+++ b/protocols/bid/bid.c
@@ -146,7 +146,7 @@ bidHdrLoad( hdr, src, len, arg )
     long	len;
 {
     xAssert( len == sizeof(BidHdr) );
-    bcopy(src, hdr, len);
+    memcpy(hdr, src, len);
     ((BidHdr *)hdr)->hlpNum = ntohl(((BidHdr *)hdr)->hlpNum);
     return len;
 }
@@ -164,7 +164,7 @@ bidHdrStore( hdr, dst, len, arg )
     h.hlpNum = htonl(((BidHdr *)hdr)->hlpNum);
     h.srcBid = ((BidHdr *)hdr)->srcBid;
     h.dstBid = ((BidHdr *)hdr)->dstBid;
-    bcopy((char *)&h, dst, len);
+    memcpy(dst, (char *)&h, len);
 }
 
 

--- a/protocols/bidctl/bidctl.c
+++ b/protocols/bidctl/bidctl.c
@@ -189,7 +189,7 @@ bidctlHdrLoad( hdr, src, len, arg )
     long	len;
 {
     xAssert( len == sizeof(BidctlHdr) );
-    bcopy(src, hdr, len);
+    memcpy(hdr, src, len);
     xTrace1(bidctlp, TR_DETAILED, "original checksum: %x",
 	    ((BidctlHdr *)hdr)->sum);
     ((BidctlHdr *)hdr)->sum = ~ ocsum((u_short *)hdr, len/2);
@@ -212,7 +212,7 @@ bidctlHdrStore( hdr, dst, len, arg )
     h->sum = ~ocsum((u_short *)h, len/2); 
     xAssert( (~ocsum((u_short *)h, len/2) & 0xffff) == 0 );
     xTrace1(bidctlp, TR_DETAILED, "outgoing checksum: %x", h->sum);
-    bcopy((char *)h, dst, len);
+    memcpy(dst, (char *)h, len);
 }
 
 
@@ -264,7 +264,7 @@ getState( self, peer, create )
 	    return 0;
 	}
 	bs = X_NEW(BidctlState);
-	bzero((char *)bs, sizeof(BidctlState));
+	memset((char *)bs, 0, sizeof(BidctlState));
 	bs->myProtl = self;
 	bs->peerHost = *peer;
 	bs->peerBid = 0;

--- a/protocols/blast/blast.c
+++ b/protocols/blast/blast.c
@@ -157,7 +157,7 @@ blastCreateSessn( self, hlpRcv, hlpType, key )
 
     pstate = (PState *)self->state;
     state = (SState *) xMalloc(sizeof(SState));
-    bzero((char *)state, sizeof(SState));
+    memset((char *)state, 0, sizeof(SState));
     state->prot_id = key->prot;
     state->rec_map = mapCreate(BLAST_REC_MAP_SZ, sizeof(BlastSeq));
     /*
@@ -321,7 +321,7 @@ blastNewMstate(s)
 	xTrace0(blastp, TR_MORE_EVENTS, "blast_pop: new_state created ");
 	mstate = X_NEW(MSG_STATE);
     }
-    bzero((char *)mstate, sizeof(MSG_STATE));
+    memset((char *)mstate, 0, sizeof(MSG_STATE));
     mstate->rcnt = 1;
     /* 
      * Add a reference count for this message state

--- a/protocols/blast/blast_hdr.c
+++ b/protocols/blast/blast_hdr.c
@@ -22,7 +22,7 @@ blastHdrLoad(hdr, src, len, arg)
     VOID *arg;
 {
     xAssert( len == sizeof(BLAST_HDR) );
-    bcopy( src, hdr, len );
+    memcpy(hdr, src, len );
     HDR->prot_id = ntohl(HDR->prot_id);
     HDR->seq = ntohl(HDR->seq);
     HDR->num_frag = ntohs(HDR->num_frag);
@@ -48,5 +48,5 @@ blastHdrStore(hdr, dst, len, arg)
     h.num_frag = htons(h.num_frag);
     BLAST_MASK_HTON(h.mask, h.mask);
     h.len = htonl(h.len);
-    bcopy( (char *)&h, dst, len );
+    memcpy(dst, (char *)&h, len );
 }

--- a/protocols/chan/chan.c
+++ b/protocols/chan/chan.c
@@ -77,7 +77,7 @@ chanHdrStore(hdr, dst, len, arg)
     h.prot_id = htonl(HDR->prot_id);
     h.seq = htonl(HDR->seq);
     h.len = htonl(HDR->len);
-    bcopy((char *)(&h), dst, CHANHLEN);
+    memcpy(dst, (char *)(&h), CHANHLEN);
 }
 
 
@@ -92,7 +92,7 @@ chanHdrLoad(hdr, src, len, arg)
     VOID *arg;
 {
     xAssert(len == sizeof(CHAN_HDR));  
-    bcopy(src, (char *)hdr, CHANHLEN);
+    memcpy((char *)hdr, src, CHANHLEN);
     HDR->chan = ntohs(HDR->chan);
     HDR->prot_id = ntohl(HDR->prot_id);
     HDR->seq = ntohl(HDR->seq);
@@ -215,7 +215,7 @@ chanCreateSessn( self, hlpRcv, hlpType, key, initFunc, keyMap, hostMap )
     xTrace0(chanp, TR_MAJOR_EVENTS, "CHAN createSessn ......................");
     xIfTrace(chanp, TR_MAJOR_EVENTS) chanDispKey(key);
     ss = X_NEW(CHAN_STATE);
-    bzero((char *)ss, sizeof(CHAN_STATE));
+    memset((char *)ss, 0, sizeof(CHAN_STATE));
     /*
      * Fill in  state
      */
@@ -949,7 +949,7 @@ chanResend( s, flags, forceUsrMsg )
     /*
      * Send message
      */
-    bzero((char *)&ss->info, sizeof(ss->info));
+    memset((char *)&ss->info, 0, sizeof(ss->info));
     msgSetAttr(&packet, 0, (void *)&ss->info, sizeof(ss->info));
     xAssert(xIsSession(xGetDown(s, 0)));
     rval = xPush(xGetDown(s, 0), &packet);

--- a/protocols/chan/chan_client.c
+++ b/protocols/chan/chan_client.c
@@ -204,7 +204,7 @@ chanCall(self, msg, rmsg)
      * Send message
      */
     packet_len    = msgLen(msg);
-    bzero((char *)&state->info, sizeof(state->info));
+    memset((char *)&state->info, 0, sizeof(state->info));
     msgSetAttr(msg, 0, (void *)&state->info, sizeof(state->info));
     if (xPush(lls, msg) <0) {
 	xTrace0(chanp, TR_SOFT_ERRORS, "chan_call: can't send message");

--- a/protocols/chan/chan_server.c
+++ b/protocols/chan/chan_server.c
@@ -324,7 +324,7 @@ doCallDemux(self, inHdr, inMsg)
      * Send reply
      */
     packet_len    = msgLen(&rmsg); 
-    bzero((char *)&state->info, sizeof(state->info));
+    memset((char *)&state->info, 0, sizeof(state->info));
     msgSetAttr(&rmsg, 0, (void *)&state->info, sizeof(state->info));
     if (xPush(lls, &rmsg) < 0) {
 	xTrace0(chanp, TR_SOFT_ERRORS, "chan_pop: (SVC) can't send message");

--- a/protocols/eth/eth.c
+++ b/protocols/eth/eth.c
@@ -540,7 +540,7 @@ ethControlSessn(s, op, buf, len)
 	
       case GETPEERHOST:
 	checkLen(len, sizeof(ETHhost));
-	bcopy((char *) &ss->hdr.dst, buf, sizeof(ETHhost));
+	memcpy(buf, (char *) &ss->hdr.dst, sizeof(ETHhost));
 	return (sizeof(ETHhost));
 	
       case GETMYHOSTCOUNT:
@@ -605,7 +605,7 @@ ethControlProtl( self, op, buf, len )
 	
       case GETMYHOST:
 	checkLen(len, sizeof(ETHhost));
-	bcopy((char *) &ps->myHost, buf, sizeof(ETHhost));
+	memcpy(buf, (char *) &ps->myHost, sizeof(ETHhost));
 	return (sizeof(ETHhost));
 
       default:

--- a/protocols/icmp/icmp.c
+++ b/protocols/icmp/icmp.c
@@ -294,7 +294,7 @@ icmpHdrLoad(hdr, src, len, arg)
     
     xAssert(len == sizeof(ICMPHeader));
     *sum = inCkSum(msg, 0, 0);
-    bcopy(src, (char *)hdr, sizeof(ICMPHeader));
+    memcpy((char *)hdr, src, sizeof(ICMPHeader));
     return sizeof(ICMPHeader);
 }  
 
@@ -318,12 +318,12 @@ icmpHdrStore(hdr, dst, len, arg)
     xAssert(len == sizeof(ICMPHeader));
     if (arg) {
 	((ICMPHeader *)hdr)->icmp_cksum = 0;
-	bcopy((char *)hdr, dst, sizeof(ICMPHeader));
+	memcpy(dst, (char *)hdr, sizeof(ICMPHeader));
 	((ICMPHeader *)hdr)->icmp_cksum = inCkSum((Msg *)arg, 0, 0);
-	bcopy((char *)hdr, dst, sizeof(ICMPHeader));
+	memcpy(dst, (char *)hdr, sizeof(ICMPHeader));
 	xAssert(! inCkSum((Msg *)arg, 0, 0));
     } else {
-	bcopy((char *)hdr, dst, sizeof(ICMPHeader));
+	memcpy(dst, (char *)hdr, sizeof(ICMPHeader));
     }
 }  
 
@@ -336,7 +336,7 @@ icmpEchoLoad(hdr, src, len, arg)
     VOID *arg;
 {
     xAssert(len == sizeof(ICMPEcho));
-    bcopy(src, (char *)hdr, sizeof(ICMPEcho));
+    memcpy((char *)hdr, src, sizeof(ICMPEcho));
     ((ICMPEcho *)hdr)->icmp_id = ntohs(((ICMPEcho *)hdr)->icmp_id);
     ((ICMPEcho *)hdr)->icmp_seqnum = ntohs(((ICMPEcho *)hdr)->icmp_seqnum);
     return sizeof(ICMPEcho);
@@ -356,7 +356,7 @@ icmpEchoStore(hdr, dst, len, arg)
     xAssert(len == sizeof(ICMPEcho));
     ((ICMPEcho *)hdr)->icmp_id = ntohs(((ICMPEcho *)hdr)->icmp_id);
     ((ICMPEcho *)hdr)->icmp_seqnum = ntohs(((ICMPEcho *)hdr)->icmp_seqnum);
-    bcopy((char *)hdr, dst, sizeof(ICMPEcho));
+    memcpy(dst, (char *)hdr, sizeof(ICMPEcho));
 }
 
 
@@ -368,7 +368,7 @@ icmpRedirectLoad(hdr, src, len, arg)
     VOID *arg;
 {
     xAssert(len == sizeof(ICMPRedirect));
-    bcopy(src, (char *)hdr, sizeof(ICMPRedirect));
+    memcpy((char *)hdr, src, sizeof(ICMPRedirect));
     return sizeof(ICMPRedirect);
 }
 

--- a/protocols/ip/ip.c
+++ b/protocols/ip/ip.c
@@ -348,7 +348,7 @@ ipCreateSessn( self, hlpRcv, hlpType, f, dst )
     s = xCreateSessn(f, hlpRcv, hlpType, self, 0, 0);
     ss = X_NEW(SState);
     s->state = (VOID *)ss;
-    bzero((char *)ss, sizeof(SState));
+    memset((char *)ss, 0, sizeof(SState));
     ss->hdr.dest = *dst;
     if ( ipHandleRedirect(s) ) {
 	xTrace0(ipp, 3, "IP open fails");

--- a/protocols/ip/ip_hdr.c
+++ b/protocols/ip/ip_hdr.c
@@ -67,7 +67,7 @@ ipHdrStore(hdr, dst, len, arg)
     ((IPheader *)hdr)->checksum = 0;
     ((IPheader *)hdr)->checksum = ~ocsum((u_short *)hdr, sizeof(IPheader) / 2);
     xAssert(! (~ ocsum( (u_short *)hdr, sizeof(IPheader) / 2 ) & 0xFFFF ));
-    bcopy ( (char *)hdr, dst, sizeof(IPheader) );
+    memcpy(dst, (char *)hdr, sizeof(IPheader) );
 }
 
 
@@ -83,7 +83,7 @@ ipStdHdrLoad(hdr, src, len, arg)
     VOID *arg;
 {
     xAssert(len == sizeof(IPheader));
-    bcopy(src, (char *)hdr, sizeof(IPheader));
+    memcpy((char *)hdr, src, sizeof(IPheader));
     ((IPheader *)hdr)->checksum =
       ~ ocsum((u_short *)hdr, sizeof(IPheader) / 2) & 0xFFFF;
     ((IPheader *)hdr)->dlen = ntohs(((IPheader *)hdr)->dlen);
@@ -100,7 +100,7 @@ ipOptionsLoad(hdr, netHdr, len, arg)
     long int len;
     VOID *arg;
 {
-    bcopy(netHdr, (char *)hdr, len);
+    memcpy((char *)hdr, netHdr, len);
     *(u_short *)arg = ~ocsum((u_short *)hdr, len / 2);
     return len;
 }

--- a/protocols/ip/iproute.c
+++ b/protocols/ip/iproute.c
@@ -49,7 +49,7 @@ rt_init( ps, defGw)
     xTrace0(ipp, TR_GROSS_EVENTS, "IP rt_init()");
     tbl->valid = TRUE;
     tbl->arr = (route **)xMalloc(ROUTETABLESIZE * sizeof(route *));
-    bzero((char *)tbl->arr, ROUTETABLESIZE * sizeof(route *));
+    memset((char *)tbl->arr, 0, ROUTETABLESIZE * sizeof(route *));
     tbl->bpoolsize = BPSIZE;
     if ( IP_EQUAL(*defGw, ipNull) ) {
 	xTrace0(ipp, TR_GROSS_EVENTS,

--- a/protocols/join/join.c
+++ b/protocols/join/join.c
@@ -63,7 +63,7 @@ join_init( self )
     }
 
     ps = X_NEW(PState);
-    bzero((char *)ps,sizeof(ps));
+    memset((char *)ps, 0, sizeof(ps));
     self->state = (VOID *)ps;
     ps->actMap = mapCreate(JOIN_ACTIVE_MAP_SZ, sizeof(ActiveId));
     ps->tagIdLen = 0;
@@ -182,11 +182,11 @@ joinCreateTagSessn (self, hlpRcv, hlpType, lls, idBuf, idLen)
     }
        
     ts = X_NEW(TState);
-    bzero((char *)ts, sizeof(TState));
+    memset((char *)ts, 0, sizeof(TState));
     semInit(&ts->wait, 1);
-    bcopy(idBuf,(char *)&ts->id,idLen);
+    memcpy((char *)&ts->id, idBuf, idLen);
     ts->numSeg = ps->numSeg;
-    bcopy((char *) &ps->order, (char *)&ts->order, sizeof(ts->order));
+    memcpy((char *)&ts->order, (char *) &ps->order, sizeof(ts->order));
  
 
     s = xCreateSessn(joinTagSessnInit, hlpRcv, hlpType, self, 1, &lls);
@@ -670,13 +670,13 @@ joinTagControlSessn(s, op, buf, len)
       case JOINGETORDER:
         {   
 	    if (len != sizeof(ts->order)) return 0; 
-	    bcopy((char *) &ts->order, buf, sizeof(ts->order));
+	    memcpy(buf, (char *) &ts->order, sizeof(ts->order));
             return(sizeof(ts->order));
         }
       case JOINSETCONTROL:
         {   
 	    if (len != sizeof(ts->controlSessn)) return 0; 
-	    bcopy(buf, (char *) &ts->controlSessn, sizeof(ts->controlSessn));
+	    memcpy((char *) &ts->controlSessn, buf, sizeof(ts->controlSessn));
             return(sizeof(ts->controlSessn));
         }
       case JOINDONE:
@@ -749,7 +749,7 @@ joinControlProtl( self, op, buf, len )
       case JOINGETORDER:
         {   
 	    if (len != sizeof(ps->order)) return 0; 
-	    bcopy((char *) &ps->order, buf, sizeof(ps->order));
+	    memcpy(buf, (char *) &ps->order, sizeof(ps->order));
             return(sizeof(ps->order));
         }
 
@@ -803,7 +803,7 @@ joinHdrStore(hdr, dst, len, arg)
         ((JOINhdr *)hdr)->len[i] = htonl(((JOINhdr *)hdr)->len[i]);
     }
 
-    bcopy((char *)hdr, dst, len);
+    memcpy(dst, (char *)hdr, len);
     xTrace0(joinp, TR_EVENTS, "joinHdrStore - exiting");
 }
 
@@ -816,7 +816,7 @@ joinHdrLoad1(hdr, src, len, arg)
 {
     xTrace0(joinp, TR_EVENTS, "joinHdrLoad1 - entered");
 
-    bcopy(src, (char *)hdr, len);
+    memcpy((char *)hdr, src, len);
     ((JOINhdr *)hdr)->id = ntohl(((JOINhdr *)hdr)->id);
     xTrace1(joinp, TR_EVENTS, "hdr->id = %d", ((JOINhdr *)hdr)->id);
     ((JOINhdr *)hdr)->numSeg = ntohl(((JOINhdr *)hdr)->numSeg);
@@ -837,7 +837,7 @@ joinHdrLoad2(hdr, src, len, arg)
     int i;
     xTrace0(joinp, TR_EVENTS, "joinHdrLoad2 - entered");
 
-    bcopy(src, (char *)&((JOINhdr *)hdr)->len, len);
+    memcpy((char *)&((JOINhdr *)hdr)->len, src, len);
     for (i=0; i<len/4; i++) {
         ((JOINhdr *)hdr)->len[i] = ntohl(((JOINhdr *)hdr)->len[i]);
         xTrace2(joinp, TR_EVENTS, "hdr->len[%d] = %d", i, ((JOINhdr *)hdr)->len[
@@ -867,7 +867,7 @@ partToId(p, buf, maxLen)
     	for (i=p[j].stack.top; i>0; i--)  {
        		len += p[j].stack.arr[i-1].len;
 		if (len > maxLen) return 0;
-        	bcopy((char *)p[j].stack.arr[i-1].ptr,(char *)ptr, p[j].stack.arr[i-1].len);
+        	memcpy((char *)ptr, (char *)p[j].stack.arr[i-1].ptr, p[j].stack.arr[i-1].len);
         	ptr += p[j].stack.arr[i-1].len;
     	}
     }
@@ -899,7 +899,7 @@ part2ToId(p, buf, maxLen)
     for (i=p[0].stack.top; i>0; i--)  {
        	len += p[1].stack.arr[i-1].len;
 	if (len > maxLen) return 0;
-       	bcopy((char *)p[1].stack.arr[i-1].ptr,(char *)ptr, p[1].stack.arr[i-1].len);
+       	memcpy((char *)ptr, (char *)p[1].stack.arr[i-1].ptr, p[1].stack.arr[i-1].len);
        	ptr += p[1].stack.arr[i-1].len;
     }
     xTrace1(joinp, TR_EVENTS, "part2ToLen - exiting len %d",len);

--- a/protocols/machnetipc/rrx.c
+++ b/protocols/machnetipc/rrx.c
@@ -518,7 +518,7 @@ lockForMovingReceiver( self, req, rep, lls )
     {
 	mportNetRep		netport;
 		       
-	bzero((char *)&netport, sizeof(netport));
+	memset((char *)&netport, 0, sizeof(netport));
 	netport.net_port_number = req->portNumber;
 	if ( findNetPort(&netport, req->archTag, FALSE, &npd) == XK_FAILURE ) {
 	    xTrace0(rrxp, TR_SOFT_ERRORS,
@@ -605,7 +605,7 @@ unlockForMovingReceiver( self, req, rep, lls )
     {
 	mportNetRep		netport;
 		       
-	bzero((char *)&netport, sizeof(netport));
+	memset((char *)&netport, 0, sizeof(netport));
 	netport.net_port_number = req->portNumber;
 	if ( findNetPort(&netport, req->archTag, FALSE, &npd) == XK_FAILURE ) {
 	    xTrace0(rrxp, TR_SOFT_ERRORS,

--- a/protocols/machnetipc/rrx_hdr.c
+++ b/protocols/machnetipc/rrx_hdr.c
@@ -129,7 +129,7 @@ rrxSendHostLoad( sh, src )
     char	*src;
 {
     xferHostLoad(&sh->xh, src);					
-    bcopy(src + XFERHOST_NETLEN, (char *)&sh->sendCount, SENDCOUNT_NETLEN);
+    memcpy((char *)&sh->sendCount, src + XFERHOST_NETLEN, SENDCOUNT_NETLEN);
 }
 
 static void
@@ -138,7 +138,7 @@ rrxSendHostStore( sh, dst )
     char	*dst;
 {
     xferHostStore(&sh->xh, dst);	
-    bcopy((char *)&sh->sendCount, dst + XFERHOST_NETLEN, SENDCOUNT_NETLEN);
+    memcpy(dst + XFERHOST_NETLEN, (char *)&sh->sendCount, SENDCOUNT_NETLEN);
     
 }
 
@@ -162,7 +162,7 @@ loadXferMsg(  hdr, src, len, arg )
     RrxSendHost	*hosts;
     int		i;
 
-    bcopy(src, (char *)&HDR->u.transfer.msgId, MSGID_NETLEN);
+    memcpy((char *)&HDR->u.transfer.msgId, src, MSGID_NETLEN);
     src += MSGID_NETLEN;
     xferHostLoad(&HDR->u.transfer.orr, src);
     src += XFERHOST_NETLEN;
@@ -257,11 +257,11 @@ loadReq( hdr, src, len, arg )
     }
     HDR->type = (RrxMsgType)src[0];
     if ( HDR->type == RECEIVE_RIGHT_TRANSFER ) {
-	bcopy(&src[2], (char *)&HDR->u.transfer.numSenders, 2);
+	memcpy((char *)&HDR->u.transfer.numSenders, &src[2], 2);
 	HDR->u.transfer.numSenders = ntohs(HDR->u.transfer.numSenders);
     }
     src += 4;
-    bcopy(src, (char *)&HDR->archTag, MN_ARCH_TAG_NETLEN);
+    memcpy((char *)&HDR->archTag, src, MN_ARCH_TAG_NETLEN);
     src += MN_ARCH_TAG_NETLEN;
     portNumberLoad(&HDR->portNumber, src);
     return RRX_REQMSG_NETLEN;
@@ -349,7 +349,7 @@ storeRequest( hdr, dst, len, arg )
     dst[1] = 0;
     dst += 4;
     archTag = MN_ARCH_MARKER;
-    bcopy((char *)&archTag, dst, MN_ARCH_TAG_NETLEN);
+    memcpy(dst, (char *)&archTag, MN_ARCH_TAG_NETLEN);
     dst += MN_ARCH_TAG_NETLEN;
     portNumberStore(&HDR->port->net_port_number, dst);
     dst += PORT_NUMBER_NETLEN;
@@ -359,7 +359,7 @@ storeRequest( hdr, dst, len, arg )
 	    ListElement	*e;
 	    u_short	numSenders = 0;
 	    
-	    bcopy((char *)&HDR->u.transfer.msgId, dst, MSGID_NETLEN);
+	    memcpy(dst, (char *)&HDR->u.transfer.msgId, MSGID_NETLEN);
 	    dst += MSGID_NETLEN;
 	    xferHostStore(&HDR->u.transfer.orr, dst);
 	    dst += XFERHOST_NETLEN;
@@ -372,7 +372,7 @@ storeRequest( hdr, dst, len, arg )
 		}
 	    }
 	    numSenders = htons(numSenders);
-	    bcopy((char *)&numSenders, origDst + 2, 2);
+	    memcpy(origDst + 2, (char *)&numSenders, 2);
 	}
 	break;
 

--- a/protocols/machnetipc/srx.c
+++ b/protocols/machnetipc/srx.c
@@ -88,7 +88,7 @@ lockForAddingSender( self, req, rep )
     {
 	mportNetRep		netport;
 		       
-	bzero((char *)&netport, sizeof(netport));
+	memset((char *)&netport, 0, sizeof(netport));
 	netport.net_port_number = req->portNumber;
 	if ( findNetPort(&netport, req->archTag, FALSE, &npd) == XK_FAILURE ) {
 	    xTrace0(srxp, TR_SOFT_ERRORS,
@@ -223,7 +223,7 @@ unlockForAddingSender( self, req, rep )
     {
 	mportNetRep		netport;
 		       
-	bzero((char *)&netport, sizeof(netport));
+	memset((char *)&netport, 0, sizeof(netport));
 	netport.net_port_number = req->portNumber;
 	if ( findNetPort(&netport, req->archTag, FALSE, &npd) == XK_FAILURE ) {
 	    xTrace0(srxp, TR_ERRORS, "request for unlocking nonexistent port");

--- a/protocols/machnetipc/srx_hdr.c
+++ b/protocols/machnetipc/srx_hdr.c
@@ -123,7 +123,7 @@ storeReply( hdr, dst, len, arg )
     if ( HDR->type == SEND_LOCK_REQ ) {
 	xAssert( len == SRX_REPMSG_NETLEN + SRX_LOCKREPLY_NETLEN );
 	dst += 4;
-	bcopy((char *)&HDR->u.lock.sendCount, dst, SENDCOUNT_NETLEN);
+	memcpy(dst, (char *)&HDR->u.lock.sendCount, SENDCOUNT_NETLEN);
     }
 #undef HDR
 }    
@@ -194,7 +194,7 @@ loadReq( hdr, src, len, arg )
     }
     HDR->type = (SrxMsgType)src[0];
     src += 4;
-    bcopy(src, (char *)&HDR->archTag, MN_ARCH_TAG_NETLEN);
+    memcpy((char *)&HDR->archTag, src, MN_ARCH_TAG_NETLEN);
     src += MN_ARCH_TAG_NETLEN;
     portNumberLoad(&HDR->portNumber, src);
     src += PORT_NUMBER_NETLEN;
@@ -263,11 +263,11 @@ loadXferReq(  hdr, src, len, arg )
 
     xAssert(len >= SRX_XFERMSG_NETLEN);
 
-    bcopy(src, (char *)&HDR->u.xfer.msgId, MSGID_NETLEN);
+    memcpy((char *)&HDR->u.xfer.msgId, src, MSGID_NETLEN);
     src += MSGID_NETLEN;
     xferHostLoad(&HDR->u.xfer.rr, src);
     src += XFERHOST_NETLEN;
-    bcopy(src, (char *)&HDR->u.xfer.sendCount, SENDCOUNT_NETLEN);
+    memcpy((char *)&HDR->u.xfer.sendCount, src, SENDCOUNT_NETLEN);
     return SRX_XFERMSG_NETLEN;
 
 #undef HDR
@@ -361,7 +361,7 @@ storeRequest( hdr, dst, len, arg )
     dst[1] = dst[2] = dst[3] = 0;
     dst += 4;
     archTag = MN_ARCH_MARKER;
-    bcopy((char *)&archTag, dst, MN_ARCH_TAG_NETLEN);
+    memcpy(dst, (char *)&archTag, MN_ARCH_TAG_NETLEN);
     dst += MN_ARCH_TAG_NETLEN;
     portNumberStore(&HDR->port->net_port_number, dst);
     dst += PORT_NUMBER_NETLEN;
@@ -376,11 +376,11 @@ storeRequest( hdr, dst, len, arg )
 
       case SEND_RIGHT_TRANSFER:
 	xAssert(len == SRX_REQMSG_NETLEN + SRX_XFERMSG_NETLEN);
-	bcopy((char *)&HDR->u.xfer.msgId, dst, MSGID_NETLEN);
+	memcpy(dst, (char *)&HDR->u.xfer.msgId, MSGID_NETLEN);
 	dst += MSGID_NETLEN;
 	xferHostStore(&HDR->u.xfer.rr, dst);
 	dst += XFERHOST_NETLEN;
-	bcopy((char *)&HDR->u.xfer.sendCount, dst, SENDCOUNT_NETLEN);
+	memcpy(dst, (char *)&HDR->u.xfer.sendCount, SENDCOUNT_NETLEN);
 	break;
 
       default:

--- a/protocols/machnetipc/xfer.h
+++ b/protocols/machnetipc/xfer.h
@@ -56,13 +56,13 @@ typedef struct {
 #define XFERHOST_NETLEN	(sizeof(IPhost) + sizeof(BootId))
 #define xferHostLoad(_xh, _src) 				\
 	{							\
-	    bcopy((_src), (char *)&(_xh)->h, sizeof(IPhost));	\
+	    memcpy((char *)&(_xh)->h, (_src), sizeof(IPhost));	\
 	    bcopy((_src) + sizeof(IPhost), (char *)&(_xh)->bid,	\
 		  sizeof(BootId));				\
 	}
 #define xferHostStore(_xh, _dst) 				\
 	{							\
-	    bcopy((char *)&(_xh)->h, (_dst), sizeof(IPhost));	\
+	    memcpy((_dst), (char *)&(_xh)->h, sizeof(IPhost));	\
 	    bcopy((char *)&(_xh)->bid, (_dst) + sizeof(IPhost),	\
 		  sizeof(BootId));				\
 	}

--- a/protocols/machnetipc/xfertest.c
+++ b/protocols/machnetipc/xfertest.c
@@ -265,7 +265,7 @@ isServerDefault()
     if ( serverParam ) {
 	return TRUE;
     }
-    return ! bcmp((char *)&myHost, (char *)&ServerAddr, sizeof(HOST_TYPE));
+    return ! memcmp((char *)&myHost, (char *)&ServerAddr, sizeof(HOST_TYPE));
 }
 
 
@@ -278,7 +278,7 @@ isClientDefault()
 	ClientAddr = myHost;
 	return TRUE;
     }
-    return ! bcmp((char *)&myHost, (char *)&ClientAddr, sizeof(HOST_TYPE));
+    return ! memcmp((char *)&myHost, (char *)&ClientAddr, sizeof(HOST_TYPE));
 }
 
 

--- a/protocols/pmap/xkpm.c
+++ b/protocols/pmap/xkpm.c
@@ -131,7 +131,7 @@ void pmap_init(self) XObj self;
 
 
 long yabcopy (to,from,len,xarg)  char *to,*from; long len; VOID *xarg;
-{ bcopy(from,to,len); return len; }
+{ memcpy(to, from, len); return len; }
 
 
 static xkern_return_t pmap_calldemux(self,s,msg,msgr)

--- a/protocols/rat/rat.c
+++ b/protocols/rat/rat.c
@@ -676,13 +676,13 @@ long ratHdrLoad(dest, src, len, ignore)
   xTrace4(ratp,TR_FULL_TRACE,"ratcopy args: %x %x %x %x",
 	  dest,src,len,ignore);
   
-  bcopy(src, (char*)hdr, len);
+  memcpy((char*)hdr, src, len);
   
   hdr->prot_num = ntohl(hdr->prot_num);
   hdr->record_length = ntohl(hdr->record_length);
-  bcopy((char *)&hdr->senderAddr,(char *)&host, sizeof(host));
+  memcpy((char *)&host, (char *)&hdr->senderAddr, sizeof(host));
   host = ntohl(host);
-  bcopy((char *)&host, (char *)&hdr->senderAddr,sizeof(host));
+  memcpy((char *)&hdr->senderAddr, (char *)&host, sizeof(host));
 
   return len;
 }
@@ -699,13 +699,13 @@ long ratDemuxHdrLoad(dest, src, len, ignore)
   xTrace4(ratp,TR_FULL_TRACE,"ratcopy args: %x %x %x %x",
           dest,src,len,ignore);
 
-  bcopy(src, (char*)hdr, len);
+  memcpy((char*)hdr, src, len);
 
   hdr->prot_num = ntohl(hdr->prot_num);
   hdr->record_length = ntohl(hdr->record_length);
-  bcopy((char *)&hdr->senderAddr,(char *)&host, sizeof(host));
+  memcpy((char *)&host, (char *)&hdr->senderAddr, sizeof(host));
   host = ntohl(host);
-  bcopy((char *)&host, (char *)&hdr->senderAddr,sizeof(host));
+  memcpy((char *)&hdr->senderAddr, (char *)&host, sizeof(host));
 
   return 0;
 }
@@ -724,10 +724,10 @@ void ratHdrStore(src, dest, len, ignore)
 
   hdr->prot_num = htonl(hdr->prot_num);
   hdr->record_length = htonl(hdr->record_length);
-  bcopy((char *)&hdr->senderAddr,(char *)&host, sizeof(host));
+  memcpy((char *)&host, (char *)&hdr->senderAddr, sizeof(host));
   host = htonl(host);
-  bcopy((char *)&host, (char *)&hdr->senderAddr,sizeof(host));
-  bcopy((char*)hdr, dest, len);
+  memcpy((char *)&hdr->senderAddr, (char *)&host, sizeof(host));
+  memcpy(dest, (char*)hdr, len);
 }
 
 

--- a/protocols/select/select_common.c
+++ b/protocols/select/select_common.c
@@ -76,7 +76,7 @@ hdrLoad( hdr, src, len, arg )
     long  	len;
 {
     xAssert(len == sizeof(SelHdr));
-    bcopy( src, hdr, len );
+    memcpy(hdr, src, len );
     ((SelHdr *)hdr)->id = ntohl(((SelHdr *)hdr)->id);
     ((SelHdr *)hdr)->status = ntohl(((SelHdr *)hdr)->status);
     return len;
@@ -94,7 +94,7 @@ hdrStore(hdr, dst, len, arg)
     xAssert( len == sizeof(SelHdr) );
     h.id = htonl(((SelHdr *)hdr)->id);
     h.status = htonl(((SelHdr *)hdr)->status);
-    bcopy( (char *)&h, dst, len );
+    memcpy(dst, (char *)&h, len );
 }
 
 
@@ -145,7 +145,7 @@ selectCreateSessn( self, hlpRcv, hlpType, key )
     
     xTrace0(selectp, TR_FUNCTIONAL_TRACE, "selectCreateSessn");
     state = X_NEW(SState);
-    bzero((char *)state, sizeof(SState));
+    memset((char *)state, 0, sizeof(SState));
     hdr = &state->hdr;
     hdr->status = SEL_OK;
     hdr->id = key->id;

--- a/protocols/simsimeth/simsimeth.c
+++ b/protocols/simsimeth/simsimeth.c
@@ -215,7 +215,7 @@ simsimeth_init( self )
     xTrace0(simsimethp, TR_MAJOR_EVENTS, "init_ether");
 
     ps = X_NEW(PState);
-    bzero((char *)ps, sizeof(PState));
+    memset((char *)ps, 0, sizeof(PState));
     self->state = (VOID *)ps;
     processRomFile(self);
     if ( ps->port == -1 ) {
@@ -264,7 +264,7 @@ ethMsgStore( void *hdr, char *netHdr, long len, void *arg )
 {
     xAssert(len == sizeof(ETHhdr));
     ((ETHhdr *)hdr)->type = ((ETHhdr *)hdr)->type;
-    bcopy(hdr, netHdr, sizeof(ETHhdr));
+    memcpy(netHdr, hdr, sizeof(ETHhdr));
 }
 
 
@@ -272,7 +272,7 @@ static long
 ethMsgLoad( void *hdr, char *netHdr, long len, void *arg )
 {
     xAssert(len == sizeof(ETHhdr));
-    bcopy(netHdr, (char *)hdr, sizeof(ETHhdr));
+    memcpy((char *)hdr, netHdr, sizeof(ETHhdr));
     ((ETHhdr *)hdr)->type = ((ETHhdr *)netHdr)->type;
     return sizeof(ETHhdr);
 }
@@ -369,7 +369,7 @@ simsimethControl( s, op, buf, len )
 
       case GETMYHOST:
 	checkLen(len, sizeof(ETHhost));
-	bcopy((char *) &ps->myHost, buf, sizeof(ETHhost));
+	memcpy(buf, (char *) &ps->myHost, sizeof(ETHhost));
 	return (sizeof(ETHhost));
 
       default:

--- a/protocols/sunrpc/sunrpc.c
+++ b/protocols/sunrpc/sunrpc.c
@@ -151,7 +151,7 @@ sunrpcOpen( self, hlpRcv, hlpType, p )
     s = xCreateSessn(getProcClient, hlpRcv, hlpType, self, 1, &lls);
     state = X_NEW(SState);
     s->state = (VOID *)state;
-    bzero((char *)state, sizeof(SState));
+    memset((char *)state, 0, sizeof(SState));
     state->c_tout = 6 * 1000 * 1000;
     state->c_wait = 1 * 1000 * 1000;
     semInit(&state->c_replySem, 0);
@@ -200,7 +200,7 @@ sunrpcOpenEnable( self, hlpRcv, hlpType, p )
     /* 
      * Save the participants to use in opendisable (if necessary)
      */
-    bcopy((char *)p, (char *)sp, partLen(p) * sizeof(Part));
+    memcpy((char *)sp, (char *)p, partLen(p) * sizeof(Part));
     /*
      * Now openenable downward
      */
@@ -321,7 +321,7 @@ rpc_demux(self, s, dg)
     /*
      * Decode header
      */
-    bzero((char *)&hdr,sizeof(hdr));
+    memset((char *)&hdr, 0, sizeof(hdr));
     if (! msgPop(dg, sunrpcHdrLoad, &hdr, MIN(XDRHDRSIZE, msgLen(dg)),
 		 &status)) {
 	xTrace0(sunrpcp, 3, "sunrpc_demux: msgPop failed");

--- a/protocols/sunrpc/sunrpc_ctl.c
+++ b/protocols/sunrpc/sunrpc_ctl.c
@@ -38,7 +38,7 @@ sunrpcControlProtl(self, opcode, buf, len)
 	{
 	    u_short port;
 	    port = (u_short) sunrpcGetPort();
-	    bcopy((char *)&port, buf, sizeof(short));
+	    memcpy(buf, (char *)&port, sizeof(short));
 	    return(0);
 	}
 	break;
@@ -79,7 +79,7 @@ sunrpcControlSessn(s, opcode, buf, len)
       case SUNRPC_SVCGETHLP: 
 	checkServer(state);
 	checkLen( len, sizeof(s->up));
-	bcopy((char *)&s->up, buf, sizeof(s->up));
+	memcpy(buf, (char *)&s->up, sizeof(s->up));
 	return(0);
 	break;
 	
@@ -88,7 +88,7 @@ sunrpcControlSessn(s, opcode, buf, len)
       case SUNRPC_CLNTGETERROR: 
 	checkClient(state);
 	checkLen( len, sizeof(struct rpc_err));
-	bcopy((char *)&state->c_error, buf, sizeof(struct rpc_err));
+	memcpy(buf, (char *)&state->c_error, sizeof(struct rpc_err));
 	return(0);
 	break;
 	
@@ -106,7 +106,7 @@ sunrpcControlSessn(s, opcode, buf, len)
 	xIfTrace(sunrpcp, 9) {
 	    prpcaddr(state->server);
 	}
-	bcopy((char *)&state->server, buf, SUNRPCADLEN);
+	memcpy(buf, (char *)&state->server, SUNRPCADLEN);
 	return(0);
 	break;
 #endif
@@ -115,7 +115,7 @@ sunrpcControlSessn(s, opcode, buf, len)
       case SUNRPC_CLNTSETTOUT:
 	checkClient(state);
 	checkLen( len, TIMEVALLEN);
-	bcopy(buf, (char *)&state->c_tout, TIMEVALLEN);
+	memcpy((char *)&state->c_tout, buf, TIMEVALLEN);
 	return(0);
 	break;
 	
@@ -123,7 +123,7 @@ sunrpcControlSessn(s, opcode, buf, len)
       case SUNRPC_CLNTGETTOUT:
 	checkClient(state);
 	checkLen( len, TIMEVALLEN);
-	bcopy((char *)&state->c_tout, buf, TIMEVALLEN);
+	memcpy(buf, (char *)&state->c_tout, TIMEVALLEN);
 	return(0);
 	break;
 	
@@ -131,7 +131,7 @@ sunrpcControlSessn(s, opcode, buf, len)
       case SUNRPC_CLNTSETWAIT:
 	checkClient(state);
 	checkLen( len, TIMEVALLEN);
-	bcopy(buf, (char *)&state->c_wait, TIMEVALLEN);
+	memcpy((char *)&state->c_wait, buf, TIMEVALLEN);
 	return(0);
 	break;
 	
@@ -139,7 +139,7 @@ sunrpcControlSessn(s, opcode, buf, len)
       case SUNRPC_CLNTGETWAIT:
 	checkClient(state);
 	checkLen( len, TIMEVALLEN);
-	bcopy((char *)&state->c_wait, buf, TIMEVALLEN);
+	memcpy(buf, (char *)&state->c_wait, TIMEVALLEN);
 	return(0);
 	break;
 	
@@ -149,7 +149,7 @@ sunrpcControlSessn(s, opcode, buf, len)
 	    Auth	*cred = getCred(state);
 
 	    checkLen( len, sizeof(int));
-	    bcopy((char *)&cred->oa_flavor, buf, sizeof(int));
+	    memcpy(buf, (char *)&cred->oa_flavor, sizeof(int));
 	    return(0);
 	    break;
 	}
@@ -160,7 +160,7 @@ sunrpcControlSessn(s, opcode, buf, len)
 	    Auth	*cred = getCred(state);
 
 	    checkLen( len, cred->oa_length); 
-	    bcopy((char *)&cred->oa_base, buf, cred->oa_length);
+	    memcpy(buf, (char *)&cred->oa_base, cred->oa_length);
 	    return(0);
 	    break;
 	}
@@ -172,7 +172,7 @@ sunrpcControlSessn(s, opcode, buf, len)
 
 	    checkLen( len, sizeof(int));
 	    sunrpcAuthFree(cred);
-	    bcopy(buf, (char *)&cred->oa_flavor, sizeof(int));
+	    memcpy((char *)&cred->oa_flavor, buf, sizeof(int));
 	    return(0);
 	    break;
 	}
@@ -187,7 +187,7 @@ sunrpcControlSessn(s, opcode, buf, len)
 	    }
 	    cred->oa_length = len;
 	    cred->oa_base = (caddr_t) xMalloc(len+2);
-	    bcopy(buf, cred->oa_base, len);
+	    memcpy(cred->oa_base, buf, len);
 	    {
 		char *mname;
 		struct authunix_parms *au_ptr;
@@ -208,7 +208,7 @@ sunrpcControlSessn(s, opcode, buf, len)
 	    Auth	*verf = getVerf(state);
 
 	    checkLen( len, sizeof(int));
-	    bcopy((char *)verf->oa_flavor, buf, sizeof(int));
+	    memcpy(buf, (char *)verf->oa_flavor, sizeof(int));
 	    return(0);
 	    break;
 	}
@@ -219,7 +219,7 @@ sunrpcControlSessn(s, opcode, buf, len)
 	    Auth	*verf = getVerf(state);
 	    
 	    checkLen( len, verf->oa_length); 
-	    bcopy((char *)&verf->oa_base, buf, verf->oa_length);
+	    memcpy(buf, (char *)&verf->oa_base, verf->oa_length);
 	    return(0);
 	    break;
 	}
@@ -231,7 +231,7 @@ sunrpcControlSessn(s, opcode, buf, len)
 	    
 	    checkLen( len, sizeof(int));
 	    sunrpcAuthFree(verf);
-	    bcopy(buf, (char *)&verf->oa_flavor, sizeof(int));
+	    memcpy((char *)&verf->oa_flavor, buf, sizeof(int));
 	    return(0);
 	    break;
 	}	
@@ -246,7 +246,7 @@ sunrpcControlSessn(s, opcode, buf, len)
 	    }
 	    verf->oa_length = len;
 	    verf->oa_base = (caddr_t) xMalloc(len+2);
-	    bcopy(buf, (char *)&verf->oa_base, len);
+	    memcpy((char *)&verf->oa_base, buf, len);
 	    return(0);
 	    break;
 	}

--- a/protocols/sunrpc/sunrpc_error.c
+++ b/protocols/sunrpc/sunrpc_error.c
@@ -34,7 +34,7 @@ sunrpcSendError(errorCode, lls, xid, arg)
     Msg 	errMsg;
 
     xTrace0(sunrpcp, 4, "sunrpc send error");
-    bzero((char *)&errHdr, sizeof(struct rpc_msg));
+    memset((char *)&errHdr, 0, sizeof(struct rpc_msg));
     errHdr.rm_xid = xid;
     errHdr.rm_direction = REPLY;
     switch( errorCode ) {

--- a/protocols/sunrpc/sunrpc_hdr.c
+++ b/protocols/sunrpc/sunrpc_hdr.c
@@ -23,7 +23,7 @@ sunrpcHdrStore(hdr, dst, len, arg)
     long int len;
     VOID *arg;
 {
-    bcopy(hdr, dst, len);
+    memcpy(dst, hdr, len);
 }
 
 
@@ -77,7 +77,7 @@ sunrpcHdrLoad(hdr, src, len, arg)
     if (LONG_ALIGNED(src)) {
 	xdrmem_create(&xdrs, src, len, XDR_DECODE);
     } else {
-	bcopy(src, (char *)alignedSrc, len);
+	memcpy((char *)alignedSrc, src, len);
 	xdrmem_create(&xdrs, (char *)alignedSrc, len, XDR_DECODE);
     }
     if (!xdr_callmsg(&xdrs, (struct rpc_msg *)hdr)) {

--- a/protocols/sunrpc/sunrpc_server.c
+++ b/protocols/sunrpc/sunrpc_server.c
@@ -142,7 +142,7 @@ createServerSessn( self, aKey, lls, hdr )
     xDuplicate(lls);
     state = X_NEW(SState);
     s->state = (VOID *)state;
-    bzero((char *)state, sizeof(SState));
+    memset((char *)state, 0, sizeof(SState));
     state->s_vers = aKey->p.vers;
     state->s_prog = aKey->p.prog;
     /*

--- a/protocols/tcp-tahoe/tcp_debug.c
+++ b/protocols/tcp-tahoe/tcp_debug.c
@@ -58,11 +58,11 @@ tcp_trace(act, ostate, tp, ti, req)
 	if (tp)
 		td->td_cb = *tp;
 	else
-		bzero((caddr_t)&td->td_cb, sizeof (*tp));
+		memset((caddr_t)&td->td_cb, 0, sizeof (*tp));
 	if (ti)
 		td->td_ti = *ti;
 	else
-		bzero((caddr_t)&td->td_ti, sizeof (*ti));
+		memset((caddr_t)&td->td_ti, 0, sizeof (*ti));
 	td->td_req = req;
 	if (tcpconsdebug == 0)
 		return;

--- a/protocols/tcp-tahoe/tcp_hdr.c
+++ b/protocols/tcp-tahoe/tcp_hdr.c
@@ -89,7 +89,7 @@ tcpHdrStore(hdr, dst, len, arg)
     ((struct tcphdr *)hdr)->th_win   = htons(((struct tcphdr *)hdr)->th_win);
     ((struct tcphdr *)hdr)->th_urp   = htons(((struct tcphdr *)hdr)->th_urp);
     ((struct tcphdr *)hdr)->th_sum   = 0;
-    bcopy(hdr, dst, len);
+    memcpy(dst, hdr, len);
     /*
      * Checksum
      */
@@ -131,7 +131,7 @@ tcpHdrLoad(hdr, src, len, arg)
     xAssert(len == sizeof(struct tcphdr));
     pHdr = (u_short *)msgGetAttr((Msg *)arg, 0);
     xAssert(pHdr);
-    bcopy(src, hdr, len);
+    memcpy(hdr, src, len);
     xIfTrace(tcpp, CKSUM_TRACE) {
 	printf("Received: ");
 	dispPseudoHdr((IPpseudoHdr *)pHdr);
@@ -194,7 +194,7 @@ tcpOptionsStore(hdr, dst, len, arg)
     int hdrLen;	
     
     hdrLen = *(int *)arg;
-    bcopy(hdr, dst, hdrLen);
+    memcpy(dst, hdr, hdrLen);
     if (hdrLen % 4) {
 	dst += hdrLen;
 	do {
@@ -212,7 +212,7 @@ tcpOptionsLoad(hdr, src, len, arg)
     long int len;
     VOID *arg;
 {
-    bcopy(src, hdr, len);
+    memcpy(hdr, src, len);
     return len;
 }
 

--- a/protocols/tcp-tahoe/tcp_output.c
+++ b/protocols/tcp-tahoe/tcp_output.c
@@ -294,7 +294,7 @@ send:
 			mss = htons(mss);
 			opt = tcp_initopt;
 			optlen = sizeof (tcp_initopt);
-			bcopy((char *)&mss, (char *)opt+2, sizeof(short));
+			memcpy((char *)opt+2, (char *)&mss, sizeof(short));
 		}
 	}
 	if (opt) {

--- a/protocols/tcp-tahoe/tcp_subr.c
+++ b/protocols/tcp-tahoe/tcp_subr.c
@@ -169,7 +169,7 @@ tcp_newtcpcb(inp)
 	register struct tcpcb *tp;
 
 	tp = (struct tcpcb *)xMalloc(sizeof *tp);
-	bzero((char*)tp, sizeof *tp);
+	memset((char*)tp, 0, sizeof *tp);
 	tp->seg_next = tp->seg_prev = (struct reass *)tp;
 	tp->t_maxseg = TCP_MSS;
 	tp->t_flags = 0;		/* sends options! */

--- a/protocols/tcp-tahoe/tcp_x.c
+++ b/protocols/tcp-tahoe/tcp_x.c
@@ -143,7 +143,7 @@ struct tcpstate *new_tcpstate()
 {
   struct tcpstate *tcpstate;
   tcpstate = (struct tcpstate *) xMalloc(sizeof(struct tcpstate));
-  bzero((char *)tcpstate, sizeof(struct tcpstate));
+  memset((char *)tcpstate, 0, sizeof(struct tcpstate));
   tcpSemInit(&tcpstate->waiting, 0);
   tcpSemInit(&tcpstate->lock, 1);
   tcpstate->closed = 0;

--- a/protocols/tcp/tcp_debug.c
+++ b/protocols/tcp/tcp_debug.c
@@ -58,11 +58,11 @@ tcp_trace(act, ostate, tp, ti, req)
 	if (tp)
 		td->td_cb = *tp;
 	else
-		bzero((caddr_t)&td->td_cb, sizeof (*tp));
+		memset((caddr_t)&td->td_cb, 0, sizeof (*tp));
 	if (ti)
 		td->td_ti = *ti;
 	else
-		bzero((caddr_t)&td->td_ti, sizeof (*ti));
+		memset((caddr_t)&td->td_ti, 0, sizeof (*ti));
 	td->td_req = req;
 	if (tcpconsdebug == 0)
 		return;

--- a/protocols/tcp/tcp_hdr.c
+++ b/protocols/tcp/tcp_hdr.c
@@ -89,7 +89,7 @@ tcpHdrStore(hdr, dst, len, arg)
     ((struct tcphdr *)hdr)->th_win   = htons(((struct tcphdr *)hdr)->th_win);
     ((struct tcphdr *)hdr)->th_urp   = htons(((struct tcphdr *)hdr)->th_urp);
     ((struct tcphdr *)hdr)->th_sum   = 0;
-    bcopy(hdr, dst, len);
+    memcpy(dst, hdr, len);
     /*
      * Checksum
      */
@@ -131,7 +131,7 @@ tcpHdrLoad(hdr, src, len, arg)
     xAssert(len == sizeof(struct tcphdr));
     pHdr = (u_short *)msgGetAttr((Msg *)arg, 0);
     xAssert(pHdr);
-    bcopy(src, hdr, len);
+    memcpy(hdr, src, len);
     xIfTrace(tcpp, CKSUM_TRACE) {
 	printf("Received: ");
 	dispPseudoHdr((IPpseudoHdr *)pHdr);
@@ -194,7 +194,7 @@ tcpOptionsStore(hdr, dst, len, arg)
     int hdrLen;	
     
     hdrLen = *(int *)arg;
-    bcopy(hdr, dst, hdrLen);
+    memcpy(dst, hdr, hdrLen);
     if (hdrLen % 4) {
 	dst += hdrLen;
 	do {
@@ -212,7 +212,7 @@ tcpOptionsLoad(hdr, src, len, arg)
     long int len;
     VOID *arg;
 {
-    bcopy(src, hdr, len);
+    memcpy(hdr, src, len);
     return len;
 }
 

--- a/protocols/tcp/tcp_output.c
+++ b/protocols/tcp/tcp_output.c
@@ -294,7 +294,7 @@ send:
 			mss = htons(mss);
 			opt = tcp_initopt;
 			optlen = sizeof (tcp_initopt);
-			bcopy((char *)&mss, (char *)opt+2, sizeof(short));
+			memcpy((char *)opt+2, (char *)&mss, sizeof(short));
 		}
 	}
 	if (opt) {

--- a/protocols/tcp/tcp_subr.c
+++ b/protocols/tcp/tcp_subr.c
@@ -180,7 +180,7 @@ tcp_newtcpcb(inp)
 	register struct tcpcb *tp;
 
 	tp = (struct tcpcb *)xMalloc(sizeof *tp);
-	bzero((char*)tp, sizeof *tp);
+	memset((char*)tp, 0, sizeof *tp);
 	tp->seg_next = tp->seg_prev = (struct reass *)tp;
 	tp->t_maxseg = TCP_MSS;
 	tp->t_flags = 0;		/* sends options! */

--- a/protocols/tcp/tcp_x.c
+++ b/protocols/tcp/tcp_x.c
@@ -103,7 +103,7 @@ tcp_init(self)
   xAssert(xIsProtocol(self));
 
   pstate = (PSTATE *)xMalloc(sizeof(PSTATE));
-  bzero((char *)pstate,sizeof(PSTATE));
+  memset((char *)pstate, 0, sizeof(PSTATE));
   self->state = (char *)pstate;
 
   self->control = tcpControlProtl;
@@ -133,7 +133,7 @@ struct tcpstate *new_tcpstate()
 {
   struct tcpstate *tcpstate;
   tcpstate = (struct tcpstate *) xMalloc(sizeof(struct tcpstate));
-  bzero((char *)tcpstate, sizeof(struct tcpstate));
+  memset((char *)tcpstate, 0, sizeof(struct tcpstate));
   tcpSemInit(&tcpstate->waiting, 0);
   tcpSemInit(&tcpstate->lock, 1);
   tcpstate->closed = 0;

--- a/protocols/test/common_test.c
+++ b/protocols/test/common_test.c
@@ -423,7 +423,7 @@ INIT_FUNC( self )
     }
     xControl(xGetDown(self, 0), GETMYHOST, (char *)&myHost, sizeof(HOST_TYPE));
     ps = X_NEW(PState);
-    bzero((char *)ps, sizeof(PState));
+    memset((char *)ps, 0, sizeof(PState));
     self->state = (VOID *)ps;
     /* 
      * Call the per-test initialization function which gives the test
@@ -457,7 +457,7 @@ isServerDefault( self )
     if ( ! strcmp(self->instName, "server") ) {
 	return TRUE;
     }
-    return ! bcmp((char *)&myHost, (char *)&ServerAddr, sizeof(HOST_TYPE));
+    return ! memcmp((char *)&myHost, (char *)&ServerAddr, sizeof(HOST_TYPE));
 }
 
 
@@ -473,7 +473,7 @@ isClientDefault( self )
 	ClientAddr = myHost;
 	return TRUE;
     }
-    return ! bcmp((char *)&myHost, (char *)&ClientAddr, sizeof(HOST_TYPE));
+    return ! memcmp((char *)&myHost, (char *)&ClientAddr, sizeof(HOST_TYPE));
 }
 
 

--- a/protocols/test/common_test_async.c
+++ b/protocols/test/common_test_async.c
@@ -150,7 +150,7 @@ defaultRunTest( self, len, testNumber )
 #ifdef CHECK_MESSAGE_CONTENTS
 static long revbcopy0(to,from,len,ignore)
     char *to, *from, *ignore; long len;
-{   bcopy(from,to,len); ignore++; return 0; }
+{   memcpy(to, from, len); ignore++; return 0; }
 #endif
 
 

--- a/protocols/test/xkpm_client.c
+++ b/protocols/test/xkpm_client.c
@@ -102,7 +102,7 @@ void pmapcln_init_part2(ev, arg) Event ev; VOID *arg;  /* arg is not used */
   { if (xControl(SUNRPC, GETMYHOST, (char *)&IPServer, sizeof(IPhost)) < 0)
     { printf("Can't find my IP addr\n"); return; }; };
 
-  bcopy((char *) &IPServer, (char *) &pmipaddr, sizeof(IPhost));
+  memcpy((char *) &pmipaddr, (char *) &IPServer, sizeof(IPhost));
 
   partInit(part, 1);
   partPush(part[0], (long *) &pmipaddr, sizeof(IPhost));
@@ -307,7 +307,7 @@ void test_server()
 	 testvalr, testvali, testzrsb=101.90625, testzisb=1767.5;
   XKXDR xdrs, xdrr; char buf[100], vbuf[100]; Msg msgr; long i;
 
-  bcopy((char *) &IPServer, (char *) &srvipaddr, sizeof(IPhost));
+  memcpy((char *) &srvipaddr, (char *) &IPServer, sizeof(IPhost));
 
 /* now actually do some testing */
 /* open a session to the determinant server */

--- a/protocols/test/xkpm_server.c
+++ b/protocols/test/xkpm_server.c
@@ -329,7 +329,7 @@ XObj self, s; Msg *msg, *msgr;
   /* the old way: extract procedure from SState structure */
   /* det_proc =  ((SState *) s->state)->s_proc; */
   /* the new way: sunrpc sticks it on the front of the message, sans xdring */
-  bcopy(buf,(char *)&det_proc,sizeof(long));
+  memcpy((char *)&det_proc, buf, sizeof(long));
   xTrace1(pmapsrvp,TR_FULL_TRACE,
 	  "det_calldemux: extracted procedure.   proc: %d", det_proc);
   if ( det_proc < 0 || 3 < det_proc )

--- a/protocols/test/xrpc_conc_test.c
+++ b/protocols/test/xrpc_conc_test.c
@@ -86,7 +86,7 @@ xrpcStore( hdr, dst, len, arg )
     long	n;
 
     n = htonl(*hdr);
-    bcopy((char *)&n, dst, sizeof(long));
+    memcpy(dst, (char *)&n, sizeof(long));
 }
 
 
@@ -95,7 +95,7 @@ xrpcLoad( hdr, src, len, arg )
     long	*hdr, len;
     VOID	*src, *arg;
 {
-    bcopy((char *)src, (char *)hdr, sizeof(long));
+    memcpy((char *)hdr, (char *)src, sizeof(long));
     *hdr = ntohl(*hdr);
     return sizeof(long);
 }

--- a/protocols/udp/udp.c
+++ b/protocols/udp/udp.c
@@ -124,7 +124,7 @@ udpHdrStore(hdr, dst, len, arg)
     ((HDR *)hdr)->sport = htons(((HDR *)hdr)->sport);
     ((HDR *)hdr)->dport = htons(((HDR *)hdr)->dport);
     ((HDR *)hdr)->sum = 0;
-    bcopy((char *)hdr, dst, sizeof(HDR));
+    memcpy(dst, (char *)hdr, sizeof(HDR));
     sstate = (SSTATE *)((storeInfo *)arg)->s->state;
     if (sstate->useCkSum) {
 	u_short sum = 0;
@@ -136,7 +136,7 @@ udpHdrStore(hdr, dst, len, arg)
 	}
 	sum = inCkSum(((storeInfo *)arg)->m, (u_short *)&sstate->pHdr,
 		       sizeof(IPpseudoHdr));
-	bcopy((char *)&sum, (char *)&((HDR *)dst)->sum, sizeof(u_short));
+	memcpy((char *)&((HDR *)dst)->sum, (char *)&sum, sizeof(u_short));
 	xAssert(! inCkSum(((storeInfo *)arg)->m, (u_short *)&sstate->pHdr,
 			  sizeof(IPpseudoHdr)));
     }
@@ -158,7 +158,7 @@ udpHdrLoad(hdr, src, len, arg)
   /*
    * 0 in the checksum field indicates checksum disabled
    */
-  bcopy(src, (char *)hdr, sizeof(HDR));
+  memcpy((char *)hdr, src, sizeof(HDR));
   if (((HDR *)hdr)->sum) {
     IPpseudoHdr *pHdr = (IPpseudoHdr *)msgGetAttr((Msg *)arg, 0);
 
@@ -194,7 +194,7 @@ udp_init(self)
     
     getproc_protl(self);
     pstate = X_NEW(PSTATE);
-    bzero((char *)pstate, sizeof(PSTATE));
+    memset((char *)pstate, 0, sizeof(PSTATE));
     self->state = (VOID *)pstate;
     pstate->activemap = mapCreate(ACTIVE_MAP_SIZE, sizeof(ActiveId));
     pstate->passivemap = mapCreate(PASSIVE_MAP_SIZE, sizeof(PassiveId)); 

--- a/protocols/util/port_mgr.c
+++ b/protocols/util/port_mgr.c
@@ -80,7 +80,7 @@ NAME/**/PortMapInit
 
   if (!(*ps))  {
     *ps = (port_state *)xMalloc(sizeof (port_state));
-    bzero((char *)*ps, sizeof(port_state));
+    memset((char *)*ps, 0, sizeof(port_state));
   }
   if ( ! (*ps)->portMap ) {
     (*ps)->portMap = mapCreate(PORT_MAP_SIZE, sizeof(long));

--- a/protocols/vcache/vcache.c
+++ b/protocols/vcache/vcache.c
@@ -205,7 +205,7 @@ vcacheCreateSessn( self, hlpRcv, hlpType, lls )
 	return ERR_XOBJ;
     }
     ss = X_NEW(SState);
-    bzero((char *)ss, sizeof(SState));
+    memset((char *)ss, 0, sizeof(SState));
     s->state = (VOID *)ss;
     ss->remote_host = peer;
     /*

--- a/protocols/vchan/vchan.c
+++ b/protocols/vchan/vchan.c
@@ -178,7 +178,7 @@ vchanOpen( self, hlpRcv, hlpType, p )
     pLen = partLen(p) * sizeof(Part);
     for ( i=0; i < DEFAULT_NUM_SESSNS; i++ ) {
 	Part	tmpPart[2];
-	bcopy((char *)p, (char *)tmpPart, pLen);
+	memcpy((char *)tmpPart, (char *)p, pLen);
 	lls = xOpen(self, hlpType, xGetDown(self, 0), tmpPart);
 	if ( lls == ERR_XOBJ ) {
 	    xTrace0(vchanp, TR_ERRORS, "vchanOpen could not open lls");
@@ -328,7 +328,7 @@ increaseConcurrency( s, n )
      */
     newArr = (XObj *)xMalloc((stack->size + n) * sizeof(XObj));
     xAssert( stack->s );
-    bcopy((char *)stack->s, (char *)newArr, stack->top * sizeof(XObj));
+    memcpy((char *)newArr, (char *)stack->s, stack->top * sizeof(XObj));
     xFree((char *)stack->s);
     stack->s = newArr;
     /*

--- a/protocols/vmux/vmux.c
+++ b/protocols/vmux/vmux.c
@@ -32,10 +32,10 @@
 	}
 
 #define savePart(pxx, spxx)	\
-    bcopy((char *)(pxx), (char *)(spxx), sizeof(Part) * partLen(p))
+    memcpy((char *)(spxx), (char *)(pxx), sizeof(Part) * partLen(p))
 
 #define restorePart(pxx, spxx)	\
-    bcopy((char *)(spxx), (char *)(pxx), sizeof(Part) * partLen(p))
+    memcpy((char *)(pxx), (char *)(spxx), sizeof(Part) * partLen(p))
 
 
 

--- a/protocols/vsize/vsize.c
+++ b/protocols/vsize/vsize.c
@@ -96,7 +96,7 @@ vsizeOpen(XObj self, XObj hlpRcv, XObj hlpType, Part *p)
      * use it in both opens and it will get munged in the first open
      */
     plen = partLen(p) * sizeof(Part);
-    bcopy((char *)p, (char *)savedPart, plen);
+    memcpy((char *)savedPart, (char *)p, plen);
 
     for (i=0; i<pstate->numdown; i++) {
     	lls[i] = xOpen(self, hlpType, xGetDown(self, i), p);
@@ -107,7 +107,7 @@ vsizeOpen(XObj self, XObj hlpRcv, XObj hlpType, Part *p)
 	    }
 	    return ERR_XOBJ;
         }
-        bcopy((char *)savedPart, (char *)p, plen);
+        memcpy((char *)p, (char *)savedPart, plen);
     }
     if ( mapResolve(pstate->activeMap, lls, &s) == XK_SUCCESS ) {
 	xTrace0(vsizep, TR_MAJOR_EVENTS, "found an existing one");


### PR DESCRIPTION
## Summary
- modernize protocols by replacing `bzero`, `bcopy` and `bcmp` with
  `memset`, `memcpy` and `memcmp`
- drop obsolete `bcopy`, `bzero` and `bcmp` prototypes from headers

## Testing
- `pre-commit` *(fails: `pre-commit: command not found`)*