### PR TITLE
Remove __STDC__ K&R prototypes

### DIFF
--- a/include/pi/idmap/idmap.c
+++ b/include/pi/idmap/idmap.c
@@ -30,24 +30,13 @@ int	traceidmap;
 
 #define MAX_MAP_SIZE 1024
 
-#ifdef __STDC__
-static int generichash( char *,  int ,  int );
-static xkern_return_t	mgenericresolve( Map, VOID *, VOID ** );
-static Bind 		mgenericbind( Map, VOID *, VOID * );
-static xkern_return_t  	mgenericunbind( Map, VOID * );
-static xkern_return_t  	mgenericremove( Map, Bind );
-static xkern_return_t  	mgenericerror( Map, VOID *, VOID ** );
-static void		removeList( MapElement * );
-
-#else
-
-static int generichash();
-static xkern_return_t	mgenericresolve();
-static Bind 		mgenericbind();
-static xkern_return_t  	mgenericunbind();
-static xkern_return_t  	mgenericremove();
-static xkern_return_t  	mgenericerror();
-#endif /* __STDC__ */
+static int generichash(char *, int, int);
+static xkern_return_t   mgenericresolve(Map, VOID *, VOID **);
+static Bind             mgenericbind(Map, VOID *, VOID *);
+static xkern_return_t   mgenericunbind(Map, VOID *);
+static xkern_return_t   mgenericremove(Map, Bind);
+static xkern_return_t   mgenericerror(Map, VOID *, VOID **);
+static void             removeList(MapElement *);
 
 /*
  * Create and return a new map containing a table with nEntries entries 
@@ -298,17 +287,13 @@ mapForEach(m, f, arg)
 #  define INLINE
 #endif
 
-#ifdef __STDC__
-
-static INLINE int	hash2( void *, int );
-static INLINE int	hash4( void *, int );
-static INLINE int	hash6( void *, int );
-static INLINE int	hash8( void *, int );
-static INLINE int	hash10( void *, int );
-static INLINE int	hash12( void *, int );
-static INLINE int	hash16( void *, int );
-
-#endif /* __STDC__ */
+static INLINE int       hash2(void *, int);
+static INLINE int       hash4(void *, int);
+static INLINE int       hash6(void *, int);
+static INLINE int       hash8(void *, int);
+static INLINE int       hash10(void *, int);
+static INLINE int       hash12(void *, int);
+static INLINE int       hash16(void *, int);
 
 
 #define GENCOMPBYTES(s1, s2) (!bcmp(s1, s2, table->keySize))

--- a/include/pi/netmask.c
+++ b/include/pi/netmask.c
@@ -40,15 +40,7 @@ static IPhost	ipNull = { 0, 0, 0, 0 };
 static	Map	netMaskMap;
 
 
-#ifdef __STDC__
-
-static int	bcastHost( IPhost *, IPhost * );
-
-#else
-
-static int	bcastHost();
-
-#endif
+static int      bcastHost(IPhost *, IPhost *);
 
 
 int

--- a/include/pi/prottbl.c
+++ b/include/pi/prottbl.c
@@ -34,37 +34,14 @@ int	traceptbl;
 #define PTBL_NAME_MAP_SIZE	101
 #define PTBL_ID_MAP_SIZE	101
 
-#ifdef __STDC__
-
-static int	backPatchBinding( void *, void * , void * );
-static int	checkEntry( void *, void *, void * );
-static void	error( char * );
-static void	mkKey( char *, char * );
-
-#  ifdef XK_DEBUG
-
-static int	dispHlp( void *, void *, void * );
-static int	dispEntry( void *, void *, void * );
-
-#  endif /* XK_DEBUG */
-
-#else
-
-char *	protIdToStr();
-
-static int	backPatchBinding();
-static int	checkEntry();
-static void	error();
-static void	mkKey();
-
-#  ifdef XK_DEBUG
-
-static int	dispHlp();
-static int	dispEntry();
-
-#  endif /* XK_DEBUG */
-
-#endif __STDC__
+static int      backPatchBinding(void *, void *, void *);
+static int      checkEntry(void *, void *, void *);
+static void     error(char *);
+static void     mkKey(char *, char *);
+#ifdef XK_DEBUG
+static int      dispHlp(void *, void *, void *);
+static int      dispEntry(void *, void *, void *);
+#endif /* XK_DEBUG */
 
 
 Map	ptblNameMap = 0;	/* strings to Entry structures */

--- a/include/pi/prottbl_parse.c
+++ b/include/pi/prottbl_parse.c
@@ -40,31 +40,16 @@
 
 #ifndef XKMACH4
 
