### PR TITLE
Remove obsolete register keywords

### DIFF
--- a/protocols/tcp-tahoe/in_hacks.c
+++ b/protocols/tcp-tahoe/in_hacks.c
@@ -27,11 +27,9 @@
 
 
 int
-in_pcballoc(so, head)
-	XObj so;
-	struct inpcb *head;
+in_pcballoc(XObj so, struct inpcb *head)
 {
-	register struct inpcb *inp;
+	struct inpcb *inp;
 
 	inp = (struct inpcb *)xMalloc(sizeof *inp);
 	inp->inp_head = head;
@@ -44,16 +42,14 @@ in_pcballoc(so, head)
 
 /*ARGSUSED*/
 void
-in_pcbdisconnect(inp)
-    struct inpcb *inp;
+in_pcbdisconnect(struct inpcb *inp)
 {
     Kabort("in_pcbdisconnect");
 }
 
 
 void
-in_pcbdetach(inp)
-    struct inpcb *inp;
+in_pcbdetach(struct inpcb *inp)
 {
     remque(inp);
     xFree((char *)inp);
@@ -61,8 +57,7 @@ in_pcbdetach(inp)
 
 
 bool
-in_broadcast(addr)
-    struct in_addr addr;
+in_broadcast(struct in_addr addr)
 {
     return (ntohl(addr.s_addr) & 0xff) == 0 ||
       	   (ntohl(addr.s_addr) & 0xff) == 0xff;

--- a/protocols/tcp-tahoe/tcp_input.c
+++ b/protocols/tcp-tahoe/tcp_input.c
@@ -79,13 +79,9 @@ static void 	tcp_pulloutofband();
 
 
 int
-tcp_reass(tp, th, so, m, demuxmsg)
-	register struct tcpcb *tp;
-	register struct tcphdr *th;
-     	XObj so;
-	Msg *m, *demuxmsg;
+tcp_reass(struct tcpcb *tp, struct tcphdr *th, XObj so, Msg *m, Msg *demuxmsg)
 {
-	register struct reass *q, *next;
+	struct reass *q, *next;
 	int flags;
 
 	xTrace0(tcpp, TR_FUNCTIONAL_TRACE, "tcp_reass function entered");
@@ -116,7 +112,7 @@ tcp_reass(tp, th, so, m, demuxmsg)
 	 * segment.  If it provides all of our data, drop us.
 	 */
 	if (q->prev != (struct reass *)tp) {
-		register int i;
+		int i;
 		q = q->prev;
 		/* conversion to int (in i) handles seq wraparound */
 		i = q->th.th_seq + msgLen(&q->m) - th->th_seq;
@@ -139,7 +135,7 @@ tcp_reass(tp, th, so, m, demuxmsg)
 	 * if they are completely covered, dequeue them.
 	 */
 	while (q != (struct reass *)tp) {
-		register int i = (th->th_seq + msgLen(m)) - q->th.th_seq;
+		int i = (th->th_seq + msgLen(m)) - q->th.th_seq;
 		if (i <= 0)
 			break;
 		if (i < msgLen(&q->m)) {
@@ -213,9 +209,7 @@ tcpPop(self, lls, m, h)
  * protocol specification dated September, 1981 very closely.
  */
 xkern_return_t
-tcp_input(self, transport_s, m)
-	XObj self, transport_s;
-	Msg *m;
+tcp_input(XObj self, XObj transport_s, Msg *m)
 {
 /*	register struct tcpiphdr *ti; */
 	struct inpcb *inp;
@@ -224,7 +218,7 @@ tcp_input(self, transport_s, m)
 	int option_len = 0;
 	int len, tlen, off;
 	struct tcpcb *tp;
-	register int tiflags;
+	int tiflags;
 	XObj so = 0, hlpType = 0;
 	struct tcpstate *tcpst;
 	int todrop, acked, ourfinisacked, needoutput = 0;
@@ -855,7 +849,7 @@ do_rst:
 		if (tp->t_rtt && SEQ_GT(tHdr.th_ack, tp->t_rtseq)) {
 			tcpstat.tcps_rttupdated++;
 			if (tp->t_srtt != 0) {
-				register short delta;
+				short delta;
 
 				/*
 				 * srtt is stored as fixed point with 3 bits
@@ -1272,13 +1266,9 @@ drop:
 
 
 static void
-tcp_dooptions(tp, options, option_len, tHdr)
-	struct tcpcb *tp;
-	char         *options;
-	int	      option_len;
-	struct tcphdr *tHdr;
+tcp_dooptions(struct tcpcb *tp, char *options, int option_len, struct tcphdr *tHdr)
 {
-	register u_char *cp;
+	u_char *cp;
 	int opt, optlen, cnt;
 
 	cp = (u_char *)options;
@@ -1315,10 +1305,7 @@ tcp_dooptions(tp, options, option_len, tHdr)
 
 
 static bool
-tcp_pulloobchar( ptr, len, oobc )
-    char	*ptr;
-    VOID	*oobc;
-    long	len;
+tcp_pulloobchar(char *ptr, long len, VOID *oobc)
 {
     xAssert(len >= 1);
     *(char *)oobc = *ptr;
@@ -1333,10 +1320,7 @@ tcp_pulloobchar( ptr, len, oobc )
  * sequencing purposes.
  */
 static void
-tcp_pulloutofband(so, th, m)
-	XObj so;
-	struct tcphdr *th;
-	Msg *m;
+tcp_pulloutofband(XObj so, struct tcphdr *th, Msg *m)
 {
 	Msg firstPart;
 	struct tcpcb *tp = sototcpcb(so);
@@ -1369,8 +1353,7 @@ tcp_pulloutofband(so, th, m)
  *  This is ugly, and doesn't belong at this level, but has to happen somehow.
  */
 int
-tcp_mss(tp)
-	register struct tcpcb *tp;
+tcp_mss(struct tcpcb *tp)
 {
     	XObj tcpSessn;
 	int mss;

--- a/protocols/tcp-tahoe/tcp_output.c
+++ b/protocols/tcp-tahoe/tcp_output.c
@@ -39,10 +39,9 @@ u_char	tcp_initopt[4] = { TCPOPT_MAXSEG, 4, 0x0, 0x0, };
 
 
 void
-tcp_setpersist(tp)
-	register struct tcpcb *tp;
+tcp_setpersist(struct tcpcb *tp)
 {
-	register t = ((tp->t_srtt >> 2) + tp->t_rttvar) >> 1;
+        int t = ((tp->t_srtt >> 2) + tp->t_rttvar) >> 1;
 
 	if (tp->t_timer[TCPT_REXMT])
 		Kabort("tcp_output REXMT");
@@ -61,12 +60,11 @@ tcp_setpersist(tp)
  * Tcp output routine: figure out what should be sent and send it.
  */
 int
-tcp_output(tp)
-	register struct tcpcb *tp;
+tcp_output(struct tcpcb *tp)
 {
-	register XObj so = tp->t_inpcb->inp_session;
-	register struct tcpstate *tcpst = sototcpst(so);
-	register int len, win;
+	XObj so = tp->t_inpcb->inp_session;
+	struct tcpstate *tcpst = sototcpst(so);
+	int len, win;
 	int off, flags, error;
 	struct tcphdr	tHdr;
 	u_char *opt;

--- a/protocols/tcp-tahoe/tcp_timer.c
+++ b/protocols/tcp-tahoe/tcp_timer.c
@@ -35,12 +35,10 @@ int	tcpnodelack = 0;
  * Fast timeout routine for processing delayed acks
  */
 void
-tcp_fasttimo( ev, unusedArg )
-    Event	ev;
-    VOID 	*unusedArg;
+tcp_fasttimo(Event ev, VOID *unusedArg)
 {
-	register struct inpcb *inp;
-	register struct tcpcb *tp;
+	struct inpcb *inp;
+	struct tcpcb *tp;
 	/* 
 	 * The original code protected this routine with splnet().  If
 	 * the timeout thread blocks, there could be a problem.
@@ -70,18 +68,16 @@ tcp_fasttimo( ev, unusedArg )
  * causes finite state machine actions if timers expire.
  */
 void
-tcp_slowtimo(ev, unusedArg)
-    Event	ev;
-    VOID 	*unusedArg;
+tcp_slowtimo(Event ev, VOID *unusedArg)
 {
-	register struct inpcb *ip, *ipnxt;
-	register struct tcpcb *tp;
+	struct inpcb *ip, *ipnxt;
+	struct tcpcb *tp;
 	/* 
 	 * The original code protected this routine with splnet().  If
 	 * the timeout thread blocks, there could be a problem.
 	 */
 	/* int s = splnet(); */
-	register int i;
+	int i;
 
 	/*
 	 * Search through tcb's and update active timers.
@@ -141,8 +137,7 @@ tpgone:
  * Cancel all timers for TCP tp.
  */
 void
-tcp_canceltimers(tp)
-	struct tcpcb *tp;
+tcp_canceltimers(struct tcpcb *tp)
 {
         tp->t_timer[0] = 0;
         tp->t_timer[1] = 0;
@@ -158,11 +153,9 @@ int	tcp_backoff[TCP_MAXRXTSHIFT + 1] =
  * TCP timer processing.
  */
 struct tcpcb *
-tcp_timers(tp, timer)
-	register struct tcpcb *tp;
-	int timer;
+tcp_timers(struct tcpcb *tp, int timer)
 {
-	register int rexmt;
+	int rexmt;
 
 	switch (timer) {
 

--- a/protocols/tcp-tahoe/tcp_usrreq.c
+++ b/protocols/tcp-tahoe/tcp_usrreq.c
@@ -50,9 +50,9 @@ tcp_usrreq(so, req, m, nam)
 	int req;
 	Msg *m, *nam;
 {
-	register struct inpcb *inp;
-	register struct tcpcb *tp = 0;
-	register struct tcpstate *tcpst = (struct tcpstate*)so->state;
+	struct inpcb *inp;
+	struct tcpcb *tp = 0;
+	struct tcpstate *tcpst = (struct tcpstate*)so->state;
 	/* int s; */
 	int error = 0;
 	int ostate;
@@ -254,7 +254,7 @@ int
 tcp_attach(so)
 	XObj so;
 {
-	register struct tcpcb *tp;
+	struct tcpcb *tp;
 	struct inpcb *inp;
 	int error;
 
@@ -280,7 +280,7 @@ tcp_attach(so)
  */
 struct tcpcb *
 tcp_disconnect(tp)
-	register struct tcpcb *tp;
+	struct tcpcb *tp;
 {
 	XObj so = tp->t_inpcb->inp_session;
 	xTrace1(tcpp, 3, "tcp_disconnect: tp %X", tp);
@@ -307,7 +307,7 @@ tcp_disconnect(tp)
  */
 struct tcpcb *
 tcp_usrclosed(tp)
-	register struct tcpcb *tp;
+	struct tcpcb *tp;
 {
 
 	switch (tp->t_state) {

--- a/protocols/tcp-tahoe/tcp_x.c
+++ b/protocols/tcp-tahoe/tcp_x.c
@@ -416,11 +416,10 @@ tcpOpenDisable(self, hlpRcv, hlpType, p)
  * We can let the user exit from the close as soon as the FIN is acked.
  */
 static xkern_return_t
-tcpClose(so)
-    XObj	so;
+tcpClose(XObj so)
 {
-    register struct tcpcb *tp;
-    register struct tcpstate *tcpst;
+    struct tcpcb *tp;
+    struct tcpstate *tcpst;
     
     xTrace1(tcpp, TR_FUNCTIONAL_TRACE, "tcpClose(so=%08x)", so);
 
@@ -448,15 +447,13 @@ tcpClose(so)
 
 /*************************************************************************/
 static xmsg_handle_t
-tcpPush(so, msg)
-     XObj so;
-     Msg *msg;
+tcpPush(XObj so, Msg *msg)
 {
     int error;
     int space;
     Msg pushMsg;
-    register struct tcpstate *tcpst = sototcpst(so);
-    register struct tcpcb *tp = sototcpcb(so);
+    struct tcpstate *tcpst = sototcpst(so);
+    struct tcpcb *tp = sototcpcb(so);
 
     xTrace2(tcpp, TR_MAJOR_EVENTS, "tcpPush: session %X, msg %d bytes",
 	    so, msgLen(msg));

--- a/protocols/tcp/in_hacks.c
+++ b/protocols/tcp/in_hacks.c
@@ -27,11 +27,9 @@
 
 
 int
-in_pcballoc(so, head)
-	XObj so;
-	struct inpcb *head;
+in_pcballoc(XObj so, struct inpcb *head)
 {
-	register struct inpcb *inp;
+        struct inpcb *inp;
 
 	inp = (struct inpcb *)xMalloc(sizeof *inp);
 	inp->inp_head = head;
@@ -44,16 +42,14 @@ in_pcballoc(so, head)
 
 /*ARGSUSED*/
 void
-in_pcbdisconnect(inp)
-    struct inpcb *inp;
+in_pcbdisconnect(struct inpcb *inp)
 {
     Kabort("in_pcbdisconnect");
 }
 
 
 void
-in_pcbdetach(inp)
-    struct inpcb *inp;
+in_pcbdetach(struct inpcb *inp)
 {
     remque(inp);
     xFree((char *)inp);
@@ -61,8 +57,7 @@ in_pcbdetach(inp)
 
 
 bool
-in_broadcast(addr)
-    struct in_addr addr;
+in_broadcast(struct in_addr addr)
 {
     return (ntohl(addr.s_addr) & 0xff) == 0 ||
       	   (ntohl(addr.s_addr) & 0xff) == 0xff;

--- a/protocols/tcp/tcp_input.c
+++ b/protocols/tcp/tcp_input.c
@@ -79,13 +79,9 @@ static void 	tcp_pulloutofband();
 
 
 int
-tcp_reass(tp, th, so, m, demuxmsg)
-	register struct tcpcb *tp;
-	register struct tcphdr *th;
-     	XObj so;
-	Msg *m, *demuxmsg;
+tcp_reass(struct tcpcb *tp, struct tcphdr *th, XObj so, Msg *m, Msg *demuxmsg)
 {
-	register struct reass *q, *next;
+	struct reass *q, *next;
 	int flags;
 
 	xTrace0(tcpp, TR_FUNCTIONAL_TRACE, "tcp_reass function entered");
@@ -116,7 +112,7 @@ tcp_reass(tp, th, so, m, demuxmsg)
 	 * segment.  If it provides all of our data, drop us.
 	 */
 	if (q->prev != (struct reass *)tp) {
-		register int i;
+		int i;
 		q = q->prev;
 		/* conversion to int (in i) handles seq wraparound */
 		i = q->th.th_seq + msgLen(&q->m) - th->th_seq;
@@ -139,7 +135,7 @@ tcp_reass(tp, th, so, m, demuxmsg)
 	 * if they are completely covered, dequeue them.
 	 */
 	while (q != (struct reass *)tp) {
-		register int i = (th->th_seq + msgLen(m)) - q->th.th_seq;
+		int i = (th->th_seq + msgLen(m)) - q->th.th_seq;
 		if (i <= 0)
 			break;
 		if (i < msgLen(&q->m)) {
@@ -198,11 +194,7 @@ drop:
 
 
 xkern_return_t
-tcpPop(self, lls, m, h)
-    XObj self;
-    XObj lls;
-    Msg *m;
-    VOID *h;
+tcpPop(XObj self, XObj lls, Msg *m, VOID *h)
 {
     return xDemux(self, m);
 }
@@ -213,9 +205,7 @@ tcpPop(self, lls, m, h)
  * protocol specification dated September, 1981 very closely.
  */
 xkern_return_t
-tcp_input(self, transport_s, m)
-	XObj self, transport_s;
-	Msg *m;
+tcp_input(XObj self, XObj transport_s, Msg *m)
 {
 /*	register struct tcpiphdr *ti; */
 	struct inpcb *inp;
@@ -224,7 +214,7 @@ tcp_input(self, transport_s, m)
 	int option_len = 0;
 	int len, tlen, off;
 	struct tcpcb *tp;
-	register int tiflags;
+	int tiflags;
 	XObj so = 0, hlpType = 0;
 	struct tcpstate *tcpst;
 	int todrop, acked, ourfinisacked, needoutput = 0;
@@ -865,7 +855,7 @@ do_rst:
 		if (tp->t_rtt && SEQ_GT(tHdr.th_ack, tp->t_rtseq)) {
 			tcpstat.tcps_rttupdated++;
 			if (tp->t_srtt != 0) {
-				register short delta;
+				short delta;
 
 				/*
 				 * srtt is stored as fixed point with 3 bits
@@ -1282,13 +1272,9 @@ drop:
 
 
 static void
-tcp_dooptions(tp, options, option_len, tHdr)
-	struct tcpcb *tp;
-	char         *options;
-	int	      option_len;
-	struct tcphdr *tHdr;
+tcp_dooptions(struct tcpcb *tp, char *options, int option_len, struct tcphdr *tHdr)
 {
-	register u_char *cp;
+	u_char *cp;
 	int opt, optlen, cnt;
 
 	cp = (u_char *)options;
@@ -1325,10 +1311,7 @@ tcp_dooptions(tp, options, option_len, tHdr)
 
 
 static bool
-tcp_pulloobchar( ptr, len, oobc )
-    char	*ptr;
-    VOID	*oobc;
-    long	len;
+tcp_pulloobchar(char *ptr, long len, VOID *oobc)
 {
     xAssert(len >= 1);
     *(char *)oobc = *ptr;
@@ -1343,10 +1326,7 @@ tcp_pulloobchar( ptr, len, oobc )
  * sequencing purposes.
  */
 static void
-tcp_pulloutofband(so, th, m)
-	XObj so;
-	struct tcphdr *th;
-	Msg *m;
+tcp_pulloutofband(XObj so, struct tcphdr *th, Msg *m)
 {
 	Msg firstPart;
 	struct tcpcb *tp = sototcpcb(so);
@@ -1379,8 +1359,7 @@ tcp_pulloutofband(so, th, m)
  *  This is ugly, and doesn't belong at this level, but has to happen somehow.
  */
 int
-tcp_mss(tp)
-	register struct tcpcb *tp;
+tcp_mss(struct tcpcb *tp)
 {
     	XObj tcpSessn;
 	int mss;

--- a/protocols/tcp/tcp_output.c
+++ b/protocols/tcp/tcp_output.c
@@ -39,10 +39,9 @@ u_char	tcp_initopt[4] = { TCPOPT_MAXSEG, 4, 0x0, 0x0, };
 
 
 void
-tcp_setpersist(tp)
-	register struct tcpcb *tp;
+tcp_setpersist(struct tcpcb *tp)
 {
-	register t = ((tp->t_srtt >> 2) + tp->t_rttvar) >> 1;
+       int t = ((tp->t_srtt >> 2) + tp->t_rttvar) >> 1;
 
 	if (tp->t_timer[TCPT_REXMT])
 		Kabort("tcp_output REXMT");
@@ -61,12 +60,11 @@ tcp_setpersist(tp)
  * Tcp output routine: figure out what should be sent and send it.
  */
 int
-tcp_output(tp)
-	register struct tcpcb *tp;
+tcp_output(struct tcpcb *tp)
 {
-	register XObj so = tp->t_inpcb->inp_session;
-	register struct tcpstate *tcpst = sototcpst(so);
-	register int len, win;
+	XObj so = tp->t_inpcb->inp_session;
+	struct tcpstate *tcpst = sototcpst(so);
+	int len, win;
 	int off, flags, error;
 	struct tcphdr	tHdr;
 	u_char *opt;

--- a/protocols/tcp/tcp_timer.c
+++ b/protocols/tcp/tcp_timer.c
@@ -35,12 +35,10 @@ int	tcpnodelack = 0;
  * Fast timeout routine for processing delayed acks
  */
 void
-tcp_fasttimo( ev, unusedArg )
-    Event	ev;
-    VOID 	*unusedArg;
+tcp_fasttimo(Event ev, VOID *unusedArg)
 {
-	register struct inpcb *inp;
-	register struct tcpcb *tp;
+	struct inpcb *inp;
+	struct tcpcb *tp;
 	/* 
 	 * The original code protected this routine with splnet().  If
 	 * the timeout thread blocks, there could be a problem.
@@ -70,18 +68,16 @@ tcp_fasttimo( ev, unusedArg )
  * causes finite state machine actions if timers expire.
  */
 void
-tcp_slowtimo(ev, unusedArg)
-    Event	ev;
-    VOID 	*unusedArg;
+tcp_slowtimo(Event ev, VOID *unusedArg)
 {
-	register struct inpcb *ip, *ipnxt;
-	register struct tcpcb *tp;
+	struct inpcb *ip, *ipnxt;
+	struct tcpcb *tp;
 	/* 
 	 * The original code protected this routine with splnet().  If
 	 * the timeout thread blocks, there could be a problem.
 	 */
 	/* int s = splnet(); */
-	register int i;
+	int i;
 
 	/*
 	 * Search through tcb's and update active timers.
@@ -125,10 +121,9 @@ tpgone:
  * Cancel all timers for TCP tp.
  */
 void
-tcp_canceltimers(tp)
-	struct tcpcb *tp;
+tcp_canceltimers(struct tcpcb *tp)
 {
-	register int i;
+	int i;
 
 	for (i = 0; i < TCPT_NTIMERS; i++)
 		tp->t_timer[i] = 0;
@@ -142,11 +137,9 @@ int	tcp_backoff[TCP_MAXRXTSHIFT + 1] =
  * TCP timer processing.
  */
 struct tcpcb *
-tcp_timers(tp, timer)
-	register struct tcpcb *tp;
-	int timer;
+tcp_timers(struct tcpcb *tp, int timer)
 {
-	register int rexmt;
+	int rexmt;
 
 	switch (timer) {
 

--- a/protocols/tcp/tcp_usrreq.c
+++ b/protocols/tcp/tcp_usrreq.c
@@ -45,14 +45,11 @@ int	tcpsenderrors;
  */
 /*ARGSUSED*/
 int
-tcp_usrreq(so, req, m, nam)
-	XObj so;
-	int req;
-	Msg *m, *nam;
+tcp_usrreq(XObj so, int req, Msg *m, Msg *nam)
 {
-	register struct inpcb *inp;
-	register struct tcpcb *tp = 0;
-	register struct tcpstate *tcpst = (struct tcpstate*)so->state;
+	struct inpcb *inp;
+	struct tcpcb *tp = 0;
+	struct tcpstate *tcpst = (struct tcpstate*)so->state;
 	/* int s; */
 	int error = 0;
 	int ostate;
@@ -251,10 +248,9 @@ int	tcp_recvspace = TCPRCVWIN;
  * bufer space, and entering LISTEN state if to accept connections.
  */
 int
-tcp_attach(so)
-	XObj so;
+tcp_attach(XObj so)
 {
-	register struct tcpcb *tp;
+	struct tcpcb *tp;
 	struct inpcb *inp;
 	int error;
 
@@ -279,8 +275,7 @@ tcp_attach(so)
  * send segment to peer (with FIN).
  */
 struct tcpcb *
-tcp_disconnect(tp)
-	register struct tcpcb *tp;
+tcp_disconnect(struct tcpcb *tp)
 {
 	XObj so = tp->t_inpcb->inp_session;
 	xTrace1(tcpp, 3, "tcp_disconnect: tp %X", tp);
@@ -306,8 +301,7 @@ tcp_disconnect(tp)
  * We can let the user exit from the close as soon as the FIN is acked.
  */
 struct tcpcb *
-tcp_usrclosed(tp)
-	register struct tcpcb *tp;
+tcp_usrclosed(struct tcpcb *tp)
 {
 
 	switch (tp->t_state) {

--- a/protocols/tcp/tcp_x.c
+++ b/protocols/tcp/tcp_x.c
@@ -406,11 +406,10 @@ tcpOpenDisable(self, hlpRcv, hlpType, p)
  * We can let the user exit from the close as soon as the FIN is acked.
  */
 static xkern_return_t
-tcpClose(so)
-    XObj	so;
+tcpClose(XObj so)
 {
-    register struct tcpcb *tp;
-    register struct tcpstate *tcpst;
+    struct tcpcb *tp;
+    struct tcpstate *tcpst;
     
     xTrace1(tcpp, TR_FUNCTIONAL_TRACE, "tcpClose(so=%08x)", so);
 
@@ -438,15 +437,13 @@ tcpClose(so)
 
 /*************************************************************************/
 static xmsg_handle_t
-tcpPush(so, msg)
-     XObj so;
-     Msg *msg;
+tcpPush(XObj so, Msg *msg)
 {
     int error;
     int space;
     Msg pushMsg;
-    register struct tcpstate *tcpst = sototcpst(so);
-    register struct tcpcb *tp = sototcpcb(so);
+    struct tcpstate *tcpst = sototcpst(so);
+    struct tcpcb *tp = sototcpcb(so);
 
     xTrace2(tcpp, TR_MAJOR_EVENTS, "tcpPush: session %X, msg %d bytes",
 	    so, msgLen(msg));


### PR DESCRIPTION
## Summary
- eliminate `register` storage class usage in TCP sources
- modernize several function definitions to ANSI C prototypes

## Testing
- `make -f Makefile.new test` *(fails: Mach headers not found)*