### PR TITLE
Replace deprecated bzero/bcopy/bcmp usages

### DIFF
--- a/bootstrap/def_pager_setup.c
+++ b/bootstrap/def_pager_setup.c
@@ -44,14 +44,14 @@ add_paging_file(master_device_port, file_name)
 	struct file     	pfile;
 	boolean_t		isa_file;
 
-	bzero((char *) &pfile, sizeof(struct file));
+	memset((char *) &pfile, 0, sizeof(struct file));
 
 	result = open_file(master_device_port, file_name, &pfile);
 	if (result != KERN_SUCCESS)
 		return result;
 
 	fdp = (struct file_direct *) kalloc(sizeof *fdp);
-	bzero((char *) fdp, sizeof *fdp);
+	memset((char *) fdp, 0, sizeof *fdp);
 
 	isa_file = file_is_structured(&pfile);
 
@@ -123,7 +123,7 @@ default_pager_setup(master_device_port, server_dir_name)
 		   paging_file_name, 
 		   result);
 
-	    bzero(paging_file_name, sizeof(paging_file_name));
+	    memset(paging_file_name, 0, sizeof(paging_file_name));
 	    printf("Paging file name ? ");
 	    safe_gets(paging_file_name, sizeof(paging_file_name));
 

--- a/bootstrap/default_pager.c
+++ b/bootstrap/default_pager.c
@@ -161,9 +161,9 @@ partition_init()
  * add it to the list of all such.
  * size is in BYTES.
  */
-void
-create_paging_partition(name, size, p_read, p_write, p_private, isa_file)
-	char		*name;
+	memset((char *)part->bitmap, 0, bmsize);
+			memset(new_list, 0, n*sizeof(partition_t));
+			    memcpy(new_list, old_list, i*sizeof(partition_t));
 	vm_size_t	size;
 	int		(*p_read)();
 	int		(*p_write)();
@@ -1319,7 +1319,7 @@ default_read(ds, addr, size, offset, out_addr, deallocate)
 	/*
 	 * Read it, trying for the entire page.
 	 */
-	offset = ptoa(block.block.p_offset);
+	    memcpy((char *)addr, (char *)raddr, rsize);
 	part   = partition_of(block.block.p_index);
 	first_time = TRUE;
 	*out_addr = addr;
@@ -1803,7 +1803,7 @@ mach_port_t default_pager_default_set;	/* Port set for "default" thread. */
 
 typedef struct default_pager_thread {
 	cthread_t	dpt_thread;	/* Server thread. */
-	vm_offset_t	dpt_buffer;	/* Read buffer. */
+	memset((char *) ds, 0, sizeof *ds);
 	boolean_t	dpt_internal;	/* Do we handle internal objects? */
 } default_pager_thread_t;
 

--- a/bootstrap/ext2_file_io.c
+++ b/bootstrap/ext2_file_io.c
@@ -652,7 +652,7 @@ ext2_open_file(master_device_port, path, fp)
 
 #ifdef	IC_FASTLINK
 		if (fp->i_ic.i_blocks == 0) {
-		    bcopy(fp->i_ic.i_block, namebuf, (unsigned) link_len);
+		    memcpy(namebuf, fp->i_ic.i_block, (unsigned) link_len);
 		}
 		else
 #endif	IC_FASTLINK
@@ -675,7 +675,7 @@ ext2_open_file(master_device_port, path, fp)
 		    if (rc)
 			goto exit;
 
-		    bcopy((char *)buf, namebuf, (unsigned)link_len);
+		    memcpy(namebuf, (char *)buf, (unsigned)link_len);
 		    (void) vm_deallocate(mach_task_self(), buf, buf_size);
 		}
 
@@ -808,7 +808,7 @@ ext2_read_file(fp, offset, start, size, resid)
 	    if (csize == 0)
 		break;
 
-	    bcopy((char *)buf, (char *)start, csize);
+	    memcpy((char *)start, (char *)buf, csize);
 
 	    offset += csize;
 	    start  += csize;