-#ifdef __STDC__
-
-static void	entry( void );
-static void	error( ErrorCode );
-static int	forceChar( int );
-static void	get( void );
-static long	id( void );
-static int	list( char * );
-static char *	name( char * );
-static void	optionalList( char * );
-static xkern_return_t	ptblRomOpt( char **, int, int, VOID * );
-static void	skipWhite( void );
-
-#else
-
-static void	entry();
-static void	error();
-static void	get();
-static long	id();
-static int	list();
-static char *	name();
-static void	optionalList();
-static xkern_return_t	ptblRomOpt();
-
-#endif __STDC__
+static void     entry(void);
+static void     error(ErrorCode);
+static int      forceChar(int);
+static void     get(void);
+static long     id(void);
+static int      list(char *);
+static char *   name(char *);
+static void     optionalList(char *);
+static xkern_return_t   ptblRomOpt(char **, int, int, VOID *);
+static void     skipWhite(void);
 
 
 static int	line = 1;

--- a/include/pi/romopt.c
+++ b/include/pi/romopt.c
@@ -25,13 +25,7 @@ typedef struct {
     xkern_return_t	(* func)();
 } GenericRomOpt;
 
-
-#ifdef __STDC__
-static xkern_return_t	findOptions( char *, char *, GenericRomOpt *,
-				     int, void *, XObj );
-#endif __STDC__
-
-
+static xkern_return_t   findOptions(char *, char *, GenericRomOpt *, int, void *, XObj);
 static xkern_return_t
 findOptions( name, fullName, opts, numOpts, arg, obj )
     char		*name, *fullName;

--- a/include/pi/sessn_gc.c
+++ b/include/pi/sessn_gc.c
@@ -29,19 +29,9 @@ typedef struct {
 } CollectInfo;
 
 
-#ifdef __STDC__
-
-static int	markIdle( void *, void *, void * );
-static void	schedule( CollectInfo * );
-static void	sessnCollect( Event, void * );
-
-#else
-
-static int	markIdle();
-static void	schedule();
-static void	sessnCollect();
-
-#endif __STDC__
+static int      markIdle(void *, void *, void *);
+static void     schedule(CollectInfo *);
+static void     sessnCollect(Event, void *);
 
 
 

