### PR TITLE
Use modern attributes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: '-*,clang-analyzer-*'
+Checks: '-*,clang-analyzer-*,modernize-use-nodiscard'
 WarningsAsErrors: ''
 ExtraArgs: ['-std=c23']
 ExtraArgsCC: ['-std=c++17']

--- a/ddekit/thread.h
+++ b/ddekit/thread.h
@@ -117,7 +117,7 @@ void ddekit_thread_wakeup(ddekit_thread_t *thread);
  *
  * \ingroup DDEKit_threads
  */
-void ddekit_thread_exit(void) __attribute__((noreturn));
+void ddekit_thread_exit(void) [[noreturn]];
 
 /** Terminate a thread 
  *

--- a/include/oddlibs/p_defs.h
+++ b/include/oddlibs/p_defs.h
@@ -74,18 +74,14 @@
  * these work for GNU C++ (modulo a slight glitch in the C++ grammar
  * in the distribution version of 2.5.5).
  */
-#if !defined(__GNUC__) || __GNUC__ < 2
-#define	__attribute__(x)	/* delete __attribute__ if non-gcc or gcc1 */
-#if defined(__GNUC__) && !defined(__STRICT_ANSI__)
-#define	__dead		__volatile
-#define	__pure		__const
-#endif
-#endif
-
-/* Delete pseudo-keywords wherever they are not available or needed. */
-#ifndef __dead
-#define	__dead
-#define	__pure
+#if defined(__cplusplus) && __cplusplus >= 201103L
+#define __dead [[noreturn]]
+#define __pure [[nodiscard]]
+#define __maybe_unused [[maybe_unused]]
+#else
+#define __dead
+#define __pure
+#define __maybe_unused
 #endif
 
 #endif /* !_CDEFS_H_ */


### PR DESCRIPTION
## Summary
- apply standard attributes in p_defs.h
- replace noreturn attribute usage
- run modernize-use-nodiscard via clang-tidy

## Testing
- `make -f Makefile.new test` *(fails: Mach headers not found)*