### PR TITLE
Update attribute macros

### DIFF
--- a/bootstrap/ext2_fs.h
+++ b/bootstrap/ext2_fs.h
@@ -337,7 +337,7 @@ struct ext2_dir_entry {
 # define NORET_AND     /**/
 #else
 # define NORET_TYPE    /**/
-# define ATTRIB_NORET  __attribute__((noreturn))
+# define ATTRIB_NORET  [[noreturn]]
 # define NORET_AND     noreturn,
 #endif
 
@@ -418,12 +418,12 @@ extern int ext2_rename (struct inode *, const char *, int,
 
 /* super.c */
 extern void ext2_error (struct super_block *, const char *, const char *, ...)
-	__attribute__ ((format (printf, 3, 4)));
+        [[gnu::format(printf, 3, 4)]];
 extern NORET_TYPE void ext2_panic (struct super_block *, const char *,
-				   const char *, ...)
-	__attribute__ ((NORET_AND format (printf, 3, 4)));
+                                   const char *, ...)
+        [[noreturn]] [[gnu::format(printf, 3, 4)]];
 extern void ext2_warning (struct super_block *, const char *, const char *, ...)
-	__attribute__ ((format (printf, 3, 4)));
+        [[gnu::format(printf, 3, 4)]];
 extern void ext2_put_super (struct super_block *);
 extern void ext2_write_super (struct super_block *);
 extern int ext2_remount (struct super_block *, int *, char *);

--- a/ddekit/attribs.h
+++ b/ddekit/attribs.h
@@ -6,8 +6,8 @@
 
 #else
 
-#define DDEKIT_USED        __attribute__((used))
-#define DDEKIT_CONSTRUCTOR __attribute__((constructor))
+#define DDEKIT_USED        [[gnu::used]]
+#define DDEKIT_CONSTRUCTOR [[gnu::constructor]]
 
 
 #define DDEKIT_PUBLIC PUBLIC

--- a/ddekit/initcall.h
+++ b/ddekit/initcall.h
@@ -19,8 +19,8 @@ void __ddekit_add_initcall(struct __ddekit_initcall_s *dis);
 #define DDEKIT_INITCALL(fn)	DDEKIT_CTOR(fn, 1)
 
 #define DDEKIT_CTOR(fn, prio) \
-	 static void __attribute__((used)) __attribute__((constructor))\
-	__ddekit_initcall_##fn() { \
+         static void [[gnu::used]] [[gnu::constructor]] \
+        __ddekit_initcall_##fn() { \
 	static struct __ddekit_initcall_s dis = {(ddekit_initcall_t)fn, prio, 0}; \
 	__ddekit_add_initcall(&dis); }
 

--- a/ddekit/inline.h
+++ b/ddekit/inline.h
@@ -1,2 +1,2 @@
-#define DDEKIT_INLINE __inline__ __attribute__((always_inline))
+#define DDEKIT_INLINE __inline__ [[gnu::always_inline]]
 

--- a/ddekit/thread.h
+++ b/ddekit/thread.h
@@ -117,7 +117,7 @@ void ddekit_thread_wakeup(ddekit_thread_t *thread);
  *
  * \ingroup DDEKit_threads
  */
-void ddekit_thread_exit(void) __attribute__((noreturn));
+[[noreturn]] void ddekit_thread_exit(void);
 
 /** Terminate a thread 
  *

--- a/i386/kernel/i386/seg.h
+++ b/i386/kernel/i386/seg.h
@@ -121,7 +121,7 @@ struct pseudo_descriptor
 {
 	unsigned short limit;
 	unsigned long linear_base;
-} __attribute__((packed));
+} [[gnu::packed]];
 
 
 /* Load the processor's IDT, GDT, or LDT pointers.  */

--- a/i386/kernel/i386at/gpl/linux/include/linux/kernel.h
+++ b/i386/kernel/i386at/gpl/linux/include/linux/kernel.h
@@ -32,13 +32,13 @@
 # define NORET_AND     /**/
 #else
 # define NORET_TYPE    /**/
-# define ATTRIB_NORET  __attribute__((noreturn))
+# define ATTRIB_NORET  [[noreturn]]
 # define NORET_AND     noreturn,
 #endif
 
 extern void math_error(void);
-NORET_TYPE void panic(const char * fmt, ...)
-	__attribute__ ((NORET_AND format (printf, 1, 2)));
+NORET_TYPE [[noreturn]] void panic(const char * fmt, ...)
+        [[gnu::format(printf, 1, 2)]];
 NORET_TYPE void do_exit(long error_code)
 	ATTRIB_NORET;
 extern unsigned long simple_strtoul(const char *,char **,unsigned int);
@@ -56,7 +56,7 @@ extern int kill_pg(int pgrp, int sig, int priv);
 extern int kill_sl(int sess, int sig, int priv);
 
 asmlinkage int printk(const char * fmt, ...)
-	__attribute__ ((format (printf, 1, 2)));
+        [[gnu::format(printf, 1, 2)]];
 
 /*
  * This is defined as a macro, but at some point this might become a

--- a/include/oddlibs/p_defs.h
+++ b/include/oddlibs/p_defs.h
@@ -66,26 +66,9 @@
 #endif /* !__cplusplus */
 
 
-/*
- * GCC1 and some versions of GCC2 declare dead (non-returning) and
- * pure (no side effects) functions using "volatile" and "const";
- * unfortunately, these then cause warnings under "-ansi -pedantic".
- * GCC2 uses a new, peculiar __attribute__((attrs)) style.  All of
- * these work for GNU C++ (modulo a slight glitch in the C++ grammar
- * in the distribution version of 2.5.5).
- */
-#if !defined(__GNUC__) || __GNUC__ < 2
-#define	__attribute__(x)	/* delete __attribute__ if non-gcc or gcc1 */
-#if defined(__GNUC__) && !defined(__STRICT_ANSI__)
-#define	__dead		__volatile
-#define	__pure		__const
-#endif
-#endif
-
-/* Delete pseudo-keywords wherever they are not available or needed. */
-#ifndef __dead
-#define	__dead
-#define	__pure
-#endif
+/* Use modern standard attributes */
+#define __dead [[noreturn]]
+#define __pure [[nodiscard]]
+#define __unused [[maybe_unused]]
 
 #endif /* !_CDEFS_H_ */


### PR DESCRIPTION
## Summary
- modernize attribute macros in `p_defs.h`
- use `[[noreturn]]` in thread interface
- mark initcall helpers with `[[gnu::used]]` and `[[gnu::constructor]]`
- apply gnu attributes to ext2 headers and linux helper
- pack pseudo-descriptor with `[[gnu::packed]]`

## Testing
- `make -n` *(fails: can't cd to /usr/obj/lites)*