### PR TITLE
Add 128-bit capability IDs

### DIFF
--- a/include/audit.h
+++ b/include/audit.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <stdint.h>
+#include "id128.h"
 
 typedef struct {
     uint32_t op;
-    uint64_t obj;
+    id128_t obj;
     int result;
 } audit_entry_t;
 
@@ -12,5 +13,5 @@ typedef struct {
 
 extern audit_entry_t audit_log[AUDIT_LOG_SIZE];
 
-void audit_record(uint32_t op, uint64_t obj, int result);
+void audit_record(uint32_t op, id128_t obj, int result);
 

--- a/include/auth.h
+++ b/include/auth.h
@@ -2,17 +2,18 @@
 
 #include <stdint.h>
 #include "../src-lites-1.1-2025/include/cap.h"
+#include "id128.h"
 
 typedef struct cap cap_t;
 
 typedef struct {
     const cap_t *subject;
     uint32_t op;
-    uint64_t obj;
+    id128_t obj;
 } acl_entry_t;
 
-void acl_add(const cap_t *subject, uint32_t op, uint64_t obj);
-int authorize(const cap_t *subject, uint32_t op, uint64_t obj);
+void acl_add(const cap_t *subject, uint32_t op, id128_t obj);
+int authorize(const cap_t *subject, uint32_t op, id128_t obj);
 
 #define CAP_OP_REFINE 1
 #define CAP_OP_REVOKE 2

--- a/include/id128.h
+++ b/include/id128.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <stdint.h>
+
+typedef unsigned _BitInt(128) id128_t;
+
+static inline id128_t id128_from_u64(uint64_t v)
+{
+    return (id128_t)v;
+}
+
+static inline uint64_t id128_to_u64(id128_t v)
+{
+    return (uint64_t)v;
+}

--- a/kern/audit.c
+++ b/kern/audit.c
@@ -3,7 +3,7 @@
 audit_entry_t audit_log[AUDIT_LOG_SIZE];
 static int audit_pos;
 
-void audit_record(uint32_t op, uint64_t obj, int result)
+void audit_record(uint32_t op, id128_t obj, int result)
 {
     audit_log[audit_pos].op = op;
     audit_log[audit_pos].obj = obj;

--- a/kern/auth.c
+++ b/kern/auth.c
@@ -6,7 +6,7 @@
 static acl_entry_t acl_table[MAX_ACL];
 static int acl_count;
 
-void acl_add(const cap_t *subject, uint32_t op, uint64_t obj)
+void acl_add(const cap_t *subject, uint32_t op, id128_t obj)
 {
     if (acl_count < MAX_ACL) {
         acl_table[acl_count].subject = subject;
@@ -16,7 +16,7 @@ void acl_add(const cap_t *subject, uint32_t op, uint64_t obj)
     }
 }
 
-int authorize(const cap_t *subject, uint32_t op, uint64_t obj)
+int authorize(const cap_t *subject, uint32_t op, id128_t obj)
 {
     for (int i = 0; i < acl_count; ++i) {
         if (acl_table[i].subject == subject &&

--- a/server/serv/ux_syscall.c
+++ b/server/serv/ux_syscall.c
@@ -45,6 +45,7 @@
 #include <serv/server_defs.h>
 #include <serv/syscall_subr.h>
 #include "auth.h"
+#include "id128.h"
 
 extern struct sysent	sysent[];
 int			nsysent;
@@ -148,7 +149,7 @@ ux_generic_server(mach_msg_header_t *InHeadP, mach_msg_header_t *OutHeadP)
 	static struct cap ipc_cap = {0};
 	ipc_cap.rights = 0xffffffff;
 	ipc_cap.epoch = 1;
-	if (!authorize(&ipc_cap, syscode, 0)) {
+        if (!authorize(&ipc_cap, syscode, id128_from_u64(0))) {
 	    rep->retcode = EPERM;
 	    return TRUE;
 	}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,25 +4,25 @@ add_executable(test_cap
     ../kern/auth.c
     ../kern/audit.c)
 target_include_directories(test_cap PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_compile_options(test_cap PRIVATE -std=gnu23 -Wall -Wextra -Werror)
+target_compile_options(test_cap PRIVATE -std=gnu2x -Wall -Wextra -Werror)
 
 add_executable(test_audit
     audit/test_audit.c
     ../kern/auth.c
     ../kern/audit.c)
 target_include_directories(test_audit PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_compile_options(test_audit PRIVATE -std=gnu23 -Wall -Wextra -Werror)
+target_compile_options(test_audit PRIVATE -std=gnu2x -Wall -Wextra -Werror)
 
 add_executable(test_iommu
     iommu/test_iommu.c
     ../src-lites-1.1-2025/iommu/iommu.c)
-target_compile_options(test_iommu PRIVATE -std=gnu23 -Wall -Wextra -Werror)
+target_compile_options(test_iommu PRIVATE -std=gnu2x -Wall -Wextra -Werror)
 
 add_executable(test_vm_fault
     vm_fault/test_vm_fault.c
     ../src-lites-1.1-2025/server/vm/vm_handlers.c
     ../posix.c)
-target_compile_options(test_vm_fault PRIVATE -std=gnu23 -Wall -Wextra -Werror)
+target_compile_options(test_vm_fault PRIVATE -std=gnu2x -Wall -Wextra -Werror)
 target_include_directories(test_vm_fault PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
 
@@ -30,13 +30,13 @@ add_executable(test_pipe
     pipe/test_pipe.c
     ../posix.c)
 target_include_directories(test_pipe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_compile_options(test_pipe PRIVATE -std=gnu23 -Wall -Wextra -Werror)
+target_compile_options(test_pipe PRIVATE -std=gnu2x -Wall -Wextra -Werror)
 
 add_executable(test_spawn_wait
     spawn_wait/test_spawn_wait.c
     ../posix.c)
 target_include_directories(test_spawn_wait PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_compile_options(test_spawn_wait PRIVATE -std=gnu23 -Wall -Wextra -Werror)
+target_compile_options(test_spawn_wait PRIVATE -std=gnu2x -Wall -Wextra -Werror)
 
 
 

--- a/tests/audit/test_audit.c
+++ b/tests/audit/test_audit.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include "../../include/auth.h"
 #include "../../include/audit.h"
+#include "../../include/id128.h"
 #include "../../src-lites-1.1-2025/include/cap.h"
 
 int main(void)
@@ -10,10 +11,10 @@ int main(void)
     subject.rights = 0xff;
     subject.epoch = 1;
 
-    acl_add(&subject, 1, 42); /* allow op 1 on obj 42 */
+    acl_add(&subject, 1, id128_from_u64(42)); /* allow op 1 on obj 42 */
 
     /* This should fail and be logged */
-    int ok = authorize(&subject, 2, 43);
+    int ok = authorize(&subject, 2, id128_from_u64(43));
     assert(!ok);
     assert(audit_log[0].op == 2);
     assert(audit_log[0].result == 0);

--- a/tests/cap/test_cap.c
+++ b/tests/cap/test_cap.c
@@ -1,8 +1,8 @@
 #include "../../src-lites-1.1-2025/include/cap.h"
 #include <assert.h>
 #include <stdlib.h>
-#include "../../src-lites-1.1-2025/include/cap.h"
 #include "../../include/auth.h"
+#include "../../include/id128.h"
 
 
 static void test_refine_basic(void) {
@@ -10,11 +10,11 @@ static void test_refine_basic(void) {
     root.rights = 0xff;
     root.epoch = 1;
 
-    acl_add(&root, CAP_OP_REFINE, 0x0f);
-    acl_add(&root, CAP_OP_REVOKE, 0);
+    acl_add(&root, CAP_OP_REFINE, id128_from_u64(0x0f));
+    acl_add(&root, CAP_OP_REVOKE, id128_from_u64(0));
     struct cap *child = cap_refine(&root, 0x0f, 0);
     assert(child);
-    acl_add(child, CAP_OP_REVOKE, 0);
+    acl_add(child, CAP_OP_REVOKE, id128_from_u64(0));
     assert(child->parent == &root);
     assert(child->rights == 0x0f);
     assert(child->epoch == root.epoch);
@@ -39,16 +39,16 @@ static void test_revoke_epoch_propagation(void) {
     root.rights = 0xff;
     root.epoch = 10;
 
-    acl_add(&root, CAP_OP_REFINE, 0x0f);
-    acl_add(&root, CAP_OP_REVOKE, 0);
+    acl_add(&root, CAP_OP_REFINE, id128_from_u64(0x0f));
+    acl_add(&root, CAP_OP_REVOKE, id128_from_u64(0));
 
     struct cap *child = cap_refine(&root, 0x0f, 0);
     assert(child);
-    acl_add(child, CAP_OP_REFINE, 0x01);
-    acl_add(child, CAP_OP_REVOKE, 0);
+    acl_add(child, CAP_OP_REFINE, id128_from_u64(0x01));
+    acl_add(child, CAP_OP_REVOKE, id128_from_u64(0));
     struct cap *grand = cap_refine(child, 0x01, 0);
     assert(grand);
-    acl_add(grand, CAP_OP_REVOKE, 0);
+    acl_add(grand, CAP_OP_REVOKE, id128_from_u64(0));
 
     revoke_capability(&root);
     assert(root.epoch == 11);


### PR DESCRIPTION
## Summary
- add helper for 128-bit identifiers
- update ACL and audit structures to use 128‑bit IDs
- switch kernel helpers and syscall wrapper to the new type
- adjust unit tests for the wider IDs
- use `gnu2x` in test CMakeLists so GCC 13 builds

## Testing
- `make -f Makefile.new test` *(fails: Mach headers not found)*