--- a/include/pi/upi.c
+++ b/include/pi/upi.c
@@ -59,19 +59,9 @@ static char *controlops[] = {
 #  define CONTROLMSG(n) ""
 #endif XK_DEBUG
 
-#ifdef __STDC__
-
 static XObj xCreateXObj(int downc, XObj *downv);
 static xkern_return_t xDestroyXObj(XObj s);
-static XObj	defaultOpen( XObj, XObj, XObj, Part * );
-
-#else
-
-static XObj xCreateXObj();
-static xkern_return_t xDestroyXObj();
-static XObj	defaultOpen();
-
-#endif __STDC__
+static XObj     defaultOpen(XObj, XObj, XObj, Part *);
 
 /* 
  * If inline functions are not being used, the upi_inline functions

--- a/include/pi/upi_defaults.c
+++ b/include/pi/upi_defaults.c
@@ -36,15 +36,7 @@ int	traceprotdef = 0;
 	}
 
 
-#ifdef __STDC__
-
-static xkern_return_t	llpOpenDisable(XObj, XObj, XObj, Part *, XObj *, int);
-
-#else
-
-static xkern_return_t  llpOpenDisable();
-
-#endif
+static xkern_return_t   llpOpenDisable(XObj, XObj, XObj, Part *, XObj *, int);
 
 
 xkern_return_t

--- a/netbsd/pxk/process.c
+++ b/netbsd/pxk/process.c
@@ -26,15 +26,7 @@
 int SignalsPossible = 0;
 
 
-#ifdef __STDC__
-
-static void	wake_sem( Event, VOID * );
-
-#else
-
-static void	wake_sem();
-
-#endif
+static void     wake_sem(Event, VOID *);
 
 
 

--- a/netbsd/pxk/time.c
+++ b/netbsd/pxk/time.c
@@ -12,11 +12,7 @@
 
 #include <sys/time.h>
 
-#ifdef __STDC__
-
-int	gettimeofday( struct timeval *, struct timezone * );
-
-#endif
+int     gettimeofday(struct timeval *, struct timezone *);
 
 void
 xGetTime(where)

--- a/protocols/rat/rat.c
+++ b/protocols/rat/rat.c
@@ -13,56 +13,27 @@
 #include "ip.h"
 #include "chan.h"
 
-#ifdef __STDC__
-
 XObj   ratOpen(XObj, XObj, XObj, Part *);
 static xkern_return_t ratOpenEnable(XObj, XObj, XObj, Part *);
 static xkern_return_t ratOpenDisable(XObj, XObj, XObj, Part *);
 static xkern_return_t ratDemux(XObj, XObj, Msg *);
 static xmsg_handle_t ratPush(XObj, Msg *);
-static xkern_return_t ratPop(XObj, XObj, Msg  *,void *);
-static int ratControl(XObj, int, char *, int );
-static int ratControlSessn(XObj, int, char *, int );
+static xkern_return_t ratPop(XObj, XObj, Msg *, void *);
+static int ratControl(XObj, int, char *, int);
+static int ratControlSessn(XObj, int, char *, int);
 static xkern_return_t ratCloseSessn(XObj);
-XObj   ratCreateSessn( XObj, XObj, XObj, ActiveID  *, IPID);
+XObj   ratCreateSessn(XObj, XObj, XObj, ActiveID *, IPID);
 void   rat_init(XObj);
 static void rat_sessn_init(XObj);
 long   ratHdrLoad(void *, char *, long, void *);
 long   ratDemuxHdrLoad(void *, char *, long, void *);
-void   ratHdrStore(void *,char *, long, void *);
+void   ratHdrStore(void *, char *, long, void *);
 XObj   ratOpenTcp(XObj, IPhost);
 XObj   ratOpenIp(XObj, IPhost);
-static xkern_return_t   readSPort( XObj, char **, int, int, VOID * );
-static xkern_return_t   readDPort( XObj, char **, int, int, VOID * );
-static xkern_return_t   readSndBuf( XObj, char **, int, int, VOID * );
-static xkern_return_t   readRcvBuf( XObj, char **, int, int, VOID * );
-
-#else
-
-XObj   ratOpen();
-static xkern_return_t ratOpenEnable();
-static xkern_return_t ratOpenDisable();
-static xkern_return_t ratDemux();
-static xmsg_handle_t ratPush();
-static xkern_return_t ratPop();
-static xkern_return_t ratCloseSessn();
-static int ratControl();
-static int ratControlSessn();
-XObj   ratCreateSessn();
-void   rat_init();
-static void rat_sessn_init();
-long   ratHdrLoad();
-long   ratDemuxHdrLoad();
-void   ratHdrStore();
-XObj   ratOpenTcp();
-XObj   ratOpenIp();
-static xkern_return_t   readSPort();
-static xkern_return_t   readDPort();
-static xkern_return_t   readSndBuf();
-static xkern_return_t   readRcvBuf();
-
-
-#endif
+static xkern_return_t   readSPort(XObj, char **, int, int, VOID *);
+static xkern_return_t   readDPort(XObj, char **, int, int, VOID *);
+static xkern_return_t   readSndBuf(XObj, char **, int, int, VOID *);
+static xkern_return_t   readRcvBuf(XObj, char **, int, int, VOID *);
 
 
 static XObjRomOpt ratOpt[] = {

--- a/protocols/vchan/vchan.c
+++ b/protocols/vchan/vchan.c
@@ -22,36 +22,21 @@ int             tracevchanp;
 static	IPhost	defaultHost = { 0, 0, 0, 0 };
 
 
-#ifdef __STDC__
-
-static void 		addSessn( XObj, XObj );
-static int 		buildKey( ActiveKey *, Part *, XObj );
-static int 		decreaseConcurrency( XObj, int );
-static void 		dispStack( SessnStack * );
-static void		getProcProtl( XObj );
-static void 		getProcSessn( XObj );
-static XObj 		getSessn( XObj );
-static int 		increaseConcurrency( XObj, int );
-static xkern_return_t 	vchanCall( XObj, Msg *, Msg * );
-static xkern_return_t 	vchanCloseSessn( XObj );
-static int		vchanControlProtl( XObj, int, char *, int );
-static int		vchanControlSessn( XObj, int, char *, int );
-static XObj 		vchanOpen( XObj, XObj, XObj, Part * );
-static xkern_return_t 	vchanOpenDisable( XObj, XObj, XObj, Part *p );	
-static xkern_return_t 	vchanOpenEnable( XObj, XObj, XObj, Part *p );	
-
-#else 
-
-static void 		addSessn();
-static int 		buildKey();
-static int 		decreaseConcurrency();
-static void 		dispStack();
-static void		getProcProtl();
-static void 		getProcSessn();
-static XObj 		getSessn();
-static int 		increaseConcurrency();
-
-#endif	__STDC__
+static void             addSessn(XObj, XObj);
+static int              buildKey(ActiveKey *, Part *, XObj);
+static int              decreaseConcurrency(XObj, int);
+static void             dispStack(SessnStack *);
+static void             getProcProtl(XObj);
+static void             getProcSessn(XObj);
+static XObj             getSessn(XObj);
+static int              increaseConcurrency(XObj, int);
+static xkern_return_t   vchanCall(XObj, Msg *, Msg *);
+static xkern_return_t   vchanCloseSessn(XObj);
+static int              vchanControlProtl(XObj, int, char *, int);
+static int              vchanControlSessn(XObj, int, char *, int);
+static XObj             vchanOpen(XObj, XObj, XObj, Part *);
+static xkern_return_t   vchanOpenDisable(XObj, XObj, XObj, Part *p);
+static xkern_return_t   vchanOpenEnable(XObj, XObj, XObj, Part *p);
 
 
 /*


### PR DESCRIPTION
## Summary
- update several modules to use ANSI-style function prototypes
- clean up old conditional `__STDC__` logic in selected files

## Testing
- `make` *(fails: can't cd to /usr/obj/lites)*