@@ -950,8 +950,7 @@ ext2_add_file_direct(fdp, fp)
 	/* copy old addresses and install the new array */
 
 	if (fdp->fd_blocks != 0) {
-		bcopy((char *) fdp->fd_blocks, (char *) buffer,
-		      fdp->fd_size * sizeof(daddr_t));
+		memcpy((char *) buffer, (char *) fdp->fd_blocks, fdp->fd_size * sizeof(daddr_t));
 
 		(void) vm_deallocate(mach_task_self(),
 				(vm_offset_t) fdp->fd_blocks,

--- a/bootstrap/ffs_file_io.c
+++ b/bootstrap/ffs_file_io.c
@@ -626,7 +626,7 @@ ffs_open_file(master_device_port, path, fp)
 
 #ifdef	IC_FASTLINK
 		if ((fp->i_flags & IC_FASTLINK) != 0) {
-		    bcopy(fp->i_symlink, namebuf, (unsigned) link_len);
+		    memcpy(namebuf, fp->i_symlink, (unsigned) link_len);
 		}
 		else
 #endif	IC_FASTLINK
@@ -645,7 +645,7 @@ ffs_open_file(master_device_port, path, fp)
 		if ((link_len <= MAX_FASTLINK_SIZE && fp->i_ic.ic_db[1] != 0)
 		     || (link_len <= 4))
 		{
-		    bcopy(fp->i_symlink, namebuf, (unsigned) link_len);
+		    memcpy(namebuf, fp->i_symlink, (unsigned) link_len);
 		}
 		else
 #endif        /* !DISABLE_BSD44_FASTLINKS */
@@ -669,7 +669,7 @@ ffs_open_file(master_device_port, path, fp)
 		    if (rc)
 			goto exit;
 
-		    bcopy((char *)buf, namebuf, (unsigned)link_len);
+		    memcpy(namebuf, (char *)buf, (unsigned)link_len);
 		    (void) vm_deallocate(mach_task_self(), buf, buf_size);
 		}
 
@@ -802,7 +802,7 @@ ffs_read_file(fp, offset, start, size, resid)
 	    if (csize == 0)
 		break;
 
-	    bcopy((char *)buf, (char *)start, csize);
+	    memcpy((char *)start, (char *)buf, csize);
 
 	    offset += csize;
 	    start  += csize;
@@ -936,8 +936,7 @@ ffs_add_file_direct(fdp, fp)
 	/* copy old addresses and install the new array */
 
 	if (fdp->fd_blocks != 0) {
-		bcopy((char *) fdp->fd_blocks, (char *) buffer,
-		      fdp->fd_size * sizeof(daddr_t));
+		memcpy((char *) buffer, (char *) fdp->fd_blocks, fdp->fd_size * sizeof(daddr_t));
 
 		(void) vm_deallocate(mach_task_self(),
 				(vm_offset_t) fdp->fd_blocks,

--- a/bootstrap/load.c
+++ b/bootstrap/load.c
@@ -122,8 +122,7 @@ static int prog_read_exec(void *handle, vm_offset_t file_ofs, vm_size_t file_siz
 
 	if (mem_size > file_size)
 	{
-		bzero((void*)area_start + (mem_addr + file_size - page_start),
-			mem_size - file_size);
+		memset((void*)area_start + (mem_addr + file_size - page_start), 0, mem_size - file_size);
 	}
 
 	result = vm_allocate(st->user_task, &page_start, page_end - page_start, FALSE);
@@ -193,7 +192,7 @@ int boot_load_program(mach_port_t master_host_port,
 	/*
 	 * Open the file
 	 */
-	bzero((char *)&file, sizeof(file));
+	memset((char *)&file, 0, sizeof(file));
 
 	result = open_file(master_device_port, namebuf, &file);
 	if (result != 0) {
@@ -334,7 +333,7 @@ printf("loaded; entrypoint %08x\n", info.entry);
 		*k_ap++ = u_cp;
 
 		/* copy string */
-		bcopy(arg_ptr, k_cp, arg_item_len);
+		memcpy(k_cp, arg_ptr, arg_item_len);
 		k_cp += arg_item_len;
 		u_cp += arg_item_len;
 	    }

--- a/bootstrap/minix_file_io.c
+++ b/bootstrap/minix_file_io.c
@@ -681,7 +681,7 @@ minix_read_file(fp, offset, start, size, resid)
 	    if (csize == 0)
 		break;
 
-	    bcopy((char *)buf, (char *)start, csize);
+	    memcpy((char *)start, (char *)buf, csize);
 
 	    offset += csize;
 	    start  += csize;
@@ -818,8 +818,7 @@ minix_add_file_direct(fdp, fp)
 	/* copy old addresses and install the new array */
 
 	if (fdp->fd_blocks != 0) {
-		bcopy((char *) fdp->fd_blocks, (char *) buffer,
-		      fdp->fd_size * sizeof(minix_daddr_t));
+		memcpy((char *) buffer, (char *) fdp->fd_blocks, fdp->fd_size * sizeof(minix_daddr_t));
 
 		(void) vm_deallocate(mach_task_self(),
 				(vm_offset_t) fdp->fd_blocks,

--- a/bootstrap/strfcns.c
+++ b/bootstrap/strfcns.c
@@ -82,9 +82,9 @@ ovbcopy(from, to, bytes)
 {
 	/* Assume that bcopy copies left-to-right (low addr first). */
 	if (from + bytes <= to || to + bytes <= from || to == from)
-		bcopy(from, to, bytes);	/* non-overlapping or no-op*/
+		memcpy(to, from, bytes);	/* non-overlapping or no-op*/
 	else if (from > to)
-		bcopy(from, to, bytes);	/* overlapping but OK */
+		memcpy(to, from, bytes);	/* overlapping but OK */
 	else {
 		/* to > from: overlapping, and must copy right-to-left. */
 		from += bytes - 1;

--- a/i386/kernel/dos/dos_fstat.c
+++ b/i386/kernel/dos/dos_fstat.c
@@ -37,7 +37,7 @@ int dos_fstat(dos_fd_t fd, struct stat *st)
 
 	dos_init_rcd(&real_call_data);
 
-	bzero(st, sizeof(*st));
+	memset(st, 0, sizeof(*st));
 	st->st_nlink = 1;
 	st->st_mode = S_IRWXU | S_IRWXG | S_IRWXO; /* XXX attributes */
 

--- a/i386/kernel/dos/dos_tcgetattr.c
+++ b/i386/kernel/dos/dos_tcgetattr.c
@@ -35,7 +35,7 @@ int dos_tcgetattr(dos_fd_t fd, struct termios *t)
 
 	dos_init_rcd(&real_call_data);
 
-	bzero(t, sizeof(*t));
+	memset(t, 0, sizeof(*t));
 
 	/* First make sure this is actually a character device.  */
 	real_call_data.eax = 0x4400;

--- a/i386/kernel/i386/fpu.c
+++ b/i386/kernel/i386/fpu.c
@@ -254,7 +254,7 @@ ASSERT_IPL(SPL0);
 	    /*
 	     * Ensure that reserved parts of the environment are 0.
 	     */
-	    bzero((char *)&ifps->fp_save_state, sizeof(struct i386_fp_save));
+	    memset((char *)&ifps->fp_save_state, 0, sizeof(struct i386_fp_save));
 
 	    ifps->fp_save_state.fp_control = user_fp_state->fp_control;
 	    ifps->fp_save_state.fp_status  = user_fp_state->fp_status;
@@ -282,14 +282,10 @@ ASSERT_IPL(SPL0);
 			>> FPS_TOS_SHIFT;	/* physical register
 						   for st(0) */
 		if (i == 0)
-		    bcopy(src, dst, 8 * 10);
+		    memcpy(dst, src, 8 * 10);
 		else {
-		    bcopy(src,
-			  dst + 10 * i,
-			  10 * (8 - i));
-		    bcopy(src + 10 * (8 - i),
-			  dst,
-			  10 * i);
+		    memcpy(dst + 10 * i, src, 10 * (8 - i));
+		    memcpy(dst, src + 10 * (8 - i), 10 * i);
 		}
 	    }
 	    else
@@ -331,7 +327,7 @@ ASSERT_IPL(SPL0);
 	     * No valid floating-point state.
 	     */
 	    simple_unlock(&pcb->lock);
-	    bzero((char *)state, sizeof(struct i386_float_state));
+	    memset((char *)state, 0, sizeof(struct i386_float_state));
 	    return KERN_SUCCESS;
 	}
 
@@ -356,7 +352,7 @@ ASSERT_IPL(SPL0);
 	    /*
 	     * Ensure that reserved parts of the environment are 0.
 	     */
-	    bzero((char *)user_fp_state,  sizeof(struct i386_fp_save));
+	    memset((char *)user_fp_state, 0, sizeof(struct i386_fp_save));
 
 	    user_fp_state->fp_control = ifps->fp_save_state.fp_control;
 	    user_fp_state->fp_status  = ifps->fp_save_state.fp_status;
@@ -384,14 +380,10 @@ ASSERT_IPL(SPL0);
 			>> FPS_TOS_SHIFT;	/* physical register
 						   for st(0) */
 		if (i == 0)
-		    bcopy(src, dst, 8 * 10);
+		    memcpy(dst, src, 8 * 10);
 		else {
-		    bcopy(src + 10 * i,
-			  dst,
-			  10 * (8 - i));
-		    bcopy(src,
-			  dst + 10 * (8 - i),
-			  10 * i);
+		    memcpy(dst, src + 10 * i, 10 * (8 - i));
+		    memcpy(dst + 10 * (8 - i), src, 10 * i);
 		}
 	    }
 	    else
@@ -619,7 +611,7 @@ ASSERT_IPL(SPL0);
 	ifps = pcb->ims.ifps;
 	if (ifps == 0) {
 	    ifps = (struct i386_fpsave_state *) zalloc(ifps_zone);
-	    bzero(ifps, sizeof *ifps);
+	    memset(ifps, 0, sizeof *ifps);
 	    pcb->ims.ifps = ifps;
 	    fpinit();
 #if 1
@@ -662,7 +654,7 @@ fp_state_alloc()
 	struct i386_fpsave_state *ifps;
 
 	ifps = (struct i386_fpsave_state *)zalloc(ifps_zone);
-	bzero(ifps, sizeof *ifps);
+	memset(ifps, 0, sizeof *ifps);
 	pcb->ims.ifps = ifps;
 
 	ifps->fp_valid = TRUE;

--- a/i386/kernel/i386/iopb.c
+++ b/i386/kernel/i386/iopb.c
@@ -245,7 +245,7 @@ io_tss_init(
 	vm_offset_t	addr = (vm_offset_t) io_tss;
 	vm_size_t	size = (char *)&io_tss->barrier - (char *)io_tss;
 
-	bzero(&io_tss->tss, sizeof(struct i386_tss));
+	memset(&io_tss->tss, 0, sizeof(struct i386_tss));
 	io_tss->tss.io_bit_map_offset
 			= (char *)&io_tss->bitmap - (char *)io_tss;
 	io_tss->tss.ss0 = KERNEL_DS;
@@ -559,7 +559,7 @@ i386_io_port_list(thread, list, list_count)
 		    return KERN_RESOURCE_SHORTAGE;
 		}
 
-		bcopy((void *)addr, (void *)new_addr, size_needed);
+		memcpy((void *)new_addr, (void *)addr, size_needed);
 		kfree(addr, size);
 		devices = (mach_device_t *)new_addr;
 	    }

--- a/i386/kernel/i386/loose_ends.c
+++ b/i386/kernel/i386/loose_ends.c
@@ -47,9 +47,9 @@ ovbcopy(from, to, bytes)
 {
 	/* Assume that bcopy copies left-to-right (low addr first). */
 	if (from + bytes <= to || to + bytes <= from || to == from)
-		bcopy(from, to, bytes);	/* non-overlapping or no-op*/
+		memcpy(to, from, bytes);	/* non-overlapping or no-op*/
 	else if (from > to)
-		bcopy(from, to, bytes);	/* overlapping but OK */
+		memcpy(to, from, bytes);	/* overlapping but OK */
 	else {
 		/* to > from: overlapping, and must copy right-to-left. */
 		from += bytes - 1;

--- a/i386/kernel/i386/mp_desc.c
+++ b/i386/kernel/i386/mp_desc.c
@@ -129,17 +129,10 @@ mp_desc_init(mycpu)
 		/*
 		 * Copy the tables
 		 */
-		bcopy((char *)idt,
-		  (char *)mpt->idt,
-		  sizeof(idt));
-		bcopy((char *)gdt,
-		  (char *)mpt->gdt,
-		  sizeof(gdt));
-		bcopy((char *)ldt,
-		  (char *)mpt->ldt,
-		  sizeof(ldt));
-		bzero((char *)&mpt->ktss,
-		  sizeof(struct i386_tss));
+		memcpy((char *)mpt->idt, (char *)idt, sizeof(idt));
+		memcpy((char *)mpt->gdt, (char *)gdt, sizeof(gdt));
+		memcpy((char *)mpt->ldt, (char *)ldt, sizeof(ldt));
+		memset((char *)&mpt->ktss, 0, sizeof(struct i386_tss));
 
 		/*
 		 * Fix up the entries in the GDT to point to

--- a/i386/kernel/i386/pcb.c
+++ b/i386/kernel/i386/pcb.c
@@ -327,7 +327,7 @@ void pcb_init(thread)
 	/*
 	 *	We can't let random values leak out to the user.
 	 */
-	bzero((char *) pcb, sizeof *pcb);
+	memset((char *) pcb, 0, sizeof *pcb);
 	simple_lock_init(&pcb->lock);
 
 	/*
@@ -526,9 +526,7 @@ kern_return_t thread_setstatus(thread, flavor, tstate, count)
 			thread->pcb->ims.io_tss = tss;
 		}
 
-		bcopy((char *) state->pm,
-		      (char *) tss->bitmap,
-		      sizeof state->pm);
+		memcpy((char *) tss->bitmap, (char *) state->pm, sizeof state->pm);
 #endif
 		break;
 	    }
@@ -687,9 +685,7 @@ kern_return_t thread_getstatus(thread, flavor, tstate, count)
 		     *	The thread has its own ktss.
 		     */
 
-		    bcopy((char *) tss->bitmap,
-			  (char *) state->pm,
-			  sizeof state->pm);
+		    memcpy((char *) state->pm, (char *) tss->bitmap, sizeof state->pm);
 		}
 
 		*count = i386_ISA_PORT_MAP_STATE_COUNT;

--- a/i386/kernel/i386/phys.c
+++ b/i386/kernel/i386/phys.c
@@ -43,7 +43,7 @@ pmap_zero_page(p)
 	vm_offset_t p;
 {
 	assert(p != vm_page_fictitious_addr);
-	bzero(phystokv(p), PAGE_SIZE);
+	memset(phystokv(p), 0, PAGE_SIZE);
 }
 
 /*
@@ -55,7 +55,7 @@ pmap_copy_page(src, dst)
 	assert(src != vm_page_fictitious_addr);
 	assert(dst != vm_page_fictitious_addr);
 
-	bcopy(phystokv(src), phystokv(dst), PAGE_SIZE);
+	memcpy(phystokv(dst), phystokv(src), PAGE_SIZE);
 }
 
 /*
@@ -68,7 +68,7 @@ copy_to_phys(src_addr_v, dst_addr_p, count)
 	int count;
 {
 	assert(dst_addr_p != vm_page_fictitious_addr);
-	bcopy(src_addr_v, phystokv(dst_addr_p), count);
+	memcpy(phystokv(dst_addr_p), src_addr_v, count);
 }
 
 /*
@@ -82,7 +82,7 @@ copy_from_phys(src_addr_p, dst_addr_v, count)
 	int count;
 {
 	assert(src_addr_p != vm_page_fictitious_addr);
-	bcopy(phystokv(src_addr_p), dst_addr_v, count);
+	memcpy(dst_addr_v, phystokv(src_addr_p), count);
 }
 
 /*

--- a/i386/kernel/i386/trap.c
+++ b/i386/kernel/i386/trap.c
@@ -943,9 +943,7 @@ v86_assist(thread, regs)
 #ifdef	gcc_1_36_worked
 		int_vec = ((struct int_vec *)0)[vec];
 #else
-		bcopy((char *) (sizeof(struct int_vec) * vec),
-		      (char *)&int_vec,
-		      sizeof (struct int_vec));
+		memcpy((char *)&int_vec, (char *) (sizeof(struct int_vec) * vec), sizeof (struct int_vec));
 #endif
 		if (copyout((char *)&iret_16,
 			    (char *)Addr8086(regs->ss,sp),

--- a/i386/kernel/i386/user_ldt.c
+++ b/i386/kernel/i386/user_ldt.c
@@ -217,9 +217,7 @@ i386_set_ldt(thread, first_selector, desc_list, count, desc_list_inline)
 	     * Have new LDT.  Copy descriptors from current to new.
 	     */
 	    if (cur_ldt)
-		bcopy((char *) &cur_ldt->ldt[0],
-		      (char *) &new_ldt->ldt[0],
-		      cur_ldt->desc.limit_low + 1);
+		memcpy((char *) &new_ldt->ldt[0], (char *) &cur_ldt->ldt[0], cur_ldt->desc.limit_low + 1);
 
 	    old_ldt = cur_ldt;	/* discard old LDT */
 	    cur_ldt = new_ldt;	/* use new LDT from now on */
@@ -231,9 +229,7 @@ i386_set_ldt(thread, first_selector, desc_list, count, desc_list_inline)
 	/*
 	 * Install new descriptors.
 	 */
-	bcopy((char *) desc_list,
-	      (char *) &cur_ldt->ldt[first_desc],
-	      count * sizeof(struct real_descriptor));
+	memcpy((char *) &cur_ldt->ldt[first_desc], (char *) desc_list, count * sizeof(struct real_descriptor));
 
 	simple_unlock(&pcb->lock);
 
@@ -344,9 +340,7 @@ i386_get_ldt(thread, first_selector, selector_count, desc_list, count)
 	/*
 	 * copy out the descriptors
 	 */
-	bcopy((char *)&user_ldt[first_desc],
-	      (char *)*desc_list,
-	      ldt_size);
+	memcpy((char *)*desc_list, (char *)&user_ldt[first_desc], ldt_size);
 	*count = ldt_count;
 	simple_unlock(&pcb->lock);
 
@@ -367,7 +361,7 @@ i386_get_ldt(thread, first_selector, selector_count, desc_list, count)
 	     */
 	    size_left = size_used - ldt_size;
 	    if (size_left > 0)
-		bzero((char *)addr + ldt_size, size_left);
+		memset((char *)addr + ldt_size, 0, size_left);
 
 	    /*
 	     * Make memory into copyin form - this unwires it.

--- a/i386/kernel/i386at/fd.c
+++ b/i386/kernel/i386at/fd.c
@@ -1011,7 +1011,7 @@ rwend:		outb(0x0a, 0x06);
 		}
 		/* clear retry count */
 		if (cip->usebuf) {
-			bcopy(cip->b_vbuf, cip->b_xferaddr, cip->b_xferdma);
+			memcpy(cip->b_xferaddr, cip->b_vbuf, cip->b_xferdma);
 			DD(printf("R(%x, %x, %x)\n",
 				cip->b_vbuf, cip->b_xferaddr, cip->b_xferdma));
 		}
@@ -1554,7 +1554,7 @@ struct unit_info *uip;
 			cip->usebuf = 1;
 			address = (long)cip->b_pbuf;
 			if (cmdp->c_rwdata[0] == WTM || cmdp->c_rwdata[0] == FMTM) {
-				bcopy(cip->b_xferaddr, cip->b_vbuf, dmalen);
+				memcpy(cip->b_vbuf, cip->b_xferaddr, dmalen);
 				DD(printf("W(%x, %x, %x)\n",
 					cip->b_xferaddr, cip->b_vbuf, dmalen));
 			}

--- a/i386/kernel/i386at/gpl/if_ul.c
+++ b/i386/kernel/i386at/gpl/if_ul.c
@@ -432,11 +432,11 @@ ul_input(ns, count, buf, ring_offset)
 		/*
 		 * Input move must be wrapped.
 		 */
-		bcopy((char *)phystokv(xfer_start), buf, semi_count);
+		memcpy(buf, (char *)phystokv(xfer_start), semi_count);
 		count -= semi_count;
-		bcopy((char *)phystokv(ul->sc_rmstart), buf+semi_count, count);
+		memcpy(buf+semi_count, (char *)phystokv(ul->sc_rmstart), count);
 	} else
-		bcopy((char *)phystokv(xfer_start), buf, count);
+		memcpy(buf, (char *)phystokv(xfer_start), count);
 }
 
 int
@@ -453,7 +453,7 @@ ul_output(ns, count, buf, start_page)
 	DEBUGF(printf("ul%d: start_page = %d\n", ns->sc_unit, start_page));
 
 	shmem = (char *)phystokv(ul->sc_mstart + ((start_page-START_PG) << 8));
-	bcopy(buf, shmem, count);
+	memcpy(shmem, buf, count);
 	while (count <  ETHERMIN + sizeof(struct ether_header)) {
 		*(shmem + count) = 0;
 		count++;

--- a/i386/kernel/i386at/gpl/if_wd.c
+++ b/i386/kernel/i386at/gpl/if_wd.c
@@ -517,11 +517,11 @@ wd_input(ns, count, buf, ring_offset)
 		/*
 		 * Input move must be wrapped.
 		 */
-		bcopy((char *)phystokv(xfer_start), buf, semi_count);
+		memcpy(buf, (char *)phystokv(xfer_start), semi_count);
 		count -= semi_count;
-		bcopy((char *)phystokv(wd->sc_rmstart),buf+semi_count,count);
+		memcpy(buf+semi_count, (char *)phystokv(wd->sc_rmstart), count);
 	} else
-		bcopy((char *)phystokv(xfer_start), buf, count);
+		memcpy(buf, (char *)phystokv(xfer_start), count);
 	if (ns->sc_word16)
 		outb(port + WD_CMDREG5, wd->sc_reg5);
 }
@@ -542,10 +542,10 @@ wd_output(ns, count, buf, start_page)
 	shmem = (char *)phystokv(wd->sc_mstart+((start_page-WD_START_PG)<<8));
 	if (ns->sc_word16) {
 		outb(port + WD_CMDREG5, ISA16 | wd->sc_reg5);
-		bcopy(buf, shmem, count);
+		memcpy(shmem, buf, count);
 		outb(port + WD_CMDREG5, wd->sc_reg5);
 	} else
-		bcopy(buf, shmem, count);
+		memcpy(shmem, buf, count);
 	while (count <  ETHERMIN + sizeof(struct ether_header)) {
 		*(shmem + count) = 0;
 		count++;

--- a/include/mach 2/mig_support.h
+++ b/include/mach 2/mig_support.h
@@ -35,16 +35,6 @@
 #include <mach/message.h>
 #include <mach/mach_types.h>
 
-#if	defined(MACH_KERNEL)
-
-#if	defined(bcopy)
-#else	/* not defined(bcopy) */
-extern void	bcopy(const void *, void *, vm_size_t);
-#define	memcpy(_dst,_src,_len)	bcopy((_src),(_dst),(_len))
-#endif	/* defined(bcopy) */
-
-#endif	/* defined(MACH_KERNEL) */
-
 extern void		mig_init(void *_first);
 
 extern void		mig_allocate(vm_address_t *_addr_p, vm_size_t _size);

--- a/include/pi/event_monitor.c
+++ b/include/pi/event_monitor.c
@@ -119,8 +119,8 @@ findEvents( key, val, arg )
     if ( eva->i >= eva->max ) {
 	newSize = eva->max ? eva->max * 2 : MAX_EVENTS;
 	newArray = (Event *)xMalloc(sizeof(Event) * newSize);
-	bzero((char *)newArray, sizeof(Event) * newSize);
-	bcopy((char *)eva->arr, (char *)newArray, sizeof(Event) * eva->max);
+	memset((char *)newArray, 0, sizeof(Event) * newSize);
+	memcpy((char *)newArray, (char *)eva->arr, sizeof(Event) * eva->max);
 	if ( eva->arr ) {
 	    xFree((char *)eva->arr);
 	}

--- a/include/pi/hostbyname.c
+++ b/include/pi/hostbyname.c
@@ -27,7 +27,7 @@ static xkern_return_t addnametotable(str, nfields, line, arg )
   char hn[MAX_XKHOST_NAMELENGTH];
   int i;
 
-  bzero(hn, MAX_XKHOST_NAMELENGTH);
+  memset(hn, 0, MAX_XKHOST_NAMELENGTH);
   strncpy(hn, str[1], min(strlen(str[1]), MAX_XKHOST_NAMELENGTH));
   for (i=0; i<DNS_MAP_SIZE; i++) {
     if (!strcmp(hostnametable[i].h_name, hn))
@@ -69,12 +69,12 @@ xk_gethostbyname(namestr, addr)
   RomOpt options[] = { {"", 3, addnametotable} };
 
   if (!initialized) {
-    bzero((char *)hostnametable, sizeof(hostnametable));
+    memset((char *)hostnametable, 0, sizeof(hostnametable));
     findRomOpts("dns", options, 1, 0);
     initialized = 1;
   }
   
-  bzero(hn, MAX_XKHOST_NAMELENGTH);
+  memset(hn, 0, MAX_XKHOST_NAMELENGTH);
   strncpy(hn, namestr, min(strlen(namestr), MAX_XKHOST_NAMELENGTH));
   return xknameresolve(hn, addr);
 }

--- a/include/pi/idmap/idmap.c
+++ b/include/pi/idmap/idmap.c
@@ -81,7 +81,7 @@ mapCreate(nEntries, keySize)
     m->cache = 0;
     m->freelist = 0;
     m->table = (MapElement **)xMalloc(nEntries * sizeof(MapElement *));
-    bzero((char *)m->table, nEntries * sizeof(MapElement *));
+    memset((char *)m->table, 0, nEntries * sizeof(MapElement *));
     if (keySize > 0) {
       if (map_functions[keySize].resolve != 0) {
 	m->resolve = map_functions[keySize].resolve;
@@ -134,7 +134,7 @@ mapVarBind ( table, ext, len, intern )
     prev_elem = elem_posn;
     while (elem_posn != 0) {
 	o_ext = elem_posn->externalid;
-	if (!bcmp(o_ext, (char *)ext, len)) {
+	if (!memcmp(o_ext, (char *)ext, len)) {
 	    if (elem_posn->internalid == intern) {
 		return(elem_posn);
 	    } else {
@@ -152,7 +152,7 @@ mapVarBind ( table, ext, len, intern )
      * beginning for the semantics mapForEach to work properly.
      */
     GETVARMAPELEM(table, new_elem, len);
-    bcopy((char *)ext, (char *)new_elem->externalid, len);
+    memcpy((char *)new_elem->externalid, (char *)ext, len);
     new_elem->internalid = intern;
     new_elem->next = 0;
     new_elem->elmlen = len;
@@ -178,7 +178,7 @@ mapVarResolve ( table, ext, len, resPtr )
     
     if ((elem_posn = table->cache) && elem_posn->elmlen == len) {
 	o_ext = elem_posn->externalid;
-	if (!bcmp(o_ext, (char *)ext, len)) {
+	if (!memcmp(o_ext, (char *)ext, len)) {
 	    if ( resPtr ) {
 		*resPtr = elem_posn->internalid;
 	    }
@@ -189,7 +189,7 @@ mapVarResolve ( table, ext, len, resPtr )
     while (elem_posn != 0) {
 	o_ext = elem_posn->externalid;
 	if (elem_posn->elmlen == len &&
-	    !bcmp(o_ext, (char *)ext, len)) {
+	    !memcmp(o_ext, (char *)ext, len)) {
 	    table->cache = elem_posn;
 	    if ( resPtr ) {
 		*resPtr = elem_posn->internalid;
@@ -280,7 +280,7 @@ mapForEach(m, f, arg)
 		prevElem = 0;
 	    }
 	    if ( elem != 0 ) {
-		bcopy((char *)elem->externalid, key, m->keySize);
+		memcpy(key, (char *)elem->externalid, m->keySize);
 		userResult = f(key, elem->internalid, arg);
 		if ( ! (userResult & MFE_CONTINUE) ) {
 		    return;
@@ -311,8 +311,8 @@ static INLINE int	hash16( void *, int );
 #endif /* __STDC__ */
 
 
-#define GENCOMPBYTES(s1, s2) (!bcmp(s1, s2, table->keySize))
-#define GENCOPYBYTES(s1, s2) bcopy(s2, s1, table->keySize)
+#define GENCOMPBYTES(s1, s2) (!memcmp(s1, s2, table->keySize))
+#define GENCOPYBYTES(s1, s2) memcpy(s1, s2, table->keySize)
 
 #define KEYSIZE 2
 #define BINDNAME m2bind
@@ -626,8 +626,8 @@ generichash(key, tableSize, keySize)
 #define UNBINDNAME mgenericunbind
 #define HASH(K, tblSize, keySize) generichash(K, tblSize, keySize)
 #define GENHASH(K, T, keySize) generichash(K, tblSize, keySize)
-#define COMPBYTES(s1, s2) (!bcmp(s1, s2, table->keySize))
-#define COPYBYTES(s1, s2) bcopy(s2, s1, table->keySize)
+#define COMPBYTES(s1, s2) (!memcmp(s1, s2, table->keySize))
+#define COPYBYTES(s1, s2) memcpy(s1, s2, table->keySize)
 
 #include "idmap_templ.c"
 

--- a/include/pi/idmap/tests/mapTestCor.c
+++ b/include/pi/idmap/tests/mapTestCor.c
@@ -65,7 +65,7 @@ formKey( char *key, char frag )
     int	i;
 
     for ( i=0; i < keySize; i++ ) {
-	bcopy(&frag, key + i, sizeof(char));
+	memcpy(key + i, &frag, sizeof(char));
     }
 }
 
@@ -143,7 +143,7 @@ main( int argc, char **argv )
     for ( j=0; j < 1000; j++ ) {
 	randomKey(key1, keySize);
 	h = generichash(key1, 511, keySize);
-	bcopy(key1, offKey+1, keySize);
+	memcpy(offKey+1, key1, keySize);
 	if ( (hashFunc && h != hashFunc(key1, 511)) ||
 	     h != generichash(offKey+1, 511, keySize) ) {
 	    for ( i=0; i < keySize; i++ ) {

--- a/include/pi/idmap/tests/mapTestCor2.c
+++ b/include/pi/idmap/tests/mapTestCor2.c
@@ -54,7 +54,7 @@ formKey( char *key, char frag )
     int	i;
 
     for ( i=0; i < keySize; i++ ) {
-	bcopy(&frag, key + i, sizeof(char));
+	memcpy(key + i, &frag, sizeof(char));
     }
 }
 
@@ -199,14 +199,14 @@ main( int argc, char **argv )
     m = mapCreate(11, keySize);
     
     randomKey(key1, keySize);
-    bcopy(key1, offKey, keySize);
+    memcpy(offKey, key1, keySize);
 
     b = mapBind(m, key1, 22);
     xAssert( b != ERR_BIND );
     xkr = mapResolve(m, key1, &ptr);
     xAssert( xkr == XK_SUCCESS );
     xAssert( ptr == (VOID *)22 );
-    bzero(key2, keySize);
+    memset(key2, 0, keySize);
     xkr = mapResolve(m, key2, &ptr);
     xAssert( xkr == XK_FAILURE );
     b = mapBind(m, offKey, 25);

--- a/include/pi/idmap/tests/mapTestPerf.c
+++ b/include/pi/idmap/tests/mapTestPerf.c
@@ -55,13 +55,13 @@ formKey( char *key, char frag )
 
 #if 0
     for ( i=0; i < keySize; i++ ) {
-	bcopy(&frag, key + i, sizeof(char)); 
+	memcpy(key + i, &frag, sizeof(char)); 
 	/* 
 	 * Try to get the same hash values independent of the key size. 
 	 */
     }
 #endif
-    bzero(key, keySize);
+    memset(key, 0, keySize);
     key[INDEX] = frag;
     xIfTrace(maptest, TR_FULL_TRACE) {
 	printf("key: ");

--- a/include/pi/msg.c
+++ b/include/pi/msg.c
@@ -606,11 +606,11 @@ void msgConstructBuffer(this, buf, len)
   this->lastStackTailPtr = this->stackTailPtr;
   this->tailstate.myLastStack = 1;
   /* copy in data */
-  bcopy(buf, this->stackHeadPtr, len);
+  memcpy(this->stackHeadPtr, buf, len);
 #else
   this->length = len;
   this->offset = this->stack->b.leaf.size - roundlen;
-  bcopy(buf, this->stack->b.leaf.data + this->offset, len);
+  memcpy(this->stack->b.leaf.data + this->offset, buf, len);
 #endif MSG_NEW_ALG
   this->attr = 0;
   this->attrLen = 0;
@@ -1136,7 +1136,7 @@ s_copy(buf, len, arg)
   /* bcopy takes an int, so be careful */
   chunki = chunk_size;
   xAssert( (long) chunki == chunk_size);
-  bcopy(buf, a->buf, chunki);
+  memcpy(a->buf, buf, chunki);
   a->buf += chunk_size;
   a->size -= chunk_size;
   return (a->size != 0);
@@ -1520,7 +1520,7 @@ static void msgnrpush(stack, item)
 
     newstack = realloc(stack->bottom, newsize);
     if (newstack != (char *)(stack->bottom)) {
-      bcopy((char *)(stack->bottom), newstack, stack->size);
+      memcpy(newstack, (char *)(stack->bottom), stack->size);
       xFree((char *)stack->bottom);
       stack->top = (MNodePage **)(newstack + ((char *)stack->top - (char *)stack->bottom));
       stack->bottom = (MNodePage **)newstack;
@@ -2139,7 +2139,7 @@ frag2Buf( frag, len, bufPtr )
 {
     xTrace3(msg, TR_FUNCTIONAL_TRACE, "frag2Buf copying %d bytes from %x to %x",
 	    len, (int)frag, (int)(*(char **)bufPtr));
-    bcopy(frag, *(char **)bufPtr, len);
+    memcpy(*(char **)bufPtr, frag, len);
     *(char **)bufPtr += len;
     return TRUE;
 }

--- a/include/pi/part.c
+++ b/include/pi/part.c
@@ -143,7 +143,7 @@ partExternalize( p, dstBuf, bufLen )
 	    buf += sizeof(int);
 	    if ( len ) {
 		CHECK_BUF_LEN(len);
-		bcopy((char *)p->stack.arr[j].ptr, buf, len);
+		memcpy(buf, (char *)p->stack.arr[j].ptr, len);
 		buf += len;
 	    } else {
 		/* 
@@ -160,7 +160,7 @@ partExternalize( p, dstBuf, bufLen )
 	}
     }
     *bufLen = buf - bufStart;
-    bcopy(bufStart, dstBuf, *bufLen);
+    memcpy(dstBuf, bufStart, *bufLen);
     xFree(bufStart);
     return XK_SUCCESS;
 }

--- a/include/pi/prottbl.c
+++ b/include/pi/prottbl.c
@@ -100,7 +100,7 @@ mkKey(key, name)
     char *key;
     char *name;
 {
-    bzero(key, MAX_PROT_NAME);
+    memset(key, 0, MAX_PROT_NAME);
     strncpy(key, name, MAX_PROT_NAME);
 }
 

--- a/include/pi/rwlock.c
+++ b/include/pi/rwlock.c
@@ -177,7 +177,7 @@ void
 rwLockInit( l )
     ReadWriteLock	*l;
 {
-    bzero((char *)l, sizeof(ReadWriteLock));
+    memset((char *)l, 0, sizeof(ReadWriteLock));
     semInit(&l->readersSem, 0);
     semInit(&l->writersSem, 0);
 }

--- a/include/pi/upi.c
+++ b/include/pi/upi.c
@@ -474,7 +474,7 @@ xCreateXObj(downc, downv)
     xTrace0(protocol, TR_ERRORS, "xCreateObj malloc failure(1)");
     return ERR_XOBJ;
   }
-  bzero((char *)s, sizeof(struct xobj));
+  memset((char *)s, 0, sizeof(struct xobj));
   s->numdown = downc;
   if (downc > STD_DOWN) {
     s->downlistsz = (((downc - STD_DOWN) / STD_DOWN) + 1) * STD_DOWN;
@@ -618,8 +618,7 @@ xSetDown( s, i, obj )
 	    newsz = ((n / STD_DOWN) + 1) * STD_DOWN;
 	    newdl = (XObj *) xMalloc(newsz * sizeof(XObj));
 	    if ( s->downlist ) {
-		bcopy((char *)s->downlist, (char *)newdl,
-		      s->downlistsz * sizeof(XObj));
+		memcpy((char *)newdl, (char *)s->downlist, s->downlistsz * sizeof(XObj));
 		xFree((char *)s->downlist);
 	    }
 	    s->downlist = newdl;

--- a/include/pi/upi_defaults.c
+++ b/include/pi/upi_defaults.c
@@ -17,10 +17,10 @@ int	traceprotdef = 0;
 
 
 #define savePart(pxx, spxx)	\
-    bcopy((char *)(pxx), (char *)(spxx), sizeof(Part) * partLen(p))
+    memcpy((char *)(spxx), (char *)(pxx), sizeof(Part) * partLen(p))
 
 #define restorePart(pxx, spxx)	\
-    bcopy((char *)(spxx), (char *)(pxx), sizeof(Part) * partLen(p))
+    memcpy((char *)(pxx), (char *)(spxx), sizeof(Part) * partLen(p))
 
 /* 
  * Check for a valid participant list
@@ -146,7 +146,7 @@ findHlpEnable( key, val, arg )
 
     if ( e->hlpRcv == fs->hlpRcv ) {
 	fs->e = e;
-	bcopy(key, fs->key, fs->keySize);
+	memcpy(fs->key, key, fs->keySize);
 	return FALSE;
     } else {
 	return TRUE;

--- a/kern/Mach Kernel/include/utah/x_libc.h
+++ b/kern/Mach Kernel/include/utah/x_libc.h
@@ -24,9 +24,6 @@
 #include <string.h>
 #include <stdio.h>
 
-extern void     bcopy( char *, char *, int );
-extern int	bcmp( char *, char *, int );
-extern void     bzero( char *, int );
 
 #endif ! XKMACHKERNEL
 

--- a/kern/Mach Kernel/include/x_libc.h
+++ b/kern/Mach Kernel/include/x_libc.h
@@ -22,9 +22,6 @@
 #include <string.h>
 #include <stdio.h>
 
-extern void     bcopy( char *, char *, int );
-extern int	bcmp( char *, char *, int );
-extern void     bzero( char *, int );
 extern int	qsort( char *, int, int, int(*)());
 
 #endif ! XKMACHKERNEL

--- a/netbsd/include/x_libc.h
+++ b/netbsd/include/x_libc.h
@@ -21,18 +21,12 @@
 
 
 #ifndef X_NETBSD
-extern void     bcopy( char *, char *, int );
-extern int	bcmp( char *, char *, int );
-extern void     bzero( char *, int );
 extern int	qsort( char *, int, int, int(*)());
 
 extern int	lwp_self();
 
 #else
 
-extern void     bcopy();
-extern int	bcmp();
-extern void     bzero();
 
 
 #endif  ! x_libc_h

--- a/server/netinet/if_ether.h
+++ b/server/netinet/if_ether.h
@@ -197,8 +197,8 @@ struct ether_multistep {
 { \
 	for ((enm) = (ac)->ac_multiaddrs; \
 	    (enm) != NULL && \
-	    (bcmp((enm)->enm_addrlo, (addrlo), 6) != 0 || \
-	     bcmp((enm)->enm_addrhi, (addrhi), 6) != 0); \
+	    (memcmp((enm)->enm_addrlo, (addrlo), 6) != 0 || \
+	     memcmp((enm)->enm_addrhi, (addrhi), 6) != 0); \
 		(enm) = (enm)->enm_next); \
 }
 

--- a/server/netinet/igmp.c
+++ b/server/netinet/igmp.c
@@ -296,7 +296,7 @@ igmp_sendreport(inm)
 	igmp->igmp_cksum = in_cksum(m, IGMP_MINLEN);
 
 	imo = &simo;
-	bzero((caddr_t)imo, sizeof(*imo));
+	memset((caddr_t)imo, 0, sizeof(*imo));
 	imo->imo_multicast_ifp = inm->inm_ifp;
 	imo->imo_multicast_ttl = 1;
 	/*

--- a/server/netinet/in.c
+++ b/server/netinet/in.c
@@ -209,7 +209,7 @@ in_control(so, cmd, data, ifp)
 				malloc(sizeof *oia, M_IFADDR, M_WAITOK);
 			if (oia == (struct in_ifaddr *)NULL)
 				return (ENOBUFS);
-			bzero((caddr_t)oia, sizeof *oia);
+			memset((caddr_t)oia, 0, sizeof *oia);
 			if (ia = in_ifaddr) {
 				for ( ; ia->ia_next; ia = ia->ia_next)
 					continue;

--- a/server/netinet/in_pcb.c
+++ b/server/netinet/in_pcb.c
@@ -67,7 +67,7 @@ in_pcballoc(so, head)
 	MALLOC(inp, struct inpcb *, sizeof(*inp), M_PCB, M_WAITOK);
 	if (inp == NULL)
 		return (ENOBUFS);
-	bzero((caddr_t)inp, sizeof(*inp));
+	memset((caddr_t)inp, 0, sizeof(*inp));
 	inp->inp_head = head;
 	inp->inp_socket = so;
 	insque(inp, head);
@@ -311,7 +311,7 @@ in_setsockaddr(inp, nam)
 	
 	nam->m_len = sizeof (*sin);
 	sin = mtod(nam, struct sockaddr_in *);
-	bzero((caddr_t)sin, sizeof (*sin));
+	memset((caddr_t)sin, 0, sizeof (*sin));
 	sin->sin_family = AF_INET;
 	sin->sin_len = sizeof(*sin);
 	sin->sin_port = inp->inp_lport;
@@ -327,7 +327,7 @@ in_setpeeraddr(inp, nam)
 	
 	nam->m_len = sizeof (*sin);
 	sin = mtod(nam, struct sockaddr_in *);
-	bzero((caddr_t)sin, sizeof (*sin));
+	memset((caddr_t)sin, 0, sizeof (*sin));
 	sin->sin_family = AF_INET;
 	sin->sin_len = sizeof(*sin);
 	sin->sin_port = inp->inp_fport;
@@ -412,7 +412,7 @@ in_losing(inp)
 
 	if ((rt = inp->inp_route.ro_rt)) {
 		inp->inp_route.ro_rt = 0;
-		bzero((caddr_t)&info, sizeof(info));
+		memset((caddr_t)&info, 0, sizeof(info));
 		info.rti_info[RTAX_DST] =
 			(struct sockaddr *)&inp->inp_route.ro_dst;
 		info.rti_info[RTAX_GATEWAY] = rt->rt_gateway;

--- a/server/netinet/ip_icmp.c
+++ b/server/netinet/ip_icmp.c
@@ -136,7 +136,7 @@ icmp_error(n, type, code, dest, destifp)
 	}
 
 	icp->icmp_code = code;
-	bcopy((caddr_t)oip, (caddr_t)&icp->icmp_ip, icmplen);
+	memcpy((caddr_t)&icp->icmp_ip, (caddr_t)oip, icmplen);
 	nip = &icp->icmp_ip;
 	nip->ip_len = htons((u_short)(nip->ip_len + oiplen));
 
@@ -151,7 +151,7 @@ icmp_error(n, type, code, dest, destifp)
 	m->m_pkthdr.len = m->m_len;
 	m->m_pkthdr.rcvif = n->m_pkthdr.rcvif;
 	nip = mtod(m, struct ip *);
-	bcopy((caddr_t)oip, (caddr_t)nip, sizeof(struct ip));
+	memcpy((caddr_t)nip, (caddr_t)oip, sizeof(struct ip));
 	nip->ip_len = m->m_len;
 	nip->ip_hl = sizeof(struct ip) >> 2;
 	nip->ip_p = IPPROTO_ICMP;
@@ -490,8 +490,7 @@ icmp_reflect(m)
 			     */
 			    if (opt == IPOPT_RR || opt == IPOPT_TS || 
 				opt == IPOPT_SECURITY) {
-				    bcopy((caddr_t)cp,
-					mtod(opts, caddr_t) + opts->m_len, len);
+				    memcpy(mtod(opts, (caddr_t)cp, caddr_t) + opts->m_len, len);
 				    opts->m_len += len;
 			    }
 		    }
@@ -518,8 +517,7 @@ icmp_reflect(m)
 		if (m->m_flags & M_PKTHDR)
 			m->m_pkthdr.len -= optlen;
 		optlen += sizeof(struct ip);
-		bcopy((caddr_t)ip + optlen, (caddr_t)(ip + 1),
-			 (unsigned)(m->m_len - sizeof(struct ip)));
+		memcpy((caddr_t)(ip + 1), (caddr_t)ip + optlen, (unsigned)(m->m_len - sizeof(struct ip)));
 	}
 	m->m_flags &= ~(M_BCAST|M_MCAST);
 	icmp_send(m, opts);

--- a/server/netinet/ip_input.c
+++ b/server/netinet/ip_input.c
@@ -138,7 +138,7 @@ ip_init()
 #if GATEWAY
 	i = (if_index + 1) * (if_index + 1) * sizeof (u_long);
 	ip_ifmatrix = (u_long *) malloc(i, M_RTABLE, M_WAITOK);
-	bzero((char *)ip_ifmatrix, i);
+	memset((char *)ip_ifmatrix, 0, i);
 #endif
 }
 
@@ -734,8 +734,7 @@ ip_dooptions(m)
 			/*
 			 * locate outgoing interface
 			 */
-			bcopy((caddr_t)(cp + off), (caddr_t)&ipaddr.sin_addr,
-			    sizeof(ipaddr.sin_addr));
+			memcpy((caddr_t)&ipaddr.sin_addr, (caddr_t)(cp + off), sizeof(ipaddr.sin_addr));
 			if (opt == IPOPT_SSRR) {
 #define	INA	struct in_ifaddr *
 #define	SA	struct sockaddr *
@@ -749,8 +748,7 @@ ip_dooptions(m)
 				goto bad;
 			}
 			ip->ip_dst = ipaddr.sin_addr;
-			bcopy((caddr_t)&(IA_SIN(ia)->sin_addr),
-			    (caddr_t)(cp + off), sizeof(struct in_addr));
+			memcpy((caddr_t)(cp + off), (caddr_t)&(IA_SIN(ia)->sin_addr), sizeof(struct in_addr));
 			cp[IPOPT_OFFSET] += sizeof(struct in_addr);
 			/*
 			 * Let ip_intr's mcast routing check handle mcast pkts
@@ -769,8 +767,7 @@ ip_dooptions(m)
 			off--;			/* 0 origin */
 			if (off > optlen - sizeof(struct in_addr))
 				break;
-			bcopy((caddr_t)(&ip->ip_dst), (caddr_t)&ipaddr.sin_addr,
-			    sizeof(ipaddr.sin_addr));
+			memcpy((caddr_t)&ipaddr.sin_addr, (caddr_t)(&ip->ip_dst), sizeof(ipaddr.sin_addr));
 			/*
 			 * locate outgoing interface; if we're the destination,
 			 * use the incoming interface (should be same).
@@ -781,8 +778,7 @@ ip_dooptions(m)
 				code = ICMP_UNREACH_HOST;
 				goto bad;
 			}
-			bcopy((caddr_t)&(IA_SIN(ia)->sin_addr),
-			    (caddr_t)(cp + off), sizeof(struct in_addr));
+			memcpy((caddr_t)(cp + off), (caddr_t)&(IA_SIN(ia)->sin_addr), sizeof(struct in_addr));
 			cp[IPOPT_OFFSET] += sizeof(struct in_addr);
 			break;
 
@@ -811,8 +807,7 @@ ip_dooptions(m)
 							    m->m_pkthdr.rcvif);
 				if (ia == 0)
 					continue;
-				bcopy((caddr_t)&IA_SIN(ia)->sin_addr,
-				    (caddr_t)sin, sizeof(struct in_addr));
+				memcpy((caddr_t)sin, (caddr_t)&IA_SIN(ia)->sin_addr, sizeof(struct in_addr));
 				ipt->ipt_ptr += sizeof(struct in_addr);
 				break;
 
@@ -820,8 +815,7 @@ ip_dooptions(m)
 				if (ipt->ipt_ptr + sizeof(n_time) +
 				    sizeof(struct in_addr) > ipt->ipt_len)
 					goto bad;
-				bcopy((caddr_t)sin, (caddr_t)&ipaddr.sin_addr,
-				    sizeof(struct in_addr));
+				memcpy((caddr_t)&ipaddr.sin_addr, (caddr_t)sin, sizeof(struct in_addr));
 				if (ifa_ifwithaddr((SA)&ipaddr) == 0)
 					continue;
 				ipt->ipt_ptr += sizeof(struct in_addr);
@@ -831,8 +825,7 @@ ip_dooptions(m)
 				goto bad;
 			}
 			ntime = iptime();
-			bcopy((caddr_t)&ntime, (caddr_t)cp + ipt->ipt_ptr - 1,
-			    sizeof(n_time));
+			memcpy((caddr_t)cp + ipt->ipt_ptr - 1, (caddr_t)&ntime, sizeof(n_time));
 			ipt->ipt_ptr += sizeof(n_time);
 		}
 	}
@@ -894,7 +887,7 @@ save_rte(option, dst)
 #endif
 	if (olen > sizeof(ip_srcrt) - (1 + sizeof(dst)))
 		return;
-	bcopy((caddr_t)option, (caddr_t)ip_srcrt.srcopt, olen);
+	memcpy((caddr_t)ip_srcrt.srcopt, (caddr_t)option, olen);
 	ip_nhops = (olen - IPOPT_OFFSET - 1) / sizeof(struct in_addr);
 	ip_srcrt.dst = dst;
 }
@@ -941,8 +934,7 @@ ip_srcroute()
 	 */
 	ip_srcrt.nop = IPOPT_NOP;
 	ip_srcrt.srcopt[IPOPT_OFFSET] = IPOPT_MINOFF;
-	bcopy((caddr_t)&ip_srcrt.nop,
-	    mtod(m, caddr_t) + sizeof(struct in_addr), OPTSIZ);
+	memcpy(mtod(m, (caddr_t)&ip_srcrt.nop, caddr_t) + sizeof(struct in_addr), OPTSIZ);
 	q = (struct in_addr *)(mtod(m, caddr_t) +
 	    sizeof(struct in_addr) + OPTSIZ);
 #undef OPTSIZ
@@ -988,7 +980,7 @@ ip_stripoptions(m, mopt)
 	olen = (ip->ip_hl<<2) - sizeof (struct ip);
 	opts = (caddr_t)(ip + 1);
 	i = m->m_len - (sizeof (struct ip) + olen);
-	bcopy(opts  + olen, opts, (unsigned)i);
+	memcpy(opts, opts  + olen, (unsigned)i);
 	m->m_len -= olen;
 	if (m->m_flags & M_PKTHDR)
 		m->m_pkthdr.len -= olen;

--- a/server/netinet/ip_mroute.c
+++ b/server/netinet/ip_mroute.c
@@ -97,7 +97,7 @@ static	void phyint_send (struct mbuf *, struct vif *);
 static	void tunnel_send (struct mbuf *, struct vif *);
 
 #define INSIZ sizeof(struct in_addr)
-#define	same(a1, a2) (bcmp((caddr_t)(a1), (caddr_t)(a2), INSIZ) == 0)
+#define	same(a1, a2) (memcmp((caddr_t)(a1), (caddr_t)(a2), INSIZ) == 0)
 #define	satosin(sa)	((struct sockaddr_in *)(sa))
 
 /*
@@ -239,7 +239,7 @@ ip_mrouter_done()
 			(*ifp->if_ioctl)(ifp, SIOCDELMULTI, (caddr_t)&ifr);
 		}
 	}
-	bzero((caddr_t)viftable, sizeof(viftable));
+	memset((caddr_t)viftable, 0, sizeof(viftable));
 	numvifs = 0;
 
 	/*
@@ -248,7 +248,7 @@ ip_mrouter_done()
 	for (i = 0; i < MRTHASHSIZ; i++)
 		if (mrttable[i])
 			free(mrttable[i], M_MRTABLE);
-	bzero((caddr_t)mrttable, sizeof(mrttable));
+	memset((caddr_t)mrttable, 0, sizeof(mrttable));
 	cached_mrt = NULL;
 
 	ip_mrouter = NULL;
@@ -347,7 +347,7 @@ del_vif(vifip)
 		(*ifp->if_ioctl)(ifp, SIOCDELMULTI, (caddr_t)&ifr);
 	}
 
-	bzero((caddr_t)vifp, sizeof (*vifp));
+	memset((caddr_t)vifp, 0, sizeof (*vifp));
 
 	/* Adjust numvifs down */
 	for (i = numvifs - 1; i >= 0; i--)
@@ -395,9 +395,8 @@ add_lgrp(gcp)
 			return (ENOBUFS);
 		}
 
-		bzero((caddr_t)ip, num * sizeof(*ip));	/* XXX paranoid */
-		bcopy((caddr_t)vifp->v_lcl_grps, (caddr_t)ip,
-		    vifp->v_lcl_grps_n * sizeof(*ip));
+		memset((caddr_t)ip, 0, num * sizeof(*ip));	/* XXX paranoid */
+		memcpy((caddr_t)ip, (caddr_t)vifp->v_lcl_grps, vifp->v_lcl_grps_n * sizeof(*ip));
 
 		vifp->v_lcl_grps_max = num;
 		if (vifp->v_lcl_grps)
@@ -444,9 +443,7 @@ del_lgrp(gcp)
 		if (same(&gcp->lgc_gaddr, &vifp->v_lcl_grps[i])) {
 			error = 0;
 			vifp->v_lcl_grps_n--;
-			bcopy((caddr_t)&vifp->v_lcl_grps[i + 1],
-			    (caddr_t)&vifp->v_lcl_grps[i],
-			    (vifp->v_lcl_grps_n - i) * sizeof(struct in_addr));
+			memcpy((caddr_t)&vifp->v_lcl_grps[i], (caddr_t)&vifp->v_lcl_grps[i + 1], (vifp->v_lcl_grps_n - i) * sizeof(struct in_addr));
 			error = 0;
 			break;
 		}

--- a/server/netinet/ip_output.c
+++ b/server/netinet/ip_output.c
@@ -114,7 +114,7 @@ ip_output(m0, opt, ro, flags, imo)
 	 */
 	if (ro == 0) {
 		ro = &iproute;
-		bzero((caddr_t)ro, sizeof (*ro));
+		memset((caddr_t)ro, 0, sizeof (*ro));
 	}
 	dst = (struct sockaddr_in *)&ro->ro_dst;
 	/*
@@ -425,7 +425,7 @@ ip_insertoptions(m, opt, phlen)
 		m = n;
 		m->m_len = optlen + sizeof(struct ip);
 		m->m_data += max_linkhdr;
-		bcopy((caddr_t)ip, mtod(m, caddr_t), sizeof(struct ip));
+		memcpy(mtod(m, (caddr_t)ip, caddr_t), sizeof(struct ip));
 	} else {
 		m->m_data -= optlen;
 		m->m_len += optlen;
@@ -433,7 +433,7 @@ ip_insertoptions(m, opt, phlen)
 		ovbcopy((caddr_t)ip, mtod(m, caddr_t), sizeof(struct ip));
 	}
 	ip = mtod(m, struct ip *);
-	bcopy((caddr_t)p->ipopt_list, (caddr_t)(ip + 1), (unsigned)optlen);
+	memcpy((caddr_t)(ip + 1), (caddr_t)p->ipopt_list, (unsigned)optlen);
 	*phlen = sizeof(struct ip) + optlen;
 	ip->ip_len += optlen;
 	return (m);
@@ -468,7 +468,7 @@ ip_optcopy(ip, jp)
 		if (optlen > cnt)
 			optlen = cnt;
 		if (IPOPT_COPIED(opt)) {
-			bcopy((caddr_t)cp, (caddr_t)dp, (unsigned)optlen);
+			memcpy((caddr_t)dp, (caddr_t)cp, (unsigned)optlen);
 			dp += optlen;
 		}
 	}
@@ -571,8 +571,7 @@ ip_ctloutput(op, so, level, optname, mp)
 			*mp = m = m_get(M_WAIT, MT_SOOPTS);
 			if (inp->inp_options) {
 				m->m_len = inp->inp_options->m_len;
-				bcopy(mtod(inp->inp_options, caddr_t),
-				    mtod(m, caddr_t), (unsigned)m->m_len);
+				memcpy(caddr_t), mtod(inp->inp_options, mtod(m, caddr_t), (unsigned)m->m_len);
 			} else
 				m->m_len = 0;
 			break;
@@ -675,7 +674,7 @@ ip_pcbopts(pcbopt, m)
 	m->m_len += sizeof(struct in_addr);
 	cp = mtod(m, u_char *) + sizeof(struct in_addr);
 	ovbcopy(mtod(m, caddr_t), (caddr_t)cp, (unsigned)cnt);
-	bzero(mtod(m, caddr_t), sizeof(struct in_addr));
+	memset(mtod(m, 0, caddr_t), sizeof(struct in_addr));
 
 	for (; cnt > 0; cnt -= optlen, cp += optlen) {
 		opt = cp[IPOPT_OPTVAL];
@@ -712,7 +711,7 @@ ip_pcbopts(pcbopt, m)
 			/*
 			 * Move first hop before start of options.
 			 */
-			bcopy((caddr_t)&cp[IPOPT_OFFSET+1], mtod(m, caddr_t),
+			memcpy(mtod(m, (caddr_t)&cp[IPOPT_OFFSET+1], caddr_t),
 			    sizeof(struct in_addr));
 			/*
 			 * Then copy rest of options back

--- a/server/netinet/tcp_debug.c
+++ b/server/netinet/tcp_debug.c
@@ -91,11 +91,11 @@ tcp_trace(act, ostate, tp, ti, req)
 	if (tp)
 		td->td_cb = *tp;
 	else
-		bzero((caddr_t)&td->td_cb, sizeof (*tp));
+		memset((caddr_t)&td->td_cb, 0, sizeof (*tp));
 	if (ti)
 		td->td_ti = *ti;
 	else
-		bzero((caddr_t)&td->td_ti, sizeof (*ti));
+		memset((caddr_t)&td->td_ti, 0, sizeof (*ti));
 	td->td_req = req;
 #ifdef TCPDEBUG
 	if (tcpconsdebug == 0)

--- a/server/netinet/tcp_input.c
+++ b/server/netinet/tcp_input.c
@@ -558,7 +558,7 @@ findpcb:
 		sin->sin_len = sizeof(*sin);
 		sin->sin_addr = ti->ti_src;
 		sin->sin_port = ti->ti_sport;
-		bzero((caddr_t)sin->sin_zero, sizeof(sin->sin_zero));
+		memset((caddr_t)sin->sin_zero, 0, sizeof(sin->sin_zero));
 		laddr = inp->inp_laddr;
 		if (inp->inp_laddr.s_addr == INADDR_ANY)
 			inp->inp_laddr = ti->ti_dst;
@@ -1351,7 +1351,7 @@ tcp_dooptions(tp, cp, cnt, ti, ts_present, ts_val, ts_ecr)
 				continue;
 			if (!(ti->ti_flags & TH_SYN))
 				continue;
-			bcopy((char *) cp + 2, (char *) &mss, sizeof(mss));
+			memcpy((char *) &mss, (char *) cp + 2, sizeof(mss));
 			NTOHS(mss);
 			(void) tcp_mss(tp, mss);	/* sets t_maxseg */
 			break;
@@ -1369,9 +1369,9 @@ tcp_dooptions(tp, cp, cnt, ti, ts_present, ts_val, ts_ecr)
 			if (optlen != TCPOLEN_TIMESTAMP)
 				continue;
 			*ts_present = 1;
-			bcopy((char *)cp + 2, (char *) ts_val, sizeof(*ts_val));
+			memcpy((char *) ts_val, (char *)cp + 2, sizeof(*ts_val));
 			NTOHL(*ts_val);
-			bcopy((char *)cp + 6, (char *) ts_ecr, sizeof(*ts_ecr));
+			memcpy((char *) ts_ecr, (char *)cp + 6, sizeof(*ts_ecr));
 			NTOHL(*ts_ecr);
 
 			/* 
@@ -1409,7 +1409,7 @@ tcp_pulloutofband(so, ti, m)
 
 			tp->t_iobc = *cp;
 			tp->t_oobflags |= TCPOOB_HAVEDATA;
-			bcopy(cp+1, cp, (unsigned)(m->m_len - cnt - 1));
+			memcpy(cp, cp+1, (unsigned)(m->m_len - cnt - 1));
 			m->m_len--;
 			return;
 		}

--- a/server/netinet/tcp_output.c
+++ b/server/netinet/tcp_output.c
@@ -281,7 +281,7 @@ send:
 			opt[0] = TCPOPT_MAXSEG;
 			opt[1] = 4;
 			mss = htons((u_short) tcp_mss(tp, 0));
-			bcopy((caddr_t)&mss, (caddr_t)(opt + 2), sizeof(mss));
+			memcpy((caddr_t)(opt + 2), (caddr_t)&mss, sizeof(mss));
 			optlen = 4;
 	 
 			if ((tp->t_flags & TF_REQ_SCALE) &&
@@ -406,7 +406,7 @@ send:
 	ti = mtod(m, struct tcpiphdr *);
 	if (tp->t_template == 0)
 		panic("tcp_output");
-	bcopy((caddr_t)tp->t_template, (caddr_t)ti, sizeof (struct tcpiphdr));
+	memcpy((caddr_t)ti, (caddr_t)tp->t_template, sizeof (struct tcpiphdr));
 
 	/*
 	 * Fill in fields, remembering maximum advertised
@@ -435,7 +435,7 @@ send:
 		ti->ti_seq = htonl(tp->snd_max);
 	ti->ti_ack = htonl(tp->rcv_nxt);
 	if (optlen) {
-		bcopy((caddr_t)opt, (caddr_t)(ti + 1), optlen);
+		memcpy((caddr_t)(ti + 1), (caddr_t)opt, optlen);
 		ti->ti_off = (sizeof (struct tcphdr) + optlen) >> 2;
 	}
 	ti->ti_flags = flags;

--- a/server/netinet/tcp_subr.c
+++ b/server/netinet/tcp_subr.c
@@ -212,7 +212,7 @@ tcp_newtcpcb(inp)
 	tp = malloc(sizeof(*tp), M_PCB, M_NOWAIT);
 	if (tp == NULL)
 		return ((struct tcpcb *)0);
-	bzero((char *) tp, sizeof(struct tcpcb));
+	memset((char *) tp, 0, sizeof(struct tcpcb));
 	tp->seg_next = tp->seg_prev = (struct tcpiphdr *)tp;
 	tp->t_maxseg = tcp_mssdflt;
 

--- a/server/netinet/udp_usrreq.c
+++ b/server/netinet/udp_usrreq.c
@@ -330,7 +330,7 @@ udp_saveopt(p, size, type)
 	if ((m = m_get(M_DONTWAIT, MT_CONTROL)) == NULL)
 		return ((struct mbuf *) NULL);
 	cp = (struct cmsghdr *) mtod(m, struct cmsghdr *);
-	bcopy(p, CMSG_DATA(cp), size);
+	memcpy(CMSG_DATA(cp), p, size);
 	size += sizeof(*cp);
 	m->m_len = size;
 	cp->cmsg_len = size;

--- a/sunos/drivers/simeth/sim_ether.c
+++ b/sunos/drivers/simeth/sim_ether.c
@@ -100,7 +100,7 @@ simEth2sock(ethAddr, sockAddr)
     ETHhost ethAddr;
     struct sockaddr_in *sockAddr;
 {
-  bzero((char *)sockAddr, sizeof (struct sockaddr_in));
+  memset((char *)sockAddr, 0, sizeof (struct sockaddr_in));
   sockAddr->sin_family = AF_INET;
   /* 
    * IP address is in the first 4 bytes of the ethernet address
@@ -317,7 +317,7 @@ simeth_init( self )
 	Kabort("simeth -- too many instances");
     }
     ps = X_NEW(PState);
-    bzero((char *)ps, sizeof(PState));
+    memset((char *)ps, 0, sizeof(PState));
     self->state = (VOID *)ps;
     ps->port = -1;
     findXObjRomOpts(self, xobjOpts, sizeof(xobjOpts)/sizeof(XObjRomOpt), 0);
@@ -367,7 +367,7 @@ static void
 ethMsgStore( void *hdr, char *netHdr, long len, void *arg )
 {
     xAssert(len == sizeof(ETHhdr));
-    bcopy(hdr, netHdr, sizeof(ETHhdr));
+    memcpy(netHdr, hdr, sizeof(ETHhdr));
 }
 
 
@@ -375,7 +375,7 @@ static long
 ethMsgLoad( void *hdr, char *netHdr, long len, void *arg )
 {
     xAssert(len == sizeof(ETHhdr));
-    bcopy(netHdr, (char *)hdr, sizeof(ETHhdr));
+    memcpy((char *)hdr, netHdr, sizeof(ETHhdr));
     return sizeof(ETHhdr);
 }
 
@@ -484,7 +484,7 @@ init_eth_blocks()
 	    numShepherdThreads);
     pool.total_blocks = numShepherdThreads;
     pool.blocks = (block *)xMalloc(numShepherdThreads * sizeof(block));
-    bzero((char *)pool.blocks, numShepherdThreads * sizeof(block));
+    memset((char *)pool.blocks, 0, numShepherdThreads * sizeof(block));
     pool.next_block = 0;
     
     bp = pool.blocks;
@@ -608,7 +608,7 @@ readether2demux( arg )
 static bool
 msg2Buf(char *msgPtr, long len, void *bufPtr)
 {
-  bcopy(msgPtr, *(char **)bufPtr, len);
+  memcpy(*(char **)bufPtr, msgPtr, len);
   *(char **)bufPtr += len;
   return TRUE;
 }
@@ -659,7 +659,7 @@ simethControl( s, op, buf, len )
 
       case GETMYHOST:
 	checkLen(len, sizeof(ETHhost));
-	bcopy((char *) &ps->myHost, buf, sizeof(ETHhost));
+	memcpy(buf, (char *) &ps->myHost, sizeof(ETHhost));
 	return (sizeof(ETHhost));
 
       case SIM_SOCK2ADDR:

--- a/sunos/include/x_libc.h
+++ b/sunos/include/x_libc.h
@@ -20,9 +20,6 @@
 #include <string.h>
 
 
-extern void     bcopy( char *, char *, int );
-extern int	bcmp( char *, char *, int );
-extern void     bzero( char *, int );
 extern int	qsort( char *, int, int, int(*)());
 
 extern int	lwp_self();

--- a/util/compose/compose_intelx86.h
+++ b/util/compose/compose_intelx86.h
@@ -27,7 +27,6 @@ int	access( char *, int );
  */
 void	perror( char * );
 int	printf();
-int	bzero( char *, int );
 int	_flsbuf();
 int	_filbuf();
 void	exit( int );

--- a/util/compose/compose_mips.h
+++ b/util/compose/compose_mips.h
@@ -27,7 +27,6 @@ int	access( char *, int );
  */
 void	perror( char * );
 int	printf();
-int	bzero( char *, int );
 int	_flsbuf();
 int	_filbuf();
 void	exit( int );


### PR DESCRIPTION
## Summary
- modernize old b* routines
- drop stale declarations from x_libc headers

## Testing
- `pre-commit` *(fails: command not found)*