### PR TITLE
Add SIMD helpers and loop profiling

### DIFF
--- a/include/simd.h
+++ b/include/simd.h
@@ -1,0 +1,48 @@
+#pragma once
+#include <stddef.h>
+#ifdef __AVX2__
+#define LITES_SIMD_AVX2 1
+#else
+#define LITES_SIMD_AVX2 0
+#endif
+#ifdef __SSE2__
+#define LITES_SIMD_SSE2 1
+#else
+#define LITES_SIMD_SSE2 0
+#endif
+#if defined(__ARM_NEON) || defined(__ARM_NEON__)
+#define LITES_SIMD_NEON 1
+#else
+#define LITES_SIMD_NEON 0
+#endif
+#ifdef __cplusplus
+extern "C" {
+#endif
+int simd_bcmp(const void *a, const void *b, size_t len);
+#ifdef __cplusplus
+}
+#endif
+
+#define UNROLL8(stmt)                                                                              \
+    do {                                                                                           \
+        stmt;                                                                                      \
+        stmt;                                                                                      \
+        stmt;                                                                                      \
+        stmt;                                                                                      \
+        stmt;                                                                                      \
+        stmt;                                                                                      \
+        stmt;                                                                                      \
+        stmt;                                                                                      \
+    } while (0)
+
+#ifdef ENABLE_PROFILING
+#include <time.h>
+static inline long profiler_ticks(void) { return clock(); }
+#define PROF_START(var) long var##_start = profiler_ticks();
+#define PROF_END(var)                                                                              \
+    long var##_time = profiler_ticks() - var##_start;                                              \
+    (void)var##_time
+#else
+#define PROF_START(var)
+#define PROF_END(var)
+#endif

--- a/include/sys/cdefs.h
+++ b/include/sys/cdefs.h
@@ -1,33 +1,32 @@
 #pragma once
 
 #if defined(__cplusplus)
-#define __BEGIN_DECLS   extern "C" {
-#define __END_DECLS     }
+#define __BEGIN_DECLS extern "C" {
+#define __END_DECLS }
 #else
 #define __BEGIN_DECLS
 #define __END_DECLS
 #endif
 
-#define __CONCAT(x,y)   x ## y
-#define __STRING(x)     #x
+#define __CONCAT(x, y) x##y
+#define __STRING(x) #x
 
 /* Function attributes */
 #if defined(__GNUC__)
-#define __dead2         __attribute__((__noreturn__))
-#define __pure2         __attribute__((__const__))
+#define __dead2 [[noreturn]]
+#define __pure2 __attribute__((__const__))
 #else
 #define __dead2
 #define __pure2
 #endif
 #ifndef _Noreturn
-# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 /* _Noreturn is a keyword */
-# elif defined(__GNUC__)
-#  define _Noreturn __attribute__((__noreturn__))
-# else
-#  define _Noreturn
-# endif
+#elif defined(__GNUC__)
+#define _Noreturn __attribute__((__noreturn__))
+#else
+#define _Noreturn
 #endif
-#define __dead
-#define __unused       __attribute__((__unused__))
-
+#endif
+#define __dead [[noreturn]]
+#define __unused [[maybe_unused]]

--- a/liblites/Makefile
+++ b/liblites/Makefile
@@ -1,69 +1,65 @@
-# 
-# Mach Operating System
-# Copyright (c) 1994 Johannes Helander
-# All Rights Reserved.
-# 
-# Permission to use, copy, modify and distribute this software and its
-# documentation is hereby granted, provided that both the copyright
-# notice and this permission notice appear in all copies of the
-# software, derivative works or modified versions, and any portions
-# thereof, and that both notices appear in supporting documentation.
-# 
-# JOHANNES HELANDER ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
-# CONDITION.  JOHANNES HELANDER DISCLAIMS ANY LIABILITY OF ANY KIND
-# FOR ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
 #
-# 
-#  HISTORY
-#  $Log: Makefile,v $
-# Revision 1.1.1.1  1995/03/02  21:49:39  mike
-# Initial Lites release from hut.fi
+#Mach Operating System
+#Copyright(c) 1994 Johannes Helander
+#All Rights Reserved.
+#
+#Permission to use, copy, modify and distribute this software and its
+#documentation is hereby granted, provided that both the copyright
+#notice and this permission notice appear in all copies of the
+#software, derivative works or modified versions, and any portions
+#thereof, and that both notices appear in supporting documentation.
+#
+#JOHANNES HELANDER ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
+#CONDITION.JOHANNES HELANDER DISCLAIMS ANY LIABILITY OF ANY KIND
+#FOR ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
 #
 #
-#	File:	emulator/Makefile
-#	Author:	Johannes Helander, Helsinki University of Technology, 1994.
+#HISTORY
+#$Log : Makefile, v $
+#Revision 1.1.1.1 1995 / 03 / 02 21 : 49 : 39 mike
+#Initial Lites release from hut.fi
+#
+#
+#File : emulator / Makefile
+#Author : Johannes Helander, Helsinki University of Technology, 1994.
 #
 
-LIBNAME=lites
+LIBNAME = lites
 
-VPATH		= ${target_cpu}
+    VPATH = ${target_cpu}
 
-LIBRARIES	= lib${LIBNAME}.a
-DEPENDENCIES	=
-MIG_HDRS	=
+LIBRARIES = lib${LIBNAME}.a DEPENDENCIES = MIG_HDRS =
 
-EXPLIB_TARGETS  = ${LIBRARIES:S/^/export_&/g}
-ILIST		= lib${LIBNAME}.a
-IDIR		= /lib/
-NO_STRIP	=
+    EXPLIB_TARGETS = ${LIBRARIES : S / ^/ export_ & / g} ILIST = lib${LIBNAME}.a IDIR =
+        / lib / NO_STRIP =
 
-INCFLAGS	= -I${MAKETOP}server -I${MAKETOP}include
+            INCFLAGS = -I${MAKETOP} server - I${MAKETOP} include
 
-# The EXPORTBASE/bsdss directory contains the include files
-# in machine
+#The EXPORTBASE / bsdss directory contains the include files
+#in machine
 
-INCDIRS		:= -I${EXPORTBASE} ${INCDIRS}
+                                                 INCDIRS
+    : = -I${EXPORTBASE} ${INCDIRS}
 
-# Makefile-version defines VERSION
+#Makefile - version defines VERSION
 
-.if exists( ${MAKETOP}Makefile-version)
-.include "${MAKETOP}Makefile-version"
-.endif
+             .if exists (${MAKETOP} Makefile - version)
+             .include "${MAKETOP}Makefile-version".endif
 
-DEFINES		= -DTypeCheck=0 -DMACH_IPC_COMPAT=0 -DLITES
-CFLAGS		= ${DEFINES} -std=c23 -g -nostdinc -I-
-PC532_CFLAGS	= -mhimem -DGNU_LD2 -Dns532
+                 DEFINES = -DTypeCheck =
+          0 - DMACH_IPC_COMPAT = 0 - DLITES CFLAGS = ${DEFINES} - std =
+                                                         c23 - g - nostdinc - I - PC532_CFLAGS =
+                                                             -mhimem - DGNU_LD2 -
+                                                             Dns532
 
-MIGFLAGS 	= ${DEFINES}
-ASFLAGS		= ${${TARGET_MACHINE}ASFLAGS}
+                                                                 MIGFLAGS = ${DEFINES} ASFLAGS =
+                                                                 ${${TARGET_MACHINE} ASFLAGS}
 
-i386_OFILES = ntoh.o memcmp.o in_cksum.o
-x86_64_OFILES = ntoh.o memcmp.o in_cksum.o
-parisc_OFILES =
-ns532_OFILES = misc_asm.s memcmp.o in_cksum.o bcmp.o
-mips_OFILES = ntoh.o memcmp.o
-alpha_OFILES =
+      i386_OFILES = ntoh.o memcmp.o in_cksum.o simd.o x86_64_OFILES =
+          ntoh.o memcmp.o in_cksum.o simd.o parisc_OFILES = ns532_OFILES =
+              misc_asm.s memcmp.o in_cksum.o bcmp.o mips_OFILES = ntoh.o memcmp.o alpha_OFILES =
 
-lib${LIBNAME}.a_OFILES = ${${target_cpu}_OFILES} exec_file.o
+                  lib${LIBNAME}.a_OFILES = ${${target_cpu} _OFILES} exec_file
+                                               .o
 
-.include <${RULES_MK}>
+                                               .include<${RULES_MK}>

--- a/liblites/simd.c
+++ b/liblites/simd.c
@@ -1,0 +1,51 @@
+#include "simd.h"
+#include <string.h>
+#if LITES_SIMD_AVX2
+#include <immintrin.h>
+#endif
+#if LITES_SIMD_SSE2
+#include <emmintrin.h>
+#endif
+#if LITES_SIMD_NEON
+#include <arm_neon.h>
+#endif
+
+int simd_bcmp(const void *a, const void *b, size_t len) {
+#if LITES_SIMD_AVX2
+    const unsigned char *p1 = a, *p2 = b;
+    size_t i = 0;
+    for (; i + 32 <= len; i += 32) {
+        __m256i va = _mm256_loadu_si256((const __m256i *)(p1 + i));
+        __m256i vb = _mm256_loadu_si256((const __m256i *)(p2 + i));
+        __m256i cmp = _mm256_cmpeq_epi8(va, vb);
+        if (_mm256_movemask_epi8(cmp) != -1)
+            return memcmp(p1 + i, p2 + i, len - i);
+    }
+    return memcmp(p1 + i, p2 + i, len - i);
+#elif LITES_SIMD_SSE2
+    const unsigned char *p1 = a, *p2 = b;
+    size_t i = 0;
+    for (; i + 16 <= len; i += 16) {
+        __m128i va = _mm_loadu_si128((const __m128i *)(p1 + i));
+        __m128i vb = _mm_loadu_si128((const __m128i *)(p2 + i));
+        __m128i cmp = _mm_cmpeq_epi8(va, vb);
+        if (_mm_movemask_epi8(cmp) != 0xFFFF)
+            return memcmp(p1 + i, p2 + i, len - i);
+    }
+    return memcmp(p1 + i, p2 + i, len - i);
+#elif LITES_SIMD_NEON
+    const unsigned char *p1 = a, *p2 = b;
+    size_t i = 0;
+    for (; i + 16 <= len; i += 16) {
+        uint8x16_t va = vld1q_u8(p1 + i);
+        uint8x16_t vb = vld1q_u8(p2 + i);
+        uint8x16_t cmp = vceqq_u8(va, vb);
+        if (vgetq_lane_u64(vreinterpretq_u64_u8(cmp), 0) != ~0ULL ||
+            vgetq_lane_u64(vreinterpretq_u64_u8(cmp), 1) != ~0ULL)
+            return memcmp(p1 + i, p2 + i, len - i);
+    }
+    return memcmp(p1 + i, p2 + i, len - i);
+#else
+    return memcmp(a, b, len);
+#endif
+}

--- a/protocols/tcp-tahoe/tcp_x.c
+++ b/protocols/tcp-tahoe/tcp_x.c
@@ -20,386 +20,359 @@
  * $Date: 1993/05/04 20:18:04 $
  */
 
-#include "xkernel.h"
 #include "ip.h"
-#include "tcp_internal.h"
 #include "tcp_fsm.h"
+#include "tcp_internal.h"
 #include "tcp_seq.h"
 #include "tcp_timer.h"
 #include "tcp_var.h"
 #include "tcpip.h"
-
+#include "xkernel.h"
+#include <simd.h>
 
 char *prurequests[] = {
-	"ATTACH",	"DETACH",	"BIND",		"LISTEN",
-	"CONNECT",	"ACCEPT",	"DISCONNECT",	"SHUTDOWN",
-	"RCVD",		"SEND",		"ABORT",	"CONTROL",
-	"SENSE",	"RCVOOB",	"SENDOOB",	"SOCKADDR",
-	"PEERADDR",	"CONNECT2",	"FASTTIMO",	"SLOWTIMO",
-	"PROTORCV",	"PROTOSEND",
+    "ATTACH",     "DETACH",   "BIND",     "LISTEN",    "CONNECT",  "ACCEPT",
+    "DISCONNECT", "SHUTDOWN", "RCVD",     "SEND",      "ABORT",    "CONTROL",
+    "SENSE",      "RCVOOB",   "SENDOOB",  "SOCKADDR",  "PEERADDR", "CONNECT2",
+    "FASTTIMO",   "SLOWTIMO", "PROTORCV", "PROTOSEND",
 };
 
-XObj            TCP;
-#define         IP (xGetDown(TCP,0))
+XObj TCP;
+#define IP (xGetDown(TCP, 0))
 
-long	tcpIpProtocolNum;
+long tcpIpProtocolNum;
 
-static IPhost   myHost;
+static IPhost myHost;
 
 #ifdef __STDC__
 
-static int	extractPart( Part *, long *, IPhost **, char * );
-static void	tcpSessnInit( XObj );
-static XObj	tcp_establishopen( XObj, XObj, XObj, IPhost *, IPhost *,
-				   int, int );
-static void	tcp_dumpstats( void );
-static int		tcpControlProtl( XObj, int, char *, int );
-static XObj		tcpOpen( XObj, XObj, XObj, Part * );
-static xkern_return_t	tcpOpenEnable( XObj, XObj, XObj, Part * );
-static xkern_return_t	tcpOpenDisable( XObj, XObj, XObj, Part * );
-
+static int extractPart(Part *, long *, IPhost **, char *);
+static void tcpSessnInit(XObj);
+static XObj tcp_establishopen(XObj, XObj, XObj, IPhost *, IPhost *, int, int);
+static void tcp_dumpstats(void);
+static int tcpControlProtl(XObj, int, char *, int);
+static XObj tcpOpen(XObj, XObj, XObj, Part *);
+static xkern_return_t tcpOpenEnable(XObj, XObj, XObj, Part *);
+static xkern_return_t tcpOpenDisable(XObj, XObj, XObj, Part *);
 
 #else
 
-static int	extractPart();
-static void	tcpSessnInit();
-static XObj	tcp_establishopen();
-static void	tcp_dumpstats();
-static int		tcpControlProtl();
-static XObj		tcpOpen();
-static xkern_return_t	tcpOpenEnable();
-static xkern_return_t	tcpOpenDisable();
+static int extractPart();
+static void tcpSessnInit();
+static XObj tcp_establishopen();
+static void tcp_dumpstats();
+static int tcpControlProtl();
+static XObj tcpOpen();
+static xkern_return_t tcpOpenEnable();
+static xkern_return_t tcpOpenDisable();
 
 #endif __STDC__
 
-
-
-/* 
+/*
  * Check for a valid participant list
  */
-#define partCheck(p, name, max, retval)					\
-	{								\
-	  if ( ! (p) || partLen(p) < 1 || partLen(p) > (max)) { 	\
-		xTrace1(tcpp, TR_ERRORS,				\
-			"%s -- bad participants",			\
-			(name));  					\
-		return (retval);					\
-	  }								\
-	}
-
+#define partCheck(p, name, max, retval)                                                            \
+    {                                                                                              \
+        if (!(p) || partLen(p) < 1 || partLen(p) > (max)) {                                        \
+            xTrace1(tcpp, TR_ERRORS, "%s -- bad participants", (name));                            \
+            return (retval);                                                                       \
+        }                                                                                          \
+    }
 
 /*************************************************************************/
 
-void
-tcp_init(self)
-    XObj            self;
+void tcp_init(self) XObj self;
 {
-  Part		p;
-  PSTATE	*pstate;
-  XObj		ip;
+    Part p;
+    PSTATE *pstate;
+    XObj ip;
 
-  TCP = self;
-  xTrace0(tcpp, TR_GROSS_EVENTS, "TCP init");
-  xTrace1(tcpp, TR_GROSS_EVENTS, "ENDIAN = %d", ENDIAN);
+    TCP = self;
+    xTrace0(tcpp, TR_GROSS_EVENTS, "TCP init");
+    xTrace1(tcpp, TR_GROSS_EVENTS, "ENDIAN = %d", ENDIAN);
 
-  xAssert(xIsProtocol(self));
+    xAssert(xIsProtocol(self));
 
-  pstate = (PSTATE *)xMalloc(sizeof(PSTATE));
-  self->state = (char *)pstate;
+    pstate = (PSTATE *)xMalloc(sizeof(PSTATE));
+    self->state = (char *)pstate;
 
-  self->control = tcpControlProtl;
-  self->open = tcpOpen;
-  self->openenable = tcpOpenEnable;
-  self->opendisable = tcpOpenDisable;
-  self->demux = tcp_input;
+    self->control = tcpControlProtl;
+    self->open = tcpOpen;
+    self->openenable = tcpOpenEnable;
+    self->opendisable = tcpOpenDisable;
+    self->demux = tcp_input;
 
-  pstate->passiveMap = mapCreate(37, sizeof(PassiveId));
-  pstate->activeMap = mapCreate(101, sizeof(ActiveId));
+    pstate->passiveMap = mapCreate(37, sizeof(PassiveId));
+    pstate->activeMap = mapCreate(101, sizeof(ActiveId));
 
-  tcb.inp_next = tcb.inp_prev = &tcb;
-  tcp_iss = 1;
-  ip = xGetProtlByName("ip");
-  if ( ! xIsXObj(ip) ) {
-      Kabort("TCP can't get IP protocol object");
-  }
-  if ( (tcpIpProtocolNum = relProtNum(self, ip)) == -1 ) {
-      Kabort("TCP can't get protocol number relative to IP");
-  }
-  xTrace1(tcpp, TR_DETAILED, "TCP uses IP protocol number %d",
-	  tcpIpProtocolNum);
-  /* Turn on IP pseudoheader length-fixup kludge in lower protocols. */
-  xControl(IP,IP_PSEUDOHDR,(char *)0,0); /* IP is abbrev for lower protocol. */
-  partInit(&p, 1);
-  partPush(p, ANY_HOST, 0);
-  xOpenEnable(TCP, TCP, IP, &p);
-  xControl(IP, GETMYHOST, (char *)&myHost, sizeof(myHost));
-  evDetach(evSchedule(tcp_fasttimo, 0, TCP_FAST_INTERVAL));
-  evDetach(evSchedule(tcp_slowtimo, 0, TCP_SLOW_INTERVAL));
-  tcpPortMapInit( &pstate->portstate );
+    tcb.inp_next = tcb.inp_prev = &tcb;
+    tcp_iss = 1;
+    ip = xGetProtlByName("ip");
+    if (!xIsXObj(ip)) {
+        Kabort("TCP can't get IP protocol object");
+    }
+    if ((tcpIpProtocolNum = relProtNum(self, ip)) == -1) {
+        Kabort("TCP can't get protocol number relative to IP");
+    }
+    xTrace1(tcpp, TR_DETAILED, "TCP uses IP protocol number %d", tcpIpProtocolNum);
+    /* Turn on IP pseudoheader length-fixup kludge in lower protocols. */
+    xControl(IP, IP_PSEUDOHDR, (char *)0, 0); /* IP is abbrev for lower protocol. */
+    partInit(&p, 1);
+    partPush(p, ANY_HOST, 0);
+    xOpenEnable(TCP, TCP, IP, &p);
+    xControl(IP, GETMYHOST, (char *)&myHost, sizeof(myHost));
+    evDetach(evSchedule(tcp_fasttimo, 0, TCP_FAST_INTERVAL));
+    evDetach(evSchedule(tcp_slowtimo, 0, TCP_SLOW_INTERVAL));
+    tcpPortMapInit(&pstate->portstate);
 }
 
 /*************************************************************************/
-struct tcpstate *new_tcpstate()
-{
-  struct tcpstate *tcpstate;
-  tcpstate = (struct tcpstate *) xMalloc(sizeof(struct tcpstate));
-  memset((char *)tcpstate, 0, sizeof(struct tcpstate));
-  tcpSemInit(&tcpstate->waiting, 0);
-  tcpSemInit(&tcpstate->lock, 1);
-  tcpstate->closed = 0;
-  tcpstate->snd = (struct sb *)xMalloc(sizeof(struct sb));
-  /* initialize buffer size to TCPRCVWIN to get things started: */
-  tcpstate->rcv_space = TCPRCVWIN;
-  tcpstate->rcv_hiwat = TCPRCVWIN;
-  return tcpstate;
+struct tcpstate *new_tcpstate() {
+    struct tcpstate *tcpstate;
+    tcpstate = (struct tcpstate *)xMalloc(sizeof(struct tcpstate));
+    memset((char *)tcpstate, 0, sizeof(struct tcpstate));
+    tcpSemInit(&tcpstate->waiting, 0);
+    tcpSemInit(&tcpstate->lock, 1);
+    tcpstate->closed = 0;
+    tcpstate->snd = (struct sb *)xMalloc(sizeof(struct sb));
+    /* initialize buffer size to TCPRCVWIN to get things started: */
+    tcpstate->rcv_space = TCPRCVWIN;
+    tcpstate->rcv_hiwat = TCPRCVWIN;
+    return tcpstate;
 }
 
 /*************************************************************************/
-void delete_tcpstate(tcpstate)
-struct tcpstate *tcpstate;
+void delete_tcpstate(tcpstate) struct tcpstate *tcpstate;
 {
-  tcpVAll(&tcpstate->waiting);
-  xFree((char *)tcpstate);
+    tcpVAll(&tcpstate->waiting);
+    xFree((char *)tcpstate);
 
-  /* From RICE 07/03/90 */
-  tcpVAll(&tcpstate->lock);
-  xFree((char *)tcpstate->snd);
-  xFree((char *)tcpstate);
+    /* From RICE 07/03/90 */
+    tcpVAll(&tcpstate->lock);
+    xFree((char *)tcpstate->snd);
+    xFree((char *)tcpstate);
 }
 
 /*************************************************************************/
-static XObj
-tcp_establishopen(self, hlpRcv, hlpType, raddr, laddr, rport, lport)
-    XObj self, hlpRcv, hlpType;
-    IPhost *raddr, *laddr;
-    int rport, lport;
+static XObj tcp_establishopen(self, hlpRcv, hlpType, raddr, laddr, rport, lport)
+XObj self, hlpRcv, hlpType;
+IPhost *raddr, *laddr;
+int rport, lport;
 {
-  Part          p[2];
-  XObj		new;
-  struct tcpstate *tcpst;
-  struct inpcb *inp;
-  ActiveId      ex_id;
-  XObj		lls;
-  PSTATE	*pstate;
+    Part p[2];
+    XObj new;
+    struct tcpstate *tcpst;
+    struct inpcb *inp;
+    ActiveId ex_id;
+    XObj lls;
+    PSTATE *pstate;
 
-  xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp_establish: on %X", hlpRcv);
-  xAssert(xIsProtocol(hlpRcv));
+    xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp_establish: on %X", hlpRcv);
+    xAssert(xIsProtocol(hlpRcv));
 
-  pstate = (PSTATE *)self->state;
-  ex_id.localport = lport;
-  ex_id.remoteport = rport;
-  ex_id.remoteaddr = *raddr;
-  if ( mapResolve(pstate->activeMap, &ex_id, &new) == XK_SUCCESS ) {
-    xTrace3(tcpp, TR_GROSS_EVENTS, "tcp_establish: (%d->%X.%d) already open",
-	    ex_id.localport, ex_id.remoteaddr, ex_id.remoteport);
-    return 0;
-  }
+    pstate = (PSTATE *)self->state;
+    ex_id.localport = lport;
+    ex_id.remoteport = rport;
+    ex_id.remoteaddr = *raddr;
+    if (mapResolve(pstate->activeMap, &ex_id, &new) == XK_SUCCESS) {
+        xTrace3(tcpp, TR_GROSS_EVENTS, "tcp_establish: (%d->%X.%d) already open", ex_id.localport,
+                ex_id.remoteaddr, ex_id.remoteport);
+        return 0;
+    }
 
-  partInit(p, laddr ? 2 : 1);
-  partPush(p[0], raddr, sizeof(IPhost));
-  if ( laddr ) {
-      partPush(p[1], laddr, sizeof(IPhost));
-  }
-  xTrace0(tcpp, TR_EVENTS, "tcpOpen: opening IP");
-  if ( (lls = xOpen(TCP, TCP, IP, p)) == ERR_SESSN ) {
-    xTrace0(tcpp, TR_ERRORS, "tcpOpen: cannot open IP session");
-    return 0;
-  }
+    partInit(p, laddr ? 2 : 1);
+    partPush(p[0], raddr, sizeof(IPhost));
+    if (laddr) {
+        partPush(p[1], laddr, sizeof(IPhost));
+    }
+    xTrace0(tcpp, TR_EVENTS, "tcpOpen: opening IP");
+    if ((lls = xOpen(TCP, TCP, IP, p)) == ERR_SESSN) {
+        xTrace0(tcpp, TR_ERRORS, "tcpOpen: cannot open IP session");
+        return 0;
+    }
 
-  new = xCreateSessn(tcpSessnInit, hlpRcv, hlpType, TCP, 1, &lls);
-  xTrace3(tcpp, TR_GROSS_EVENTS, "Mapping %d->%X.%d", lport, raddr, rport);
-  new->binding = mapBind(pstate->activeMap, (char *) &ex_id, (int) new);
-  if ((int)new->binding == -1) {
-    xTrace3(tcpp, TR_GROSS_EVENTS, "tcp_establish: Bind of %d->%X.%d failed", 
-      lport, raddr, rport);
-    return 0;
-  }
+    new = xCreateSessn(tcpSessnInit, hlpRcv, hlpType, TCP, 1, &lls);
+    xTrace3(tcpp, TR_GROSS_EVENTS, "Mapping %d->%X.%d", lport, raddr, rport);
+    new->binding = mapBind(pstate->activeMap, (char *)&ex_id, (int)new);
+    if ((int)new->binding == -1) {
+        xTrace3(tcpp, TR_GROSS_EVENTS, "tcp_establish: Bind of %d->%X.%d failed", lport, raddr,
+                rport);
+        return 0;
+    }
 
-  tcpst = new_tcpstate();
-  tcpst->hlpType = hlpType;
-  new->state = (char *)tcpst;
-  xTrace0(tcpp, TR_EVENTS, "tcpOpen: attaching...");
-  tcp_attach(new);
+    tcpst = new_tcpstate();
+    tcpst->hlpType = hlpType;
+    new->state = (char *)tcpst;
+    xTrace0(tcpp, TR_EVENTS, "tcpOpen: attaching...");
+    tcp_attach(new);
 
-  inp = sotoinpcb(new);
-  tcpst->inpcb = inp;
-  tcpst->tcpcb = (struct tcpcb *)inp->inp_ppcb;
-  *(IPhost *)&inp->inp_laddr = myHost;
-  inp->inp_lport = ex_id.localport;
-  *(IPhost *)&inp->inp_raddr = ex_id.remoteaddr;
-  inp->inp_rport = ex_id.remoteport;
+    inp = sotoinpcb(new);
+    tcpst->inpcb = inp;
+    tcpst->tcpcb = (struct tcpcb *)inp->inp_ppcb;
+    *(IPhost *)&inp->inp_laddr = myHost;
+    inp->inp_lport = ex_id.localport;
+    *(IPhost *)&inp->inp_raddr = ex_id.remoteaddr;
+    inp->inp_rport = ex_id.remoteport;
 
-  /*  xControl(xGetDown(new,0),IP_PSEUDOHDR,(char *)0,0);  moved to tcp_init --rcs */
-  return new;
+    /*  xControl(xGetDown(new,0),IP_PSEUDOHDR,(char *)0,0);  moved to tcp_init --rcs */
+    return new;
 }
 
-
-static int
-extractPart( p, port, host, s )
-    Part	*p;
-    long	*port;
-    IPhost	**host;
-    char	*s;
+static int extractPart(p, port, host, s)
+Part *p;
+long *port;
+IPhost **host;
+char *s;
 {
-    long	*portPtr;
-    IPhost	*hostPtr;
+    long *portPtr;
+    IPhost *hostPtr;
 
     xAssert(port);
-    if ( (portPtr = (long *)partPop(*p)) == 0 ) {
-	xTrace1(tcpp, TR_SOFT_ERROR, "Bad participant in %s -- no port", s);
-	return -1;
+    if ((portPtr = (long *)partPop(*p)) == 0) {
+        xTrace1(tcpp, TR_SOFT_ERROR, "Bad participant in %s -- no port", s);
+        return -1;
     }
     *port = *portPtr;
-    if ( *port > MAX_PORT ) {
-	xTrace2(tcpp, TR_SOFT_ERROR,
-		"Bad participant in %s -- port %d out of range", s, *port);
-	return -1;
+    if (*port > MAX_PORT) {
+        xTrace2(tcpp, TR_SOFT_ERROR, "Bad participant in %s -- port %d out of range", s, *port);
+        return -1;
     }
-    if ( host ) {
-	if ( (hostPtr = (IPhost *)partPop(*p)) == 0 ) {
-	    xTrace1(tcpp, TR_SOFT_ERROR,
-		    "Bad participant in %s -- no host", s);
-	    return -1;
-	}
-	*host = hostPtr;
+    if (host) {
+        if ((hostPtr = (IPhost *)partPop(*p)) == 0) {
+            xTrace1(tcpp, TR_SOFT_ERROR, "Bad participant in %s -- no host", s);
+            return -1;
+        }
+        *host = hostPtr;
     }
     return 0;
 }
 
-
 /*************************************************************************/
-static XObj
-tcpOpen(self, hlpRcv, hlpType, p)
-    XObj            self, hlpRcv, hlpType;
-    Part           *p;
+static XObj tcpOpen(self, hlpRcv, hlpType, p)
+XObj self, hlpRcv, hlpType;
+Part *p;
 {
-    XObj	s;
-    long	remotePort, localPort = ANY_PORT;
-    IPhost	*remoteHost, *localHost = 0;
-    
+    XObj s;
+    long remotePort, localPort = ANY_PORT;
+    IPhost *remoteHost, *localHost = 0;
+
     xTrace0(tcpp, TR_GROSS_EVENTS, "TCP open");
     partCheck(p, "tcpOpen", 2, ERR_XOBJ);
-    if ( extractPart(p, &remotePort, &remoteHost, "tcpOpen (remote)") ) {
-	return ERR_XOBJ;
+    if (extractPart(p, &remotePort, &remoteHost, "tcpOpen (remote)")) {
+        return ERR_XOBJ;
     }
-    if ( partLen(p) > 1 ) {
-	if ( extractPart(p+1, &localPort, &localHost, "tcpOpen (local)") ) {
-	    return ERR_XOBJ;
-	}
-	if ( localHost == (IPhost *)ANY_HOST ) {
-	    localHost = 0;
-	}
+    if (partLen(p) > 1) {
+        if (extractPart(p + 1, &localPort, &localHost, "tcpOpen (local)")) {
+            return ERR_XOBJ;
+        }
+        if (localHost == (IPhost *)ANY_HOST) {
+            localHost = 0;
+        }
     }
-    if ( localPort == ANY_PORT ) {
-	/* 
-	 * We need to find a free local port
-	 */
-	long	freePort;
-	if ( tcpGetFreePort(((PSTATE *)(self->state))->portstate, &freePort) ) {
-	    xError("tcpOpen -- no free ports!");
-	    return ERR_XOBJ;
-	}
-	localPort = freePort;
+    if (localPort == ANY_PORT) {
+        /*
+         * We need to find a free local port
+         */
+        long freePort;
+        if (tcpGetFreePort(((PSTATE *)(self->state))->portstate, &freePort)) {
+            xError("tcpOpen -- no free ports!");
+            return ERR_XOBJ;
+        }
+        localPort = freePort;
     } else {
-	/* 
-	 * A specific local port was requested
-	 */
-	if ( tcpDuplicatePort(((PSTATE *)(self->state))->portstate, localPort))
-	  {
-	    xTrace1(tcpp, TR_MAJOR_EVENTS,
-		    "tcpOpen: requested port %d is already in use",
-		    localPort);
-	    return ERR_XOBJ;
-	  }
-      }
-    s = tcp_establishopen(self, hlpRcv, hlpType, remoteHost, localHost,
-			  remotePort, localPort);
+        /*
+         * A specific local port was requested
+         */
+        if (tcpDuplicatePort(((PSTATE *)(self->state))->portstate, localPort)) {
+            xTrace1(tcpp, TR_MAJOR_EVENTS, "tcpOpen: requested port %d is already in use",
+                    localPort);
+            return ERR_XOBJ;
+        }
+    }
+    s = tcp_establishopen(self, hlpRcv, hlpType, remoteHost, localHost, remotePort, localPort);
     if (!s) {
-	tcpReleasePort(((PSTATE *)(self->state))->portstate, localPort);
-	s = ERR_SESSN;
+        tcpReleasePort(((PSTATE *)(self->state))->portstate, localPort);
+        s = ERR_SESSN;
     } else {
-	xTrace0(tcpp, TR_EVENTS, "tcpOpen: connecting...");
-	tcp_usrreq(s, PRU_CONNECT, 0, 0);
-	
-	xTrace0(tcpp, TR_EVENTS, "tcpOpen: waiting...");
-	tcpSemWait(&(sototcpst(s)->waiting));
-	if (sototcpcb(s)->t_state != TCPS_ESTABLISHED) {
-	    xTrace3(tcpp, TR_EVENTS, "tcpOpen: open (%d->%X.%d) connect failed",
-		    localPort,  ipHostStr(remoteHost), remotePort);
-	    tcp_destroy(sototcpcb(s));
-	    tcpReleasePort(((PSTATE *)(self->state))->portstate, localPort);
-	    s = ERR_SESSN;
-	}
+        xTrace0(tcpp, TR_EVENTS, "tcpOpen: connecting...");
+        tcp_usrreq(s, PRU_CONNECT, 0, 0);
+
+        xTrace0(tcpp, TR_EVENTS, "tcpOpen: waiting...");
+        tcpSemWait(&(sototcpst(s)->waiting));
+        if (sototcpcb(s)->t_state != TCPS_ESTABLISHED) {
+            xTrace3(tcpp, TR_EVENTS, "tcpOpen: open (%d->%X.%d) connect failed", localPort,
+                    ipHostStr(remoteHost), remotePort);
+            tcp_destroy(sototcpcb(s));
+            tcpReleasePort(((PSTATE *)(self->state))->portstate, localPort);
+            s = ERR_SESSN;
+        }
     }
     xTrace1(tcpp, TR_GROSS_EVENTS, "Return from tcpOpen, session = %x", s);
     return s;
 }
 
 /*************************************************************************/
-static xkern_return_t
-tcpOpenEnable(self, hlpRcv, hlpType, p)
-    XObj	self, hlpRcv, hlpType;
-    Part	*p;
+static xkern_return_t tcpOpenEnable(self, hlpRcv, hlpType, p)
+XObj self, hlpRcv, hlpType;
+Part *p;
 {
-    PassiveId	key;
-    long	protNum;
-    PSTATE	*pstate;
-    Enable	*e;
-    
+    PassiveId key;
+    long protNum;
+    PSTATE *pstate;
+    Enable *e;
+
     partCheck(p, "tcpOpenEnable", 1, XK_FAILURE);
-    if ( extractPart(p, &protNum, 0, "tcpOpenEnable") ) {
-	return XK_FAILURE;
+    if (extractPart(p, &protNum, 0, "tcpOpenEnable")) {
+        return XK_FAILURE;
     }
     key = protNum;
     pstate = (PSTATE *)self->state;
-    xTrace2(tcpp, TR_MAJOR_EVENTS, "tcpOpenEnable mapping %d->%x", key,
-	    hlpRcv);
-    if ( mapResolve(pstate->passiveMap, &key, &e) == XK_SUCCESS ) {
-	if ( e->hlpRcv == hlpRcv && e->hlpType == hlpType ) {
-	    e->rcnt++;
-	    return XK_SUCCESS;
-	}
-	return XK_FAILURE;
+    xTrace2(tcpp, TR_MAJOR_EVENTS, "tcpOpenEnable mapping %d->%x", key, hlpRcv);
+    if (mapResolve(pstate->passiveMap, &key, &e) == XK_SUCCESS) {
+        if (e->hlpRcv == hlpRcv && e->hlpType == hlpType) {
+            e->rcnt++;
+            return XK_SUCCESS;
+        }
+        return XK_FAILURE;
     }
     tcpDuplicatePort(pstate->portstate, key);
     e = (Enable *)xMalloc(sizeof(Enable));
     e->hlpRcv = hlpRcv;
     e->hlpType = hlpType;
     e->rcnt = 1;
-    e->binding = mapBind(pstate->passiveMap, (char *) &key, (int) e);
-    if ( e->binding == ERR_BIND ) {
-	xFree((char *)e);
-	return XK_FAILURE;
+    e->binding = mapBind(pstate->passiveMap, (char *)&key, (int)e);
+    if (e->binding == ERR_BIND) {
+        xFree((char *)e);
+        return XK_FAILURE;
     }
     return XK_SUCCESS;
 }
 
 /*************************************************************************/
-static xkern_return_t
-tcpOpenDisable(self, hlpRcv, hlpType, p)
-    XObj	self, hlpRcv, hlpType;
-    Part        *p;
+static xkern_return_t tcpOpenDisable(self, hlpRcv, hlpType, p)
+XObj self, hlpRcv, hlpType;
+Part *p;
 {
-    PassiveId	key;
-    long	protNum;
-    Enable	*e;
-    PSTATE	*pstate;
+    PassiveId key;
+    long protNum;
+    Enable *e;
+    PSTATE *pstate;
 
     pstate = (PSTATE *)self->state;
     partCheck(p, "tcpOpenDisable", 1, XK_FAILURE);
-    if ( extractPart(p, &protNum, 0, "tcpOpenEnable") ) {
-	return XK_FAILURE;
+    if (extractPart(p, &protNum, 0, "tcpOpenEnable")) {
+        return XK_FAILURE;
     }
     key = protNum;
     xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp_disable removing %d", key);
-    if ( mapResolve(pstate->passiveMap, &key, &e) == XK_FAILURE ||
-		e->hlpRcv != hlpRcv || e->hlpType != hlpType ) {
-	return XK_FAILURE;
+    if (mapResolve(pstate->passiveMap, &key, &e) == XK_FAILURE || e->hlpRcv != hlpRcv ||
+        e->hlpType != hlpType) {
+        return XK_FAILURE;
     }
     if (--(e->rcnt) == 0) {
-	mapRemoveBinding(pstate->passiveMap, e->binding);
-	xFree((char *)e);
-	tcpReleasePort(pstate->portstate, key);
+        mapRemoveBinding(pstate->passiveMap, e->binding);
+        xFree((char *)e);
+        tcpReleasePort(pstate->portstate, key);
     }
     return XK_SUCCESS;
 }
@@ -415,307 +388,281 @@ tcpOpenDisable(self, hlpRcv, hlpType, p)
  * for peer to send FIN or not respond to keep-alives, etc.
  * We can let the user exit from the close as soon as the FIN is acked.
  */
-static xkern_return_t
-tcpClose(XObj so)
-{
+static xkern_return_t tcpClose(XObj so) {
     struct tcpcb *tp;
     struct tcpstate *tcpst;
-    
+
     xTrace1(tcpp, TR_FUNCTIONAL_TRACE, "tcpClose(so=%08x)", so);
 
     tcpst = sototcpst(so);
     tcpst->closed |= 1;
-    
+
     tp = sototcpcb(so);
     tp = tcp_usrclosed(tp);
-    if (tp) tcp_output(tp);
+    if (tp)
+        tcp_output(tp);
 
-    xTrace2(tcpp, TR_MAJOR_EVENTS, "tcpClose: tp=%08x, tcpst->closed=%x",
-	    tp, tcpst->closed);
-    
+    xTrace2(tcpp, TR_MAJOR_EVENTS, "tcpClose: tp=%08x, tcpst->closed=%x", tp, tcpst->closed);
+
     if (tcpst->closed == 1) {
-	/*
-	 * This was a user close before the network close
-	 */
-	xTrace0(tcpp, TR_EVENTS, "tcpClose: waiting...");
-	tcpSemWait(&tcpst->waiting);
-	xTrace0(tcpp, TR_EVENTS, "tcpClose: done");
+        /*
+         * This was a user close before the network close
+         */
+        xTrace0(tcpp, TR_EVENTS, "tcpClose: waiting...");
+        tcpSemWait(&tcpst->waiting);
+        xTrace0(tcpp, TR_EVENTS, "tcpClose: done");
     }
     return XK_SUCCESS;
 }
 
-
 /*************************************************************************/
-static xmsg_handle_t
-tcpPush(XObj so, Msg *msg)
-{
+static xmsg_handle_t tcpPush(XObj so, Msg *msg) {
     int error;
     int space;
     Msg pushMsg;
     struct tcpstate *tcpst = sototcpst(so);
     struct tcpcb *tp = sototcpcb(so);
 
-    xTrace2(tcpp, TR_MAJOR_EVENTS, "tcpPush: session %X, msg %d bytes",
-	    so, msgLen(msg));
+    xTrace2(tcpp, TR_MAJOR_EVENTS, "tcpPush: session %X, msg %d bytes", so, msgLen(msg));
     if (so->rcnt < 1) {
-	xTrace1(tcpp, TR_GROSS_EVENTS, "tcpPush: session ref count = %d",
-		so->rcnt);
-	return XMSG_ERR_HANDLE;
+        xTrace1(tcpp, TR_GROSS_EVENTS, "tcpPush: session ref count = %d", so->rcnt);
+        return XMSG_ERR_HANDLE;
     }
     if (tcpst->closed) {
-	xTrace1(tcpp, TR_SOFT_ERROR, "tcpPush: session already closed %d",
-		tcpst->closed);
-	return XMSG_ERR_HANDLE;
+        xTrace1(tcpp, TR_SOFT_ERROR, "tcpPush: session already closed %d", tcpst->closed);
+        return XMSG_ERR_HANDLE;
     }
 
-#undef CHUNKSIZE (sbhiwat(tcpst->snd) / 2)
+#undef CHUNKSIZE(sbhiwat(tcpst->snd) / 2)
 #define CHUNKSIZE (tp->t_maxseg)
 
-    if ((tcpst->flags & TCPST_NBIO) &&
-	(sbspace(tcpst->snd) < MIN(msgLen(msg), CHUNKSIZE)))
-    {
-	return XMSG_ERR_WOULDBLOCK;
+    if ((tcpst->flags & TCPST_NBIO) && (sbspace(tcpst->snd) < MIN(msgLen(msg), CHUNKSIZE))) {
+        return XMSG_ERR_WOULDBLOCK;
     } /* if */
 
     msgConstructEmpty(&pushMsg);
-    while ( msgLen(msg) != 0 ) {
-	xTrace1(tcpp, TR_FUNCTIONAL_TRACE,
-		"tcpPush: msgLen = <%d>", msgLen(msg));
-	msgChopOff(msg, &pushMsg, CHUNKSIZE);
-	xTrace2(tcpp, TR_FUNCTIONAL_TRACE,
-		"tcpPush: after break pushMsg = <%d> msg = <%d>",
-		msgLen(&pushMsg), msgLen(msg));
-	while ((space = sbspace(tcpst->snd)) < msgLen(&pushMsg)) {
-	    xTrace1(tcpp, TR_GROSS_EVENTS,
-		    "tcpPush: waiting for space (%d available)", space);
-	    xTrace1(tcpp, TR_FUNCTIONAL_TRACE,
-		    "tcpPush: msgLen == %d before blocking",
-		    msgLen(msg));
-	    tcpSemWait(&tcpst->waiting);
-	    if (tcpst->closed) {
-		xTrace1(tcpp, TR_FUNCTIONAL_TRACE,
-			"tcpPush: session already closed %d", tcpst->closed);
-		msgDestroy(&pushMsg);
-		return XMSG_ERR_HANDLE;
-	    }
-	}
-	xTrace1(tcpp, TR_FUNCTIONAL_TRACE,
-		"tcppush about to append to sb.  orig msgLen == %d",
-		msgLen(msg));
-	sbappend(tcpst->snd, &pushMsg);
-	error = tcp_output(sototcpcb(so));
-	if (error) {
-	    xTrace1(tcpp, TR_ERRORS, "tcpPush failed with code %d", error);
-	    msgDestroy(&pushMsg);
-	    return XMSG_ERR_HANDLE;
-	}
+    while (msgLen(msg) != 0) {
+        xTrace1(tcpp, TR_FUNCTIONAL_TRACE, "tcpPush: msgLen = <%d>", msgLen(msg));
+        msgChopOff(msg, &pushMsg, CHUNKSIZE);
+        xTrace2(tcpp, TR_FUNCTIONAL_TRACE, "tcpPush: after break pushMsg = <%d> msg = <%d>",
+                msgLen(&pushMsg), msgLen(msg));
+        while ((space = sbspace(tcpst->snd)) < msgLen(&pushMsg)) {
+            xTrace1(tcpp, TR_GROSS_EVENTS, "tcpPush: waiting for space (%d available)", space);
+            xTrace1(tcpp, TR_FUNCTIONAL_TRACE, "tcpPush: msgLen == %d before blocking",
+                    msgLen(msg));
+            tcpSemWait(&tcpst->waiting);
+            if (tcpst->closed) {
+                xTrace1(tcpp, TR_FUNCTIONAL_TRACE, "tcpPush: session already closed %d",
+                        tcpst->closed);
+                msgDestroy(&pushMsg);
+                return XMSG_ERR_HANDLE;
+            }
+        }
+        xTrace1(tcpp, TR_FUNCTIONAL_TRACE, "tcppush about to append to sb.  orig msgLen == %d",
+                msgLen(msg));
+        sbappend(tcpst->snd, &pushMsg);
+        error = tcp_output(sototcpcb(so));
+        if (error) {
+            xTrace1(tcpp, TR_ERRORS, "tcpPush failed with code %d", error);
+            msgDestroy(&pushMsg);
+            return XMSG_ERR_HANDLE;
+        }
     }
     msgDestroy(&pushMsg);
     return XMSG_NULL_HANDLE;
 }
 
 /*************************************************************************/
-static int
-tcpControlSessn(s, opcode, buf, len)
-    Sessn           s;
-    char           *buf;
-    int             opcode;
-    int             len;
+static int tcpControlSessn(s, opcode, buf, len)
+Sessn s;
+char *buf;
+int opcode;
+int len;
 {
-  struct tcpstate *ts;
-  struct tcpcb   *tp;
-  u_short size;
+    struct tcpstate *ts;
+    struct tcpcb *tp;
+    u_short size;
 
-  ts = (struct tcpstate *) s->state;
-  tp = ts->tcpcb;
-  switch (opcode) {
+    ts = (struct tcpstate *)s->state;
+    tp = ts->tcpcb;
+    switch (opcode) {
 
-   case GETMYPROTO:
-     checkLen(len, sizeof(long));
-     *(long *)buf = tp->t_template->ti_sport;
-     return sizeof(long);
+    case GETMYPROTO:
+        checkLen(len, sizeof(long));
+        *(long *)buf = tp->t_template->ti_sport;
+        return sizeof(long);
 
-   case GETPEERPROTO:
-     checkLen(len, sizeof(long));
-     *(long *)buf = tp->t_template->ti_dport;
-     return sizeof(long);
+    case GETPEERPROTO:
+        checkLen(len, sizeof(long));
+        *(long *)buf = tp->t_template->ti_dport;
+        return sizeof(long);
 
-   case TCP_PUSH:
-     tp->t_force = 1;
-     tcp_output(tp);
-     tp->t_force = 0;
-     return 0;
+    case TCP_PUSH:
+        tp->t_force = 1;
+        tcp_output(tp);
+        tp->t_force = 0;
+        return 0;
 
-   case TCP_GETSTATEINFO:
-     *(int *) buf = tp->t_state;
-     return (sizeof(int));
+    case TCP_GETSTATEINFO:
+        *(int *)buf = tp->t_state;
+        return (sizeof(int));
 
-   case GETOPTPACKET:
-   case GETMAXPACKET:
-     if ( xControl(xGetDown(s, 0), opcode, buf, len) < sizeof(int) ) {
-	 return -1;
-     }
-     *(int *)buf -= sizeof(struct tcphdr);
-     return sizeof(int);
-     
-   case GETPARTICIPANTS:
-     {
-	 Part		p[2];
-	 int 		retLen;
-	 long		localPort, remotePort;
-	 int		numParts;
-	 xkern_return_t	xkr;
-	 
-	 retLen = xControl(xGetDown(s, 0), opcode, buf, len);
-	 if ( retLen < 0 ) {
-	     return retLen;
-	 }
-	 numParts = partExtLen(buf);
-	 if ( numParts > 0 && numParts <= 2 ) {
-	     partInternalize(p, buf);
-	     if ( numParts == 2 ) {
-		 localPort = tp->t_template->ti_sport;
-		 partPush(p[1], &localPort, sizeof(long));
-	     }
-	     remotePort = tp->t_template->ti_dport;
-	     partPush(p[0], &remotePort, sizeof(long));
-	     xkr = partExternalize(p, buf, &len);
-	     if ( xkr == XK_FAILURE ) {
-		 xTrace0(tcpp, TR_SOFT_ERRORS,
-			 "TCP GETPARTS -- buffer too small");
-		 retLen = -1;
-	     } else {
-		 retLen = len;
-	     }
-	 } else {
-	     xTrace1(tcpp, TR_SOFT_ERRORS,
-		 "TCP -- Bad number of participants (%d) returned in GETPARTS",
-		     partExtLen(buf));
-	     retLen = -1;
-	 }
-	 return retLen;
-     }
+    case GETOPTPACKET:
+    case GETMAXPACKET:
+        if (xControl(xGetDown(s, 0), opcode, buf, len) < sizeof(int)) {
+            return -1;
+        }
+        *(int *)buf -= sizeof(struct tcphdr);
+        return sizeof(int);
 
-   case SETNONBLOCKINGIO:
-     xControl(xGetDown(s, 0), opcode, buf, len);
-     if (*(int*)buf) {
-	 ts->flags |= TCPST_NBIO;
-     } else {
-	 ts->flags &= ~TCPST_NBIO;
-     } /* if */
-     return 0;
+    case GETPARTICIPANTS: {
+        Part p[2];
+        int retLen;
+        long localPort, remotePort;
+        int numParts;
+        xkern_return_t xkr;
 
-   case TCP_SETRCVBUFSPACE:
-     checkLen(len, sizeof(u_short));
-     size = *(u_short *)buf;
-     ts->rcv_space = size;
-     /* after receiving message possibly send window update: */
-     tcp_output(tp);
-     return 0;
+        retLen = xControl(xGetDown(s, 0), opcode, buf, len);
+        if (retLen < 0) {
+            return retLen;
+        }
+        numParts = partExtLen(buf);
+        if (numParts > 0 && numParts <= 2) {
+            partInternalize(p, buf);
+            if (numParts == 2) {
+                localPort = tp->t_template->ti_sport;
+                partPush(p[1], &localPort, sizeof(long));
+            }
+            remotePort = tp->t_template->ti_dport;
+            partPush(p[0], &remotePort, sizeof(long));
+            xkr = partExternalize(p, buf, &len);
+            if (xkr == XK_FAILURE) {
+                xTrace0(tcpp, TR_SOFT_ERRORS, "TCP GETPARTS -- buffer too small");
+                retLen = -1;
+            } else {
+                retLen = len;
+            }
+        } else {
+            xTrace1(tcpp, TR_SOFT_ERRORS,
+                    "TCP -- Bad number of participants (%d) returned in GETPARTS", partExtLen(buf));
+            retLen = -1;
+        }
+        return retLen;
+    }
 
-   case TCP_GETSNDBUFSPACE:
-     checkLen(len, sizeof(u_short));
-     *(u_short*)buf = sbspace(ts->snd);
-     return sizeof(u_short);
+    case SETNONBLOCKINGIO:
+        xControl(xGetDown(s, 0), opcode, buf, len);
+        if (*(int *)buf) {
+            ts->flags |= TCPST_NBIO;
+        } else {
+            ts->flags &= ~TCPST_NBIO;
+        } /* if */
+        return 0;
 
-   case TCP_SETRCVBUFSIZE:
-     checkLen(len, sizeof(u_short));
-     size = *(u_short *)buf;
-     ts->rcv_hiwat = size;
-     return 0;
+    case TCP_SETRCVBUFSPACE:
+        checkLen(len, sizeof(u_short));
+        size = *(u_short *)buf;
+        ts->rcv_space = size;
+        /* after receiving message possibly send window update: */
+        tcp_output(tp);
+        return 0;
 
-   case TCP_SETSNDBUFSIZE:
-     checkLen(len, sizeof(u_short));
-     sbhiwat(ts->snd) = *(u_short *)buf;
-     return 0;
+    case TCP_GETSNDBUFSPACE:
+        checkLen(len, sizeof(u_short));
+        *(u_short *)buf = sbspace(ts->snd);
+        return sizeof(u_short);
 
-   case TCP_SETOOBINLINE:
-     checkLen(len, sizeof(int));
-     if (*(int*)buf) {
-	 ts->flags |= TCPST_OOBINLINE;
-     } else {
-	 ts->flags &= ~TCPST_OOBINLINE;
-     } /* if */
-     return 0;
+    case TCP_SETRCVBUFSIZE:
+        checkLen(len, sizeof(u_short));
+        size = *(u_short *)buf;
+        ts->rcv_hiwat = size;
+        return 0;
 
-   case TCP_GETOOBDATA:
-     {     
-	 char peek;
+    case TCP_SETSNDBUFSIZE:
+        checkLen(len, sizeof(u_short));
+        sbhiwat(ts->snd) = *(u_short *)buf;
+        return 0;
 
-	 checkLen(len, sizeof(char));
+    case TCP_SETOOBINLINE:
+        checkLen(len, sizeof(int));
+        if (*(int *)buf) {
+            ts->flags |= TCPST_OOBINLINE;
+        } else {
+            ts->flags &= ~TCPST_OOBINLINE;
+        } /* if */
+        return 0;
 
-	 peek = *(char*)buf;
-	 if ((tp->t_oobflags & TCPOOB_HADDATA) ||
-	     !(tp->t_oobflags & TCPOOB_HAVEDATA))
-	 {
-	     return 0;
-	 } /* if */
-	 *(char*)buf = tp->t_iobc;
-	 if (!peek) {
-	     tp->t_oobflags ^= TCPOOB_HAVEDATA | TCPOOB_HADDATA;
-	 } /* if */
-	 return 1;
-     }
+    case TCP_GETOOBDATA: {
+        char peek;
 
-   case TCP_OOBPUSH:
-     {
-	 Msg *m;
+        checkLen(len, sizeof(char));
 
-	 checkLen(len, sizeof(Msg*));
+        peek = *(char *)buf;
+        if ((tp->t_oobflags & TCPOOB_HADDATA) || !(tp->t_oobflags & TCPOOB_HAVEDATA)) {
+            return 0;
+        } /* if */
+        *(char *)buf = tp->t_iobc;
+        if (!peek) {
+            tp->t_oobflags ^= TCPOOB_HAVEDATA | TCPOOB_HADDATA;
+        } /* if */
+        return 1;
+    }
 
-	 m = (Msg*)buf;
-	 sbappend(ts->snd, m);
-	 tp->snd_up = tp->snd_una + sblength(ts->snd);
-	 tp->t_force = 1;
-	 tcp_output(tp);
-	 tp->t_force = 0;
-	 return 0;
-     }
+    case TCP_OOBPUSH: {
+        Msg *m;
 
-   default:
-     return xControl(xGetDown(s, 0), opcode, buf, len);
-  }
+        checkLen(len, sizeof(Msg *));
+
+        m = (Msg *)buf;
+        sbappend(ts->snd, m);
+        tp->snd_up = tp->snd_una + sblength(ts->snd);
+        tp->t_force = 1;
+        tcp_output(tp);
+        tp->t_force = 0;
+        return 0;
+    }
+
+    default:
+        return xControl(xGetDown(s, 0), opcode, buf, len);
+    }
 }
 
 /*************************************************************************/
-static int
-tcpControlProtl(self, opcode, buf, len)
-    XObj	    self;
-    int             opcode, len;
-    char           *buf;
+static int tcpControlProtl(self, opcode, buf, len)
+XObj self;
+int opcode, len;
+char *buf;
 {
     long port;
 
     switch (opcode) {
 
-      case TCP_DUMPSTATEINFO:
-	tcp_dumpstats();
-	return 0;
+    case TCP_DUMPSTATEINFO:
+        tcp_dumpstats();
+        return 0;
 
-      case TCP_GETFREEPROTNUM:
-	checkLen(len, sizeof(long));
-	port = *(long *)buf;
-	if (tcpGetFreePort(((PSTATE *)(self->state))->portstate, &port)) {
-	    return -1;
-	} /* if */
-	*(long *)buf = port;
-	return 0;
+    case TCP_GETFREEPROTNUM:
+        checkLen(len, sizeof(long));
+        port = *(long *)buf;
+        if (tcpGetFreePort(((PSTATE *)(self->state))->portstate, &port)) {
+            return -1;
+        } /* if */
+        *(long *)buf = port;
+        return 0;
 
-      case TCP_RELEASEPROTNUM:
-	checkLen(len, sizeof(long));
-	port = *(long *)buf;
-	tcpReleasePort(((PSTATE *)(self->state))->portstate, port);
-	return 0;
+    case TCP_RELEASEPROTNUM:
+        checkLen(len, sizeof(long));
+        port = *(long *)buf;
+        tcpReleasePort(((PSTATE *)(self->state))->portstate, port);
+        return 0;
 
-      default:
-	return xControl(xGetDown(self,0), opcode, buf, len);
+    default:
+        return xControl(xGetDown(self, 0), opcode, buf, len);
     }
 }
 
 /*************************************************************************/
-static void
-tcpSessnInit(s)
-    XObj s;
+static void tcpSessnInit(s) XObj s;
 {
     xAssert(xIsSession(s));
     s->push = tcpPush;
@@ -726,301 +673,269 @@ tcpSessnInit(s)
 }
 
 /*************************************************************************/
-void
-sorwakeup(so)
-XObj so;
+void sorwakeup(so) XObj so;
 {
-  xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp: sorwakeup on %X", so);
+    xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp: sorwakeup on %X", so);
 }
-    
+
 /*************************************************************************/
-void
-sowwakeup(so)
-XObj so;
+void sowwakeup(so) XObj so;
 {
-  xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp: sowwakeup on %X", so);
-  tcpSemSignal(&sototcpst(so)->waiting);
+    xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp: sowwakeup on %X", so);
+    tcpSemSignal(&sototcpst(so)->waiting);
 }
 
 /*************************************************************************/
 /*ARGSUSED*/
-int
-soreserve(so, send, recv)
+int soreserve(so, send, recv)
 XObj so;
 int send, recv;
 {
-  struct tcpstate *tcpst = sototcpst(so);
-  sbinit(tcpst->snd);
-  return 0;
+    struct tcpstate *tcpst = sototcpst(so);
+    sbinit(tcpst->snd);
+    return 0;
 }
 
 /*************************************************************************/
-void
-socantsendmore(so)
-    XObj so;
+void socantsendmore(so) XObj so;
 {
     xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp:  socantsendmore on %X", so);
 }
 
 /*************************************************************************/
-void
-soisdisconnected(so)
-    XObj so;
+void soisdisconnected(so) XObj so;
 {
     xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp:  soisdisconnected on %X", so);
     if (sototcpst(so)->closed) {
-	/* It was already closed, either by the network or the user */
+        /* It was already closed, either by the network or the user */
     } else {
-	/* deliver close done after we're done handling current message: */
-	xCloseDone(so);
+        /* deliver close done after we're done handling current message: */
+        xCloseDone(so);
     } /* if */
     tcpVAll(&sototcpst(so)->waiting);
 } /* soisdisconnected */
 
 /*************************************************************************/
-void
-soabort(so)
-XObj so;
+void soabort(so) XObj so;
 {
 }
 
 /*************************************************************************/
-void
-socantrcvmore(so)
-    XObj so;
+void socantrcvmore(so) XObj so;
 {
     xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp:  socantrcvmore on %X", so);
-    
+
     sototcpst(so)->closed |= 2;
     if (sototcpst(so)->closed & 1) {
-	/* do nothing, the user already knows that it is closed */
+        /* do nothing, the user already knows that it is closed */
     } else {
-	xCloseDone(so);
+        xCloseDone(so);
     }
 }
 
 /*************************************************************************/
-void
-soisconnected(so)
-    XObj so;
+void soisconnected(so) XObj so;
 {
-    struct tcpstate	*state = sototcpst(so);
-    TcpSem 		*s = &state->waiting;
+    struct tcpstate *state = sototcpst(so);
+    TcpSem *s = &state->waiting;
 
     xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp:  soisconnected on %X", so);
     if (s->waitCount) {
-	xTrace1(tcpp, TR_EVENTS, "tcp:  waking up opener on %X", so);
-	tcpSemSignal(s);
+        xTrace1(tcpp, TR_EVENTS, "tcp:  waking up opener on %X", so);
+        tcpSemSignal(s);
     } else {
-	/*
-	 * I think that this is the time for a open done
-	 */
-	xOpenDone(xGetUp(so), so, xMyProtl(so));
+        /*
+         * I think that this is the time for a open done
+         */
+        xOpenDone(xGetUp(so), so, xMyProtl(so));
     }
 }
 
 /*************************************************************************/
-void
-soisconnecting(so)
-    XObj so;
+void soisconnecting(so) XObj so;
 {
     xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp:  soisconnecting on %X", so);
 }
 
 /*************************************************************************/
-void
-soisdisconnecting(so)
-XObj so;
+void soisdisconnecting(so) XObj so;
 {
     xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp:  soisdisconnecting on %X", so);
 }
 
 /*************************************************************************/
-/* 
+/*
  * sonewconn is called by the input routine to establish a passive open
  */
-XObj
-sonewconn(self, so, hlpType, src, dst, sport, dport)
-    XObj self, so, hlpType;
-    IPhost *src, *dst;
-    int sport, dport;
+XObj sonewconn(self, so, hlpType, src, dst, sport, dport)
+XObj self, so, hlpType;
+IPhost *src, *dst;
+int sport, dport;
 {
-  XObj new;
-  xAssert(xIsProtocol(so));
-  xTrace1(tcpp, TR_MAJOR_EVENTS, "sonewconn on %X", so);
-  new = tcp_establishopen(self, so, hlpType, src, dst, sport, dport);
-  if ( new ) {
-      tcpDuplicatePort(((PSTATE *)self->state)->portstate, dport);
-  }
-  return new;
+    XObj new;
+    xAssert(xIsProtocol(so));
+    xTrace1(tcpp, TR_MAJOR_EVENTS, "sonewconn on %X", so);
+    new = tcp_establishopen(self, so, hlpType, src, dst, sport, dport);
+    if (new) {
+        tcpDuplicatePort(((PSTATE *)self->state)->portstate, dport);
+    }
+    return new;
 }
 
-
 /*************************************************************************/
-/* 
+/*
  * sohasoutofband is called by the input routine to signal the presence
  * of urgent (out-of-band) data
  */
-void
-sohasoutofband(so, oobmark)
-     XObj so;
-     u_int oobmark;
+void sohasoutofband(so, oobmark) XObj so;
+u_int oobmark;
 {
     void *buf[2];
 
     buf[0] = so;
-    buf[1] = (void*) oobmark;
-    xControl(xGetUp(so), TCP_OOBMODE, (char*) buf, sizeof(buf));
+    buf[1] = (void *)oobmark;
+    xControl(xGetUp(so), TCP_OOBMODE, (char *)buf, sizeof(buf));
 } /* sohasoutofband */
 
 /*************************************************************************/
 
-void
-tcpSemWait( ts )
-    TcpSem	*ts;
+void tcpSemWait(ts) TcpSem *ts;
 {
     ts->waitCount++;
     semWait(&ts->s);
     ts->waitCount--;
 }
 
-
-void
-tcpSemSignal( ts )
-    TcpSem	*ts;
+void tcpSemSignal(ts) TcpSem *ts;
 {
     semSignal(&ts->s);
 }
 
-
-void
-tcpVAll( ts )
-    TcpSem	*ts;
+void tcpVAll(ts) TcpSem *ts;
 {
     int i, n;
+    PROF_START(tcpVAll);
 
-    n=ts->waitCount;
-    for ( i=0; i < n; i++ ) {
-	semSignal(&ts->s);
+    n = ts->waitCount;
+    for (i = n / 8; i > 0; --i) {
+        UNROLL8(semSignal(&ts->s));
     }
+    for (i = 0; i < (n & 7); ++i) {
+        semSignal(&ts->s);
+    }
+    PROF_END(tcpVAll);
 }
 
-
-void
-tcpSemInit( ts, n )
-    TcpSem	*ts;
-    int		n;
+void tcpSemInit(ts, n) TcpSem *ts;
+int n;
 {
     semInit(&ts->s, n);
     ts->waitCount = 0;
 }
 
 /*************************************************************************/
-static void
-tcp_dumpstats()
-{
-  printf("tcps_badsum %d\n", tcpstat.tcps_badsum);
-  printf("tcps_badoff %d\n", tcpstat.tcps_badoff);
-  printf("tcps_hdrops %d\n", tcpstat.tcps_hdrops);
-  printf("tcps_badsegs %d\n", tcpstat.tcps_badsegs);
-  printf("tcps_unack %d\n", tcpstat.tcps_unack);
-  printf("connections initiated %d\n", tcpstat.tcps_connattempt);
-  printf("connections accepted %d\n", tcpstat.tcps_accepts);
-  printf("connections established %d\n", tcpstat.tcps_connects);
-  printf("connections dropped %d\n", tcpstat.tcps_drops);
-  printf("embryonic connections dropped %d\n", tcpstat.tcps_conndrops);
-  printf("conn. closed (includes drops) %d\n", tcpstat.tcps_closed);
-  printf("segs where we tried to get rtt %d\n", tcpstat.tcps_segstimed);
-  printf("times we succeeded %d\n", tcpstat.tcps_rttupdated);
-  printf("delayed acks sent %d\n", tcpstat.tcps_delack);
-  printf("conn. dropped in rxmt timeout %d\n", tcpstat.tcps_timeoutdrop);
-  printf("retransmit timeouts %d\n", tcpstat.tcps_rexmttimeo);
-  printf("persist timeouts %d\n", tcpstat.tcps_persisttimeo);
-  printf("keepalive timeouts %d\n", tcpstat.tcps_keeptimeo);
-  printf("keepalive probes sent %d\n", tcpstat.tcps_keepprobe);
-  printf("connections dropped in keepalive %d\n", tcpstat.tcps_keepdrops);
-  printf("total packets sent %d\n", tcpstat.tcps_sndtotal);
-  printf("data packets sent %d\n", tcpstat.tcps_sndpack);
-  printf("data bytes sent %d\n", tcpstat.tcps_sndbyte);
-  printf("data packets retransmitted %d\n", tcpstat.tcps_sndrexmitpack);
-  printf("data bytes retransmitted %d\n", tcpstat.tcps_sndrexmitbyte);
-  printf("ack-only packets sent %d\n", tcpstat.tcps_sndacks);
-  printf("window probes sent %d\n", tcpstat.tcps_sndprobe);
-  printf("packets sent with URG only %d\n", tcpstat.tcps_sndurg);
-  printf("window update-only packets sent %d\n", tcpstat.tcps_sndwinup);
-  printf("control (SYN|FIN|RST) packets sent %d\n", tcpstat.tcps_sndctrl);
-  printf("total packets received %d\n", tcpstat.tcps_rcvtotal);
-  printf("packets received in sequence %d\n", tcpstat.tcps_rcvpack);
-  printf("bytes received in sequence %d\n", tcpstat.tcps_rcvbyte);
-  printf("packets received with ccksum errs %d\n", tcpstat.tcps_rcvbadsum);
-  printf("packets received with bad offset %d\n", tcpstat.tcps_rcvbadoff);
-  printf("packets received too short %d\n", tcpstat.tcps_rcvshort);
-  printf("duplicate-only packets received %d\n", tcpstat.tcps_rcvduppack);
-  printf("duplicate-only bytes received %d\n", tcpstat.tcps_rcvdupbyte);
-  printf("packets with some duplicate data %d\n", tcpstat.tcps_rcvpartduppack);
-  printf("dup. bytes in part-dup. packets %d\n", tcpstat.tcps_rcvpartdupbyte);
-  printf("out-of-order packets received %d\n", tcpstat.tcps_rcvoopack);
-  printf("out-of-order bytes received %d\n", tcpstat.tcps_rcvoobyte);
-  printf("packets with data after window %d\n", tcpstat.tcps_rcvpackafterwin);
-  printf("bytes rcvd after window %d\n", tcpstat.tcps_rcvbyteafterwin);
-  printf("packets rcvd after \"close\" %d\n", tcpstat.tcps_rcvafterclose);
-  printf("rcvd window probe packets %d\n", tcpstat.tcps_rcvwinprobe);
-  printf("rcvd duplicate acks %d\n", tcpstat.tcps_rcvdupack);
-  printf("rcvd acks for unsent data %d\n", tcpstat.tcps_rcvacktoomuch);
-  printf("rcvd ack packets %d\n", tcpstat.tcps_rcvackpack);
-  printf("bytes acked by rcvd acks %d\n", tcpstat.tcps_rcvackbyte);
-  printf("rcvd window update packets %d\n", tcpstat.tcps_rcvwinupd);
+static void tcp_dumpstats() {
+    printf("tcps_badsum %d\n", tcpstat.tcps_badsum);
+    printf("tcps_badoff %d\n", tcpstat.tcps_badoff);
+    printf("tcps_hdrops %d\n", tcpstat.tcps_hdrops);
+    printf("tcps_badsegs %d\n", tcpstat.tcps_badsegs);
+    printf("tcps_unack %d\n", tcpstat.tcps_unack);
+    printf("connections initiated %d\n", tcpstat.tcps_connattempt);
+    printf("connections accepted %d\n", tcpstat.tcps_accepts);
+    printf("connections established %d\n", tcpstat.tcps_connects);
+    printf("connections dropped %d\n", tcpstat.tcps_drops);
+    printf("embryonic connections dropped %d\n", tcpstat.tcps_conndrops);
+    printf("conn. closed (includes drops) %d\n", tcpstat.tcps_closed);
+    printf("segs where we tried to get rtt %d\n", tcpstat.tcps_segstimed);
+    printf("times we succeeded %d\n", tcpstat.tcps_rttupdated);
+    printf("delayed acks sent %d\n", tcpstat.tcps_delack);
+    printf("conn. dropped in rxmt timeout %d\n", tcpstat.tcps_timeoutdrop);
+    printf("retransmit timeouts %d\n", tcpstat.tcps_rexmttimeo);
+    printf("persist timeouts %d\n", tcpstat.tcps_persisttimeo);
+    printf("keepalive timeouts %d\n", tcpstat.tcps_keeptimeo);
+    printf("keepalive probes sent %d\n", tcpstat.tcps_keepprobe);
+    printf("connections dropped in keepalive %d\n", tcpstat.tcps_keepdrops);
+    printf("total packets sent %d\n", tcpstat.tcps_sndtotal);
+    printf("data packets sent %d\n", tcpstat.tcps_sndpack);
+    printf("data bytes sent %d\n", tcpstat.tcps_sndbyte);
+    printf("data packets retransmitted %d\n", tcpstat.tcps_sndrexmitpack);
+    printf("data bytes retransmitted %d\n", tcpstat.tcps_sndrexmitbyte);
+    printf("ack-only packets sent %d\n", tcpstat.tcps_sndacks);
+    printf("window probes sent %d\n", tcpstat.tcps_sndprobe);
+    printf("packets sent with URG only %d\n", tcpstat.tcps_sndurg);
+    printf("window update-only packets sent %d\n", tcpstat.tcps_sndwinup);
+    printf("control (SYN|FIN|RST) packets sent %d\n", tcpstat.tcps_sndctrl);
+    printf("total packets received %d\n", tcpstat.tcps_rcvtotal);
+    printf("packets received in sequence %d\n", tcpstat.tcps_rcvpack);
+    printf("bytes received in sequence %d\n", tcpstat.tcps_rcvbyte);
+    printf("packets received with ccksum errs %d\n", tcpstat.tcps_rcvbadsum);
+    printf("packets received with bad offset %d\n", tcpstat.tcps_rcvbadoff);
+    printf("packets received too short %d\n", tcpstat.tcps_rcvshort);
+    printf("duplicate-only packets received %d\n", tcpstat.tcps_rcvduppack);
+    printf("duplicate-only bytes received %d\n", tcpstat.tcps_rcvdupbyte);
+    printf("packets with some duplicate data %d\n", tcpstat.tcps_rcvpartduppack);
+    printf("dup. bytes in part-dup. packets %d\n", tcpstat.tcps_rcvpartdupbyte);
+    printf("out-of-order packets received %d\n", tcpstat.tcps_rcvoopack);
+    printf("out-of-order bytes received %d\n", tcpstat.tcps_rcvoobyte);
+    printf("packets with data after window %d\n", tcpstat.tcps_rcvpackafterwin);
+    printf("bytes rcvd after window %d\n", tcpstat.tcps_rcvbyteafterwin);
+    printf("packets rcvd after \"close\" %d\n", tcpstat.tcps_rcvafterclose);
+    printf("rcvd window probe packets %d\n", tcpstat.tcps_rcvwinprobe);
+    printf("rcvd duplicate acks %d\n", tcpstat.tcps_rcvdupack);
+    printf("rcvd acks for unsent data %d\n", tcpstat.tcps_rcvacktoomuch);
+    printf("rcvd ack packets %d\n", tcpstat.tcps_rcvackpack);
+    printf("bytes acked by rcvd acks %d\n", tcpstat.tcps_rcvackbyte);
+    printf("rcvd window update packets %d\n", tcpstat.tcps_rcvwinupd);
 
-
-  tcpstat.tcps_badsum = 0;
-  tcpstat.tcps_badoff = 0;
-  tcpstat.tcps_hdrops = 0;
-  tcpstat.tcps_badsegs = 0;
-  tcpstat.tcps_unack = 0;
-  tcpstat.tcps_connattempt = 0;
-  tcpstat.tcps_accepts = 0;
-  tcpstat.tcps_connects = 0;
-  tcpstat.tcps_drops = 0;
-  tcpstat.tcps_conndrops = 0;
-  tcpstat.tcps_closed = 0;
-  tcpstat.tcps_segstimed = 0;
-  tcpstat.tcps_rttupdated = 0;
-  tcpstat.tcps_delack = 0;
-  tcpstat.tcps_timeoutdrop = 0;
-  tcpstat.tcps_rexmttimeo = 0;
-  tcpstat.tcps_persisttimeo = 0;
-  tcpstat.tcps_keeptimeo = 0;
-  tcpstat.tcps_keepprobe = 0;
-  tcpstat.tcps_keepdrops = 0;
-  tcpstat.tcps_sndtotal = 0;
-  tcpstat.tcps_sndpack = 0;
-  tcpstat.tcps_sndbyte = 0;
-  tcpstat.tcps_sndrexmitpack = 0;
-  tcpstat.tcps_sndrexmitbyte = 0;
-  tcpstat.tcps_sndacks = 0;
-  tcpstat.tcps_sndprobe = 0;
-  tcpstat.tcps_sndurg = 0;
-  tcpstat.tcps_sndwinup = 0;
-  tcpstat.tcps_sndctrl = 0;
-  tcpstat.tcps_rcvtotal = 0;
-  tcpstat.tcps_rcvpack = 0;
-  tcpstat.tcps_rcvbyte = 0;
-  tcpstat.tcps_rcvbadsum = 0;
-  tcpstat.tcps_rcvbadoff = 0;
-  tcpstat.tcps_rcvshort = 0;
-  tcpstat.tcps_rcvduppack = 0;
-  tcpstat.tcps_rcvdupbyte = 0;
-  tcpstat.tcps_rcvpartduppack = 0;
-  tcpstat.tcps_rcvpartdupbyte = 0;
-  tcpstat.tcps_rcvoopack = 0;
-  tcpstat.tcps_rcvoobyte = 0;
-  tcpstat.tcps_rcvpackafterwin = 0;
-  tcpstat.tcps_rcvbyteafterwin = 0;
-  tcpstat.tcps_rcvafterclose = 0;
-  tcpstat.tcps_rcvwinprobe = 0;
-  tcpstat.tcps_rcvdupack = 0;
-  tcpstat.tcps_rcvacktoomuch = 0;
-  tcpstat.tcps_rcvackpack = 0;
-  tcpstat.tcps_rcvackbyte = 0;
-  tcpstat.tcps_rcvwinupd = 0;
+    tcpstat.tcps_badsum = 0;
+    tcpstat.tcps_badoff = 0;
+    tcpstat.tcps_hdrops = 0;
+    tcpstat.tcps_badsegs = 0;
+    tcpstat.tcps_unack = 0;
+    tcpstat.tcps_connattempt = 0;
+    tcpstat.tcps_accepts = 0;
+    tcpstat.tcps_connects = 0;
+    tcpstat.tcps_drops = 0;
+    tcpstat.tcps_conndrops = 0;
+    tcpstat.tcps_closed = 0;
+    tcpstat.tcps_segstimed = 0;
+    tcpstat.tcps_rttupdated = 0;
+    tcpstat.tcps_delack = 0;
+    tcpstat.tcps_timeoutdrop = 0;
+    tcpstat.tcps_rexmttimeo = 0;
+    tcpstat.tcps_persisttimeo = 0;
+    tcpstat.tcps_keeptimeo = 0;
+    tcpstat.tcps_keepprobe = 0;
+    tcpstat.tcps_keepdrops = 0;
+    tcpstat.tcps_sndtotal = 0;
+    tcpstat.tcps_sndpack = 0;
+    tcpstat.tcps_sndbyte = 0;
+    tcpstat.tcps_sndrexmitpack = 0;
+    tcpstat.tcps_sndrexmitbyte = 0;
+    tcpstat.tcps_sndacks = 0;
+    tcpstat.tcps_sndprobe = 0;
+    tcpstat.tcps_sndurg = 0;
+    tcpstat.tcps_sndwinup = 0;
+    tcpstat.tcps_sndctrl = 0;
+    tcpstat.tcps_rcvtotal = 0;
+    tcpstat.tcps_rcvpack = 0;
+    tcpstat.tcps_rcvbyte = 0;
+    tcpstat.tcps_rcvbadsum = 0;
+    tcpstat.tcps_rcvbadoff = 0;
+    tcpstat.tcps_rcvshort = 0;
+    tcpstat.tcps_rcvduppack = 0;
+    tcpstat.tcps_rcvdupbyte = 0;
+    tcpstat.tcps_rcvpartduppack = 0;
+    tcpstat.tcps_rcvpartdupbyte = 0;
+    tcpstat.tcps_rcvoopack = 0;
+    tcpstat.tcps_rcvoobyte = 0;
+    tcpstat.tcps_rcvpackafterwin = 0;
+    tcpstat.tcps_rcvbyteafterwin = 0;
+    tcpstat.tcps_rcvafterclose = 0;
+    tcpstat.tcps_rcvwinprobe = 0;
+    tcpstat.tcps_rcvdupack = 0;
+    tcpstat.tcps_rcvacktoomuch = 0;
+    tcpstat.tcps_rcvackpack = 0;
+    tcpstat.tcps_rcvackbyte = 0;
+    tcpstat.tcps_rcvwinupd = 0;
 }

--- a/protocols/tcp/tcp_x.c
+++ b/protocols/tcp/tcp_x.c
@@ -20,376 +20,349 @@
  * $Date: 1993/08/04 00:44:45 $
  */
 
-#include "xkernel.h"
 #include "ip.h"
-#include "tcp_internal.h"
 #include "tcp_fsm.h"
+#include "tcp_internal.h"
 #include "tcp_seq.h"
 #include "tcp_timer.h"
 #include "tcp_var.h"
 #include "tcpip.h"
-
+#include "xkernel.h"
+#include <simd.h>
 
 char *prurequests[] = {
-	"ATTACH",	"DETACH",	"BIND",		"LISTEN",
-	"CONNECT",	"ACCEPT",	"DISCONNECT",	"SHUTDOWN",
-	"RCVD",		"SEND",		"ABORT",	"CONTROL",
-	"SENSE",	"RCVOOB",	"SENDOOB",	"SOCKADDR",
-	"PEERADDR",	"CONNECT2",	"FASTTIMO",	"SLOWTIMO",
-	"PROTORCV",	"PROTOSEND",
+    "ATTACH",     "DETACH",   "BIND",     "LISTEN",    "CONNECT",  "ACCEPT",
+    "DISCONNECT", "SHUTDOWN", "RCVD",     "SEND",      "ABORT",    "CONTROL",
+    "SENSE",      "RCVOOB",   "SENDOOB",  "SOCKADDR",  "PEERADDR", "CONNECT2",
+    "FASTTIMO",   "SLOWTIMO", "PROTORCV", "PROTOSEND",
 };
 
-XObj            TCP;
-#define         IP (xGetDown(TCP,0))
+XObj TCP;
+#define IP (xGetDown(TCP, 0))
 
-
-static IPhost   myHost;
+static IPhost myHost;
 
 #ifdef __STDC__
 
-static int	extractPart( Part *, long *, IPhost **, char * );
-static void	tcpSessnInit( XObj );
-static XObj	tcp_establishopen( XObj, XObj, XObj, IPhost *, IPhost *,
-				   int, int );
-static void	tcp_dumpstats( void );
-static int		tcpControlProtl( XObj, int, char *, int );
-static XObj		tcpOpen( XObj, XObj, XObj, Part * );
-static xkern_return_t	tcpOpenEnable( XObj, XObj, XObj, Part * );
-static xkern_return_t	tcpOpenDisable( XObj, XObj, XObj, Part * );
-
+static int extractPart(Part *, long *, IPhost **, char *);
+static void tcpSessnInit(XObj);
+static XObj tcp_establishopen(XObj, XObj, XObj, IPhost *, IPhost *, int, int);
+static void tcp_dumpstats(void);
+static int tcpControlProtl(XObj, int, char *, int);
+static XObj tcpOpen(XObj, XObj, XObj, Part *);
+static xkern_return_t tcpOpenEnable(XObj, XObj, XObj, Part *);
+static xkern_return_t tcpOpenDisable(XObj, XObj, XObj, Part *);
 
 #else
 
-static int	extractPart();
-static void	tcpSessnInit();
-static XObj	tcp_establishopen();
-static void	tcp_dumpstats();
-static int		tcpControlProtl();
-static XObj		tcpOpen();
-static xkern_return_t	tcpOpenEnable();
-static xkern_return_t	tcpOpenDisable();
+static int extractPart();
+static void tcpSessnInit();
+static XObj tcp_establishopen();
+static void tcp_dumpstats();
+static int tcpControlProtl();
+static XObj tcpOpen();
+static xkern_return_t tcpOpenEnable();
+static xkern_return_t tcpOpenDisable();
 
 #endif __STDC__
 
-
-
-/* 
+/*
  * Check for a valid participant list
  */
-#define partCheck(p, name, max, retval)					\
-	{								\
-	  if ( ! (p) || partLen(p) < 1 || partLen(p) > (max)) { 	\
-		xTrace1(tcpp, TR_ERRORS,				\
-			"%s -- bad participants",			\
-			(name));  					\
-		return (retval);					\
-	  }								\
-	}
-
+#define partCheck(p, name, max, retval)                                                            \
+    {                                                                                              \
+        if (!(p) || partLen(p) < 1 || partLen(p) > (max)) {                                        \
+            xTrace1(tcpp, TR_ERRORS, "%s -- bad participants", (name));                            \
+            return (retval);                                                                       \
+        }                                                                                          \
+    }
 
 /*************************************************************************/
 
-void
-tcp_init(self)
-    XObj            self;
+void tcp_init(self) XObj self;
 {
-  Part		p;
-  PSTATE	*pstate;
+    Part p;
+    PSTATE *pstate;
 
-  TCP = self;
-  xTrace0(tcpp, TR_GROSS_EVENTS, "TCP init");
-  xTrace1(tcpp, TR_GROSS_EVENTS, "ENDIAN = %d", ENDIAN);
+    TCP = self;
+    xTrace0(tcpp, TR_GROSS_EVENTS, "TCP init");
+    xTrace1(tcpp, TR_GROSS_EVENTS, "ENDIAN = %d", ENDIAN);
 
-  xAssert(xIsProtocol(self));
+    xAssert(xIsProtocol(self));
 
-  pstate = (PSTATE *)xMalloc(sizeof(PSTATE));
-  memset((char *)pstate, 0, sizeof(PSTATE));
-  self->state = (char *)pstate;
+    pstate = (PSTATE *)xMalloc(sizeof(PSTATE));
+    memset((char *)pstate, 0, sizeof(PSTATE));
+    self->state = (char *)pstate;
 
-  self->control = tcpControlProtl;
-  self->open = tcpOpen;
-  self->openenable = tcpOpenEnable;
-  self->opendisable = tcpOpenDisable;
-  self->demux = tcp_input;
+    self->control = tcpControlProtl;
+    self->open = tcpOpen;
+    self->openenable = tcpOpenEnable;
+    self->opendisable = tcpOpenDisable;
+    self->demux = tcp_input;
 
-  pstate->passiveMap = mapCreate(37, sizeof(PassiveId));
-  pstate->activeMap = mapCreate(101, sizeof(ActiveId));
+    pstate->passiveMap = mapCreate(37, sizeof(PassiveId));
+    pstate->activeMap = mapCreate(101, sizeof(ActiveId));
 
-  tcb.inp_next = tcb.inp_prev = &tcb;
-  tcp_iss = 1;
-  /* Turn on IP pseudoheader length-fixup kludge in lower protocols. */
-  xControl(IP,IP_PSEUDOHDR,(char *)0,0); /* IP is abbrev for lower protocol. */
-  partInit(&p, 1);
-  partPush(p, ANY_HOST, 0);
-  xOpenEnable(TCP, TCP, IP, &p);
-  xControl(IP, GETMYHOST, (char *)&myHost, sizeof(myHost));
-  evDetach(evSchedule(tcp_fasttimo, 0, TCP_FAST_INTERVAL));
-  evDetach(evSchedule(tcp_slowtimo, 0, TCP_SLOW_INTERVAL));
-  tcpPortMapInit( &pstate->portstate );
+    tcb.inp_next = tcb.inp_prev = &tcb;
+    tcp_iss = 1;
+    /* Turn on IP pseudoheader length-fixup kludge in lower protocols. */
+    xControl(IP, IP_PSEUDOHDR, (char *)0, 0); /* IP is abbrev for lower protocol. */
+    partInit(&p, 1);
+    partPush(p, ANY_HOST, 0);
+    xOpenEnable(TCP, TCP, IP, &p);
+    xControl(IP, GETMYHOST, (char *)&myHost, sizeof(myHost));
+    evDetach(evSchedule(tcp_fasttimo, 0, TCP_FAST_INTERVAL));
+    evDetach(evSchedule(tcp_slowtimo, 0, TCP_SLOW_INTERVAL));
+    tcpPortMapInit(&pstate->portstate);
 }
 
 /*************************************************************************/
-struct tcpstate *new_tcpstate()
-{
-  struct tcpstate *tcpstate;
-  tcpstate = (struct tcpstate *) xMalloc(sizeof(struct tcpstate));
-  memset((char *)tcpstate, 0, sizeof(struct tcpstate));
-  tcpSemInit(&tcpstate->waiting, 0);
-  tcpSemInit(&tcpstate->lock, 1);
-  tcpstate->closed = 0;
-  tcpstate->snd = (struct sb *)xMalloc(sizeof(struct sb));
-  /* initialize buffer size to TCPRCVWIN to get things started: */
-  tcpstate->rcv_space = TCPRCVWIN;
-  tcpstate->rcv_hiwat = TCPRCVWIN;
-  return tcpstate;
+struct tcpstate *new_tcpstate() {
+    struct tcpstate *tcpstate;
+    tcpstate = (struct tcpstate *)xMalloc(sizeof(struct tcpstate));
+    memset((char *)tcpstate, 0, sizeof(struct tcpstate));
+    tcpSemInit(&tcpstate->waiting, 0);
+    tcpSemInit(&tcpstate->lock, 1);
+    tcpstate->closed = 0;
+    tcpstate->snd = (struct sb *)xMalloc(sizeof(struct sb));
+    /* initialize buffer size to TCPRCVWIN to get things started: */
+    tcpstate->rcv_space = TCPRCVWIN;
+    tcpstate->rcv_hiwat = TCPRCVWIN;
+    return tcpstate;
 }
 
 /*************************************************************************/
-void delete_tcpstate(tcpstate)
-struct tcpstate *tcpstate;
+void delete_tcpstate(tcpstate) struct tcpstate *tcpstate;
 {
-  tcpVAll(&tcpstate->waiting);
-  xFree((char *)tcpstate);
+    tcpVAll(&tcpstate->waiting);
+    xFree((char *)tcpstate);
 
-  /* From RICE 07/03/90 */
-  tcpVAll(&tcpstate->lock);
-  xFree((char *)tcpstate->snd);
-  xFree((char *)tcpstate);
+    /* From RICE 07/03/90 */
+    tcpVAll(&tcpstate->lock);
+    xFree((char *)tcpstate->snd);
+    xFree((char *)tcpstate);
 }
 
 /*************************************************************************/
-static XObj
-tcp_establishopen(self, hlpRcv, hlpType, raddr, laddr, rport, lport)
-    XObj self, hlpRcv, hlpType;
-    IPhost *raddr, *laddr;
-    int rport, lport;
+static XObj tcp_establishopen(self, hlpRcv, hlpType, raddr, laddr, rport, lport)
+XObj self, hlpRcv, hlpType;
+IPhost *raddr, *laddr;
+int rport, lport;
 {
-  Part          p[2];
-  XObj		new;
-  struct tcpstate *tcpst;
-  struct inpcb *inp;
-  ActiveId      ex_id;
-  XObj		lls;
-  PSTATE	*pstate;
+    Part p[2];
+    XObj new;
+    struct tcpstate *tcpst;
+    struct inpcb *inp;
+    ActiveId ex_id;
+    XObj lls;
+    PSTATE *pstate;
 
-  xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp_establish: on %X", hlpRcv);
-  xAssert(xIsProtocol(hlpRcv));
+    xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp_establish: on %X", hlpRcv);
+    xAssert(xIsProtocol(hlpRcv));
 
-  pstate = (PSTATE *)self->state;
-  ex_id.localport = lport;
-  ex_id.remoteport = rport;
-  ex_id.remoteaddr = *raddr;
-  if ( mapResolve(pstate->activeMap, &ex_id, &new) == XK_SUCCESS ) {
-    xTrace3(tcpp, TR_GROSS_EVENTS, "tcp_establish: (%d->%X.%d) already open",
-	    ex_id.localport, ex_id.remoteaddr, ex_id.remoteport);
-    return 0;
-  }
+    pstate = (PSTATE *)self->state;
+    ex_id.localport = lport;
+    ex_id.remoteport = rport;
+    ex_id.remoteaddr = *raddr;
+    if (mapResolve(pstate->activeMap, &ex_id, &new) == XK_SUCCESS) {
+        xTrace3(tcpp, TR_GROSS_EVENTS, "tcp_establish: (%d->%X.%d) already open", ex_id.localport,
+                ex_id.remoteaddr, ex_id.remoteport);
+        return 0;
+    }
 
-  partInit(p, laddr ? 2 : 1);
-  partPush(p[0], raddr, sizeof(IPhost));
-  if ( laddr ) {
-      partPush(p[1], laddr, sizeof(IPhost));
-  }
-  xTrace0(tcpp, TR_EVENTS, "tcpOpen: opening IP");
-  if ( (lls = xOpen(TCP, TCP, IP, p)) == ERR_SESSN ) {
-    xTrace0(tcpp, TR_ERRORS, "tcpOpen: cannot open IP session");
-    return 0;
-  }
+    partInit(p, laddr ? 2 : 1);
+    partPush(p[0], raddr, sizeof(IPhost));
+    if (laddr) {
+        partPush(p[1], laddr, sizeof(IPhost));
+    }
+    xTrace0(tcpp, TR_EVENTS, "tcpOpen: opening IP");
+    if ((lls = xOpen(TCP, TCP, IP, p)) == ERR_SESSN) {
+        xTrace0(tcpp, TR_ERRORS, "tcpOpen: cannot open IP session");
+        return 0;
+    }
 
-  new = xCreateSessn(tcpSessnInit, hlpRcv, hlpType, TCP, 1, &lls);
-  xTrace3(tcpp, TR_GROSS_EVENTS, "Mapping %d->%X.%d", lport, raddr, rport);
-  new->binding = mapBind(pstate->activeMap, (char *) &ex_id, (int) new);
-  if ((int)new->binding == -1) {
-    xTrace3(tcpp, TR_GROSS_EVENTS, "tcp_establish: Bind of %d->%X.%d failed", 
-      lport, raddr, rport);
-    return 0;
-  }
+    new = xCreateSessn(tcpSessnInit, hlpRcv, hlpType, TCP, 1, &lls);
+    xTrace3(tcpp, TR_GROSS_EVENTS, "Mapping %d->%X.%d", lport, raddr, rport);
+    new->binding = mapBind(pstate->activeMap, (char *)&ex_id, (int)new);
+    if ((int)new->binding == -1) {
+        xTrace3(tcpp, TR_GROSS_EVENTS, "tcp_establish: Bind of %d->%X.%d failed", lport, raddr,
+                rport);
+        return 0;
+    }
 
-  tcpst = new_tcpstate();
-  tcpst->hlpType = hlpType;
-  new->state = (char *)tcpst;
-  xTrace0(tcpp, TR_EVENTS, "tcpOpen: attaching...");
-  tcp_attach(new);
+    tcpst = new_tcpstate();
+    tcpst->hlpType = hlpType;
+    new->state = (char *)tcpst;
+    xTrace0(tcpp, TR_EVENTS, "tcpOpen: attaching...");
+    tcp_attach(new);
 
-  inp = sotoinpcb(new);
-  tcpst->inpcb = inp;
-  tcpst->tcpcb = (struct tcpcb *)inp->inp_ppcb;
-  *(IPhost *)&inp->inp_laddr = myHost;
-  inp->inp_lport = ex_id.localport;
-  *(IPhost *)&inp->inp_raddr = ex_id.remoteaddr;
-  inp->inp_rport = ex_id.remoteport;
+    inp = sotoinpcb(new);
+    tcpst->inpcb = inp;
+    tcpst->tcpcb = (struct tcpcb *)inp->inp_ppcb;
+    *(IPhost *)&inp->inp_laddr = myHost;
+    inp->inp_lport = ex_id.localport;
+    *(IPhost *)&inp->inp_raddr = ex_id.remoteaddr;
+    inp->inp_rport = ex_id.remoteport;
 
-  /*  xControl(xGetDown(new,0),IP_PSEUDOHDR,(char *)0,0);  moved to tcp_init --rcs */
-  return new;
+    /*  xControl(xGetDown(new,0),IP_PSEUDOHDR,(char *)0,0);  moved to tcp_init --rcs */
+    return new;
 }
 
-
-static int
-extractPart( p, port, host, s )
-    Part	*p;
-    long	*port;
-    IPhost	**host;
-    char	*s;
+static int extractPart(p, port, host, s)
+Part *p;
+long *port;
+IPhost **host;
+char *s;
 {
-    long	*portPtr;
-    IPhost	*hostPtr;
+    long *portPtr;
+    IPhost *hostPtr;
 
     xAssert(port);
-    if ( (portPtr = (long *)partPop(*p)) == 0 ) {
-	xTrace1(tcpp, TR_SOFT_ERROR, "Bad participant in %s -- no port", s);
-	return -1;
+    if ((portPtr = (long *)partPop(*p)) == 0) {
+        xTrace1(tcpp, TR_SOFT_ERROR, "Bad participant in %s -- no port", s);
+        return -1;
     }
     *port = *portPtr;
-    if ( *port > MAX_PORT ) {
-	xTrace2(tcpp, TR_SOFT_ERROR,
-		"Bad participant in %s -- port %d out of range", s, *port);
-	return -1;
+    if (*port > MAX_PORT) {
+        xTrace2(tcpp, TR_SOFT_ERROR, "Bad participant in %s -- port %d out of range", s, *port);
+        return -1;
     }
-    if ( host ) {
-	if ( (hostPtr = (IPhost *)partPop(*p)) == 0 ) {
-	    xTrace1(tcpp, TR_SOFT_ERROR,
-		    "Bad participant in %s -- no host", s);
-	    return -1;
-	}
-	*host = hostPtr;
+    if (host) {
+        if ((hostPtr = (IPhost *)partPop(*p)) == 0) {
+            xTrace1(tcpp, TR_SOFT_ERROR, "Bad participant in %s -- no host", s);
+            return -1;
+        }
+        *host = hostPtr;
     }
     return 0;
 }
 
-
 /*************************************************************************/
-static XObj
-tcpOpen(self, hlpRcv, hlpType, p)
-    XObj            self, hlpRcv, hlpType;
-    Part           *p;
+static XObj tcpOpen(self, hlpRcv, hlpType, p)
+XObj self, hlpRcv, hlpType;
+Part *p;
 {
-    XObj	s;
-    long	remotePort, localPort = ANY_PORT;
-    IPhost	*remoteHost, *localHost = 0;
-    
+    XObj s;
+    long remotePort, localPort = ANY_PORT;
+    IPhost *remoteHost, *localHost = 0;
+
     xTrace0(tcpp, TR_GROSS_EVENTS, "TCP open");
     partCheck(p, "tcpOpen", 2, ERR_XOBJ);
-    if ( extractPart(p, &remotePort, &remoteHost, "tcpOpen (remote)") ) {
-	return ERR_XOBJ;
+    if (extractPart(p, &remotePort, &remoteHost, "tcpOpen (remote)")) {
+        return ERR_XOBJ;
     }
-    if ( partLen(p) > 1 ) {
-	if ( extractPart(p+1, &localPort, &localHost, "tcpOpen (local)") ) {
-	    return ERR_XOBJ;
-	}
-	if ( localHost == (IPhost *)ANY_HOST ) {
-	    localHost = 0;
-	}
+    if (partLen(p) > 1) {
+        if (extractPart(p + 1, &localPort, &localHost, "tcpOpen (local)")) {
+            return ERR_XOBJ;
+        }
+        if (localHost == (IPhost *)ANY_HOST) {
+            localHost = 0;
+        }
     }
-    if ( localPort == ANY_PORT ) {
-	/* 
-	 * We need to find a free local port
-	 */
-	long	freePort;
-	if ( tcpGetFreePort(((PSTATE *)(self->state))->portstate, &freePort) ) {
-	    xError("tcpOpen -- no free ports!");
-	    return ERR_XOBJ;
-	}
-	localPort = freePort;
+    if (localPort == ANY_PORT) {
+        /*
+         * We need to find a free local port
+         */
+        long freePort;
+        if (tcpGetFreePort(((PSTATE *)(self->state))->portstate, &freePort)) {
+            xError("tcpOpen -- no free ports!");
+            return ERR_XOBJ;
+        }
+        localPort = freePort;
     } else {
-	/* 
-	 * A specific local port was requested
-	 */
-	if ( tcpDuplicatePort(((PSTATE *)(self->state))->portstate, localPort))
-	  {
-	    xTrace1(tcpp, TR_MAJOR_EVENTS,
-		    "tcpOpen: requested port %d is already in use",
-		    localPort);
-	    return ERR_XOBJ;
-	  }
-      }
-    s = tcp_establishopen(self, hlpRcv, hlpType, remoteHost, localHost,
-			  remotePort, localPort);
+        /*
+         * A specific local port was requested
+         */
+        if (tcpDuplicatePort(((PSTATE *)(self->state))->portstate, localPort)) {
+            xTrace1(tcpp, TR_MAJOR_EVENTS, "tcpOpen: requested port %d is already in use",
+                    localPort);
+            return ERR_XOBJ;
+        }
+    }
+    s = tcp_establishopen(self, hlpRcv, hlpType, remoteHost, localHost, remotePort, localPort);
     if (!s) {
-	tcpReleasePort(((PSTATE *)(self->state))->portstate, localPort);
-	s = ERR_SESSN;
+        tcpReleasePort(((PSTATE *)(self->state))->portstate, localPort);
+        s = ERR_SESSN;
     } else {
-	xTrace0(tcpp, TR_EVENTS, "tcpOpen: connecting...");
-	tcp_usrreq(s, PRU_CONNECT, 0, 0);
-	
-	xTrace0(tcpp, TR_EVENTS, "tcpOpen: waiting...");
-	tcpSemWait(&(sototcpst(s)->waiting));
-	if (sototcpcb(s)->t_state != TCPS_ESTABLISHED) {
-	    xTrace3(tcpp, TR_EVENTS, "tcpOpen: open (%d->%X.%d) connect failed",
-		    localPort,  ipHostStr(remoteHost), remotePort);
-	    tcp_destroy(sototcpcb(s));
-	    tcpReleasePort(((PSTATE *)(self->state))->portstate, localPort);
-	    s = ERR_SESSN;
-	}
+        xTrace0(tcpp, TR_EVENTS, "tcpOpen: connecting...");
+        tcp_usrreq(s, PRU_CONNECT, 0, 0);
+
+        xTrace0(tcpp, TR_EVENTS, "tcpOpen: waiting...");
+        tcpSemWait(&(sototcpst(s)->waiting));
+        if (sototcpcb(s)->t_state != TCPS_ESTABLISHED) {
+            xTrace3(tcpp, TR_EVENTS, "tcpOpen: open (%d->%X.%d) connect failed", localPort,
+                    ipHostStr(remoteHost), remotePort);
+            tcp_destroy(sototcpcb(s));
+            tcpReleasePort(((PSTATE *)(self->state))->portstate, localPort);
+            s = ERR_SESSN;
+        }
     }
     xTrace1(tcpp, TR_GROSS_EVENTS, "Return from tcpOpen, session = %x", s);
     return s;
 }
 
 /*************************************************************************/
-static xkern_return_t
-tcpOpenEnable(self, hlpRcv, hlpType, p)
-    XObj	self, hlpRcv, hlpType;
-    Part	*p;
+static xkern_return_t tcpOpenEnable(self, hlpRcv, hlpType, p)
+XObj self, hlpRcv, hlpType;
+Part *p;
 {
-    PassiveId	key;
-    long	protNum;
-    PSTATE	*pstate;
-    Enable	*e;
-    
+    PassiveId key;
+    long protNum;
+    PSTATE *pstate;
+    Enable *e;
+
     partCheck(p, "tcpOpenEnable", 1, XK_FAILURE);
-    if ( extractPart(p, &protNum, 0, "tcpOpenEnable") ) {
-	return XK_FAILURE;
+    if (extractPart(p, &protNum, 0, "tcpOpenEnable")) {
+        return XK_FAILURE;
     }
     key = protNum;
     pstate = (PSTATE *)self->state;
-    xTrace2(tcpp, TR_MAJOR_EVENTS, "tcpOpenEnable mapping %d->%x", key,
-	    hlpRcv);
-    if ( mapResolve(pstate->passiveMap, &key, &e) == XK_SUCCESS ) {
-	if ( e->hlpRcv == hlpRcv && e->hlpType == hlpType ) {
-	    e->rcnt++;
-	    return XK_SUCCESS;
-	}
-	return XK_FAILURE;
+    xTrace2(tcpp, TR_MAJOR_EVENTS, "tcpOpenEnable mapping %d->%x", key, hlpRcv);
+    if (mapResolve(pstate->passiveMap, &key, &e) == XK_SUCCESS) {
+        if (e->hlpRcv == hlpRcv && e->hlpType == hlpType) {
+            e->rcnt++;
+            return XK_SUCCESS;
+        }
+        return XK_FAILURE;
     }
     tcpDuplicatePort(pstate->portstate, key);
     e = (Enable *)xMalloc(sizeof(Enable));
     e->hlpRcv = hlpRcv;
     e->hlpType = hlpType;
     e->rcnt = 1;
-    e->binding = mapBind(pstate->passiveMap, (char *) &key, (int) e);
-    if ( e->binding == ERR_BIND ) {
-	xFree((char *)e);
-	return XK_FAILURE;
+    e->binding = mapBind(pstate->passiveMap, (char *)&key, (int)e);
+    if (e->binding == ERR_BIND) {
+        xFree((char *)e);
+        return XK_FAILURE;
     }
     return XK_SUCCESS;
 }
 
 /*************************************************************************/
-static xkern_return_t
-tcpOpenDisable(self, hlpRcv, hlpType, p)
-    XObj	self, hlpRcv, hlpType;
-    Part        *p;
+static xkern_return_t tcpOpenDisable(self, hlpRcv, hlpType, p)
+XObj self, hlpRcv, hlpType;
+Part *p;
 {
-    PassiveId	key;
-    long	protNum;
-    Enable	*e;
-    PSTATE	*pstate;
+    PassiveId key;
+    long protNum;
+    Enable *e;
+    PSTATE *pstate;
 
     pstate = (PSTATE *)self->state;
     partCheck(p, "tcpOpenDisable", 1, XK_FAILURE);
-    if ( extractPart(p, &protNum, 0, "tcpOpenEnable") ) {
-	return XK_FAILURE;
+    if (extractPart(p, &protNum, 0, "tcpOpenEnable")) {
+        return XK_FAILURE;
     }
     key = protNum;
     xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp_disable removing %d", key);
-    if ( mapResolve(pstate->passiveMap, &key, &e) == XK_FAILURE ||
-		e->hlpRcv != hlpRcv || e->hlpType != hlpType ) {
-	return XK_FAILURE;
+    if (mapResolve(pstate->passiveMap, &key, &e) == XK_FAILURE || e->hlpRcv != hlpRcv ||
+        e->hlpType != hlpType) {
+        return XK_FAILURE;
     }
     if (--(e->rcnt) == 0) {
-	mapRemoveBinding(pstate->passiveMap, e->binding);
-	xFree((char *)e);
-	tcpReleasePort(pstate->portstate, key);
+        mapRemoveBinding(pstate->passiveMap, e->binding);
+        xFree((char *)e);
+        tcpReleasePort(pstate->portstate, key);
     }
     return XK_SUCCESS;
 }
@@ -405,307 +378,281 @@ tcpOpenDisable(self, hlpRcv, hlpType, p)
  * for peer to send FIN or not respond to keep-alives, etc.
  * We can let the user exit from the close as soon as the FIN is acked.
  */
-static xkern_return_t
-tcpClose(XObj so)
-{
+static xkern_return_t tcpClose(XObj so) {
     struct tcpcb *tp;
     struct tcpstate *tcpst;
-    
+
     xTrace1(tcpp, TR_FUNCTIONAL_TRACE, "tcpClose(so=%08x)", so);
 
     tcpst = sototcpst(so);
     tcpst->closed |= 1;
-    
+
     tp = sototcpcb(so);
     tp = tcp_usrclosed(tp);
-    if (tp) tcp_output(tp);
+    if (tp)
+        tcp_output(tp);
 
-    xTrace2(tcpp, TR_MAJOR_EVENTS, "tcpClose: tp=%08x, tcpst->closed=%x",
-	    tp, tcpst->closed);
-    
+    xTrace2(tcpp, TR_MAJOR_EVENTS, "tcpClose: tp=%08x, tcpst->closed=%x", tp, tcpst->closed);
+
     if (tcpst->closed == 1) {
-	/*
-	 * This was a user close before the network close
-	 */
-	xTrace0(tcpp, TR_EVENTS, "tcpClose: waiting...");
-	tcpSemWait(&tcpst->waiting);
-	xTrace0(tcpp, TR_EVENTS, "tcpClose: done");
+        /*
+         * This was a user close before the network close
+         */
+        xTrace0(tcpp, TR_EVENTS, "tcpClose: waiting...");
+        tcpSemWait(&tcpst->waiting);
+        xTrace0(tcpp, TR_EVENTS, "tcpClose: done");
     }
     return XK_SUCCESS;
 }
 
-
 /*************************************************************************/
-static xmsg_handle_t
-tcpPush(XObj so, Msg *msg)
-{
+static xmsg_handle_t tcpPush(XObj so, Msg *msg) {
     int error;
     int space;
     Msg pushMsg;
     struct tcpstate *tcpst = sototcpst(so);
     struct tcpcb *tp = sototcpcb(so);
 
-    xTrace2(tcpp, TR_MAJOR_EVENTS, "tcpPush: session %X, msg %d bytes",
-	    so, msgLen(msg));
+    xTrace2(tcpp, TR_MAJOR_EVENTS, "tcpPush: session %X, msg %d bytes", so, msgLen(msg));
     if (so->rcnt < 1) {
-	xTrace1(tcpp, TR_GROSS_EVENTS, "tcpPush: session ref count = %d",
-		so->rcnt);
-	return XMSG_ERR_HANDLE;
+        xTrace1(tcpp, TR_GROSS_EVENTS, "tcpPush: session ref count = %d", so->rcnt);
+        return XMSG_ERR_HANDLE;
     }
     if (tcpst->closed) {
-	xTrace1(tcpp, TR_SOFT_ERROR, "tcpPush: session already closed %d",
-		tcpst->closed);
-	return XMSG_ERR_HANDLE;
+        xTrace1(tcpp, TR_SOFT_ERROR, "tcpPush: session already closed %d", tcpst->closed);
+        return XMSG_ERR_HANDLE;
     }
 
-#undef CHUNKSIZE (sbhiwat(tcpst->snd) / 2)
+#undef CHUNKSIZE(sbhiwat(tcpst->snd) / 2)
 #define CHUNKSIZE (tp->t_maxseg)
 
-    if ((tcpst->flags & TCPST_NBIO) &&
-	(sbspace(tcpst->snd) < MIN(msgLen(msg), CHUNKSIZE)))
-    {
-	return XMSG_ERR_WOULDBLOCK;
+    if ((tcpst->flags & TCPST_NBIO) && (sbspace(tcpst->snd) < MIN(msgLen(msg), CHUNKSIZE))) {
+        return XMSG_ERR_WOULDBLOCK;
     } /* if */
 
     msgConstructEmpty(&pushMsg);
-    while ( msgLen(msg) != 0 ) {
-	xTrace1(tcpp, TR_FUNCTIONAL_TRACE,
-		"tcpPush: msgLen = <%d>", msgLen(msg));
-	msgChopOff(msg, &pushMsg, CHUNKSIZE);
-	xTrace2(tcpp, TR_FUNCTIONAL_TRACE,
-		"tcpPush: after break pushMsg = <%d> msg = <%d>",
-		msgLen(&pushMsg), msgLen(msg));
-	while ((space = sbspace(tcpst->snd)) < msgLen(&pushMsg)) {
-	    xTrace1(tcpp, TR_GROSS_EVENTS,
-		    "tcpPush: waiting for space (%d available)", space);
-	    xTrace1(tcpp, TR_FUNCTIONAL_TRACE,
-		    "tcpPush: msgLen == %d before blocking",
-		    msgLen(msg));
-	    tcpSemWait(&tcpst->waiting);
-	    if (tcpst->closed) {
-		xTrace1(tcpp, TR_FUNCTIONAL_TRACE,
-			"tcpPush: session already closed %d", tcpst->closed);
-		msgDestroy(&pushMsg);
-		return XMSG_ERR_HANDLE;
-	    }
-	}
-	xTrace1(tcpp, TR_FUNCTIONAL_TRACE,
-		"tcppush about to append to sb.  orig msgLen == %d",
-		msgLen(msg));
-	sbappend(tcpst->snd, &pushMsg);
-	error = tcp_output(sototcpcb(so));
-	if (error) {
-	    xTrace1(tcpp, TR_ERRORS, "tcpPush failed with code %d", error);
-	    msgDestroy(&pushMsg);
-	    return XMSG_ERR_HANDLE;
-	}
+    while (msgLen(msg) != 0) {
+        xTrace1(tcpp, TR_FUNCTIONAL_TRACE, "tcpPush: msgLen = <%d>", msgLen(msg));
+        msgChopOff(msg, &pushMsg, CHUNKSIZE);
+        xTrace2(tcpp, TR_FUNCTIONAL_TRACE, "tcpPush: after break pushMsg = <%d> msg = <%d>",
+                msgLen(&pushMsg), msgLen(msg));
+        while ((space = sbspace(tcpst->snd)) < msgLen(&pushMsg)) {
+            xTrace1(tcpp, TR_GROSS_EVENTS, "tcpPush: waiting for space (%d available)", space);
+            xTrace1(tcpp, TR_FUNCTIONAL_TRACE, "tcpPush: msgLen == %d before blocking",
+                    msgLen(msg));
+            tcpSemWait(&tcpst->waiting);
+            if (tcpst->closed) {
+                xTrace1(tcpp, TR_FUNCTIONAL_TRACE, "tcpPush: session already closed %d",
+                        tcpst->closed);
+                msgDestroy(&pushMsg);
+                return XMSG_ERR_HANDLE;
+            }
+        }
+        xTrace1(tcpp, TR_FUNCTIONAL_TRACE, "tcppush about to append to sb.  orig msgLen == %d",
+                msgLen(msg));
+        sbappend(tcpst->snd, &pushMsg);
+        error = tcp_output(sototcpcb(so));
+        if (error) {
+            xTrace1(tcpp, TR_ERRORS, "tcpPush failed with code %d", error);
+            msgDestroy(&pushMsg);
+            return XMSG_ERR_HANDLE;
+        }
     }
     msgDestroy(&pushMsg);
     return XMSG_NULL_HANDLE;
 }
 
 /*************************************************************************/
-static int
-tcpControlSessn(s, opcode, buf, len)
-    Sessn           s;
-    char           *buf;
-    int             opcode;
-    int             len;
+static int tcpControlSessn(s, opcode, buf, len)
+Sessn s;
+char *buf;
+int opcode;
+int len;
 {
-  struct tcpstate *ts;
-  struct tcpcb   *tp;
-  u_short size;
+    struct tcpstate *ts;
+    struct tcpcb *tp;
+    u_short size;
 
-  ts = (struct tcpstate *) s->state;
-  tp = ts->tcpcb;
-  switch (opcode) {
+    ts = (struct tcpstate *)s->state;
+    tp = ts->tcpcb;
+    switch (opcode) {
 
-   case GETMYPROTO:
-     checkLen(len, sizeof(long));
-     *(long *)buf = tp->t_template->ti_sport;
-     return sizeof(long);
+    case GETMYPROTO:
+        checkLen(len, sizeof(long));
+        *(long *)buf = tp->t_template->ti_sport;
+        return sizeof(long);
 
-   case GETPEERPROTO:
-     checkLen(len, sizeof(long));
-     *(long *)buf = tp->t_template->ti_dport;
-     return sizeof(long);
+    case GETPEERPROTO:
+        checkLen(len, sizeof(long));
+        *(long *)buf = tp->t_template->ti_dport;
+        return sizeof(long);
 
-   case TCP_PUSH:
-     tp->t_force = 1;
-     tcp_output(tp);
-     tp->t_force = 0;
-     return 0;
+    case TCP_PUSH:
+        tp->t_force = 1;
+        tcp_output(tp);
+        tp->t_force = 0;
+        return 0;
 
-   case TCP_GETSTATEINFO:
-     *(int *) buf = tp->t_state;
-     return (sizeof(int));
+    case TCP_GETSTATEINFO:
+        *(int *)buf = tp->t_state;
+        return (sizeof(int));
 
-   case GETOPTPACKET:
-   case GETMAXPACKET:
-     if ( xControl(xGetDown(s, 0), opcode, buf, len) < sizeof(int) ) {
-	 return -1;
-     }
-     *(int *)buf -= sizeof(struct tcphdr);
-     return sizeof(int);
-     
-   case GETPARTICIPANTS:
-     {
-	 Part		p[2];
-	 int 		retLen;
-	 long		localPort, remotePort;
-	 int		numParts;
-	 xkern_return_t	xkr;
-	 
-	 retLen = xControl(xGetDown(s, 0), opcode, buf, len);
-	 if ( retLen < 0 ) {
-	     return retLen;
-	 }
-	 numParts = partExtLen(buf);
-	 if ( numParts > 0 && numParts <= 2 ) {
-	     partInternalize(p, buf);
-	     if ( numParts == 2 ) {
-		 localPort = tp->t_template->ti_sport;
-		 partPush(p[1], &localPort, sizeof(long));
-	     }
-	     remotePort = tp->t_template->ti_dport;
-	     partPush(p[0], &remotePort, sizeof(long));
-	     xkr = partExternalize(p, buf, &len);
-	     if ( xkr == XK_FAILURE ) {
-		 xTrace0(tcpp, TR_SOFT_ERRORS,
-			 "TCP GETPARTS -- buffer too small");
-		 retLen = -1;
-	     } else {
-		 retLen = len;
-	     }
-	 } else {
-	     xTrace1(tcpp, TR_SOFT_ERRORS,
-		 "TCP -- Bad number of participants (%d) returned in GETPARTS",
-		     partExtLen(buf));
-	     retLen = -1;
-	 }
-	 return retLen;
-     }
+    case GETOPTPACKET:
+    case GETMAXPACKET:
+        if (xControl(xGetDown(s, 0), opcode, buf, len) < sizeof(int)) {
+            return -1;
+        }
+        *(int *)buf -= sizeof(struct tcphdr);
+        return sizeof(int);
 
-   case SETNONBLOCKINGIO:
-     xControl(xGetDown(s, 0), opcode, buf, len);
-     if (*(int*)buf) {
-	 ts->flags |= TCPST_NBIO;
-     } else {
-	 ts->flags &= ~TCPST_NBIO;
-     } /* if */
-     return 0;
+    case GETPARTICIPANTS: {
+        Part p[2];
+        int retLen;
+        long localPort, remotePort;
+        int numParts;
+        xkern_return_t xkr;
 
-   case TCP_SETRCVBUFSPACE:
-     checkLen(len, sizeof(u_short));
-     size = *(u_short *)buf;
-     ts->rcv_space = size;
-     /* after receiving message possibly send window update: */
-     tcp_output(tp);
-     return 0;
+        retLen = xControl(xGetDown(s, 0), opcode, buf, len);
+        if (retLen < 0) {
+            return retLen;
+        }
+        numParts = partExtLen(buf);
+        if (numParts > 0 && numParts <= 2) {
+            partInternalize(p, buf);
+            if (numParts == 2) {
+                localPort = tp->t_template->ti_sport;
+                partPush(p[1], &localPort, sizeof(long));
+            }
+            remotePort = tp->t_template->ti_dport;
+            partPush(p[0], &remotePort, sizeof(long));
+            xkr = partExternalize(p, buf, &len);
+            if (xkr == XK_FAILURE) {
+                xTrace0(tcpp, TR_SOFT_ERRORS, "TCP GETPARTS -- buffer too small");
+                retLen = -1;
+            } else {
+                retLen = len;
+            }
+        } else {
+            xTrace1(tcpp, TR_SOFT_ERRORS,
+                    "TCP -- Bad number of participants (%d) returned in GETPARTS", partExtLen(buf));
+            retLen = -1;
+        }
+        return retLen;
+    }
 
-   case TCP_GETSNDBUFSPACE:
-     checkLen(len, sizeof(u_short));
-     *(u_short*)buf = sbspace(ts->snd);
-     return sizeof(u_short);
+    case SETNONBLOCKINGIO:
+        xControl(xGetDown(s, 0), opcode, buf, len);
+        if (*(int *)buf) {
+            ts->flags |= TCPST_NBIO;
+        } else {
+            ts->flags &= ~TCPST_NBIO;
+        } /* if */
+        return 0;
 
-   case TCP_SETRCVBUFSIZE:
-     checkLen(len, sizeof(u_short));
-     size = *(u_short *)buf;
-     ts->rcv_hiwat = size;
-     return 0;
+    case TCP_SETRCVBUFSPACE:
+        checkLen(len, sizeof(u_short));
+        size = *(u_short *)buf;
+        ts->rcv_space = size;
+        /* after receiving message possibly send window update: */
+        tcp_output(tp);
+        return 0;
 
-   case TCP_SETSNDBUFSIZE:
-     checkLen(len, sizeof(u_short));
-     sbhiwat(ts->snd) = *(u_short *)buf;
-     return 0;
+    case TCP_GETSNDBUFSPACE:
+        checkLen(len, sizeof(u_short));
+        *(u_short *)buf = sbspace(ts->snd);
+        return sizeof(u_short);
 
-   case TCP_SETOOBINLINE:
-     checkLen(len, sizeof(int));
-     if (*(int*)buf) {
-	 ts->flags |= TCPST_OOBINLINE;
-     } else {
-	 ts->flags &= ~TCPST_OOBINLINE;
-     } /* if */
-     return 0;
+    case TCP_SETRCVBUFSIZE:
+        checkLen(len, sizeof(u_short));
+        size = *(u_short *)buf;
+        ts->rcv_hiwat = size;
+        return 0;
 
-   case TCP_GETOOBDATA:
-     {     
-	 char peek;
+    case TCP_SETSNDBUFSIZE:
+        checkLen(len, sizeof(u_short));
+        sbhiwat(ts->snd) = *(u_short *)buf;
+        return 0;
 
-	 checkLen(len, sizeof(char));
+    case TCP_SETOOBINLINE:
+        checkLen(len, sizeof(int));
+        if (*(int *)buf) {
+            ts->flags |= TCPST_OOBINLINE;
+        } else {
+            ts->flags &= ~TCPST_OOBINLINE;
+        } /* if */
+        return 0;
 
-	 peek = *(char*)buf;
-	 if ((tp->t_oobflags & TCPOOB_HADDATA) ||
-	     !(tp->t_oobflags & TCPOOB_HAVEDATA))
-	 {
-	     return 0;
-	 } /* if */
-	 *(char*)buf = tp->t_iobc;
-	 if (!peek) {
-	     tp->t_oobflags ^= TCPOOB_HAVEDATA | TCPOOB_HADDATA;
-	 } /* if */
-	 return 1;
-     }
+    case TCP_GETOOBDATA: {
+        char peek;
 
-   case TCP_OOBPUSH:
-     {
-	 Msg *m;
+        checkLen(len, sizeof(char));
 
-	 checkLen(len, sizeof(Msg*));
+        peek = *(char *)buf;
+        if ((tp->t_oobflags & TCPOOB_HADDATA) || !(tp->t_oobflags & TCPOOB_HAVEDATA)) {
+            return 0;
+        } /* if */
+        *(char *)buf = tp->t_iobc;
+        if (!peek) {
+            tp->t_oobflags ^= TCPOOB_HAVEDATA | TCPOOB_HADDATA;
+        } /* if */
+        return 1;
+    }
 
-	 m = (Msg*)buf;
-	 sbappend(ts->snd, m);
-	 tp->snd_up = tp->snd_una + sblength(ts->snd);
-	 tp->t_force = 1;
-	 tcp_output(tp);
-	 tp->t_force = 0;
-	 return 0;
-     }
+    case TCP_OOBPUSH: {
+        Msg *m;
 
-   default:
-     return xControl(xGetDown(s, 0), opcode, buf, len);
-  }
+        checkLen(len, sizeof(Msg *));
+
+        m = (Msg *)buf;
+        sbappend(ts->snd, m);
+        tp->snd_up = tp->snd_una + sblength(ts->snd);
+        tp->t_force = 1;
+        tcp_output(tp);
+        tp->t_force = 0;
+        return 0;
+    }
+
+    default:
+        return xControl(xGetDown(s, 0), opcode, buf, len);
+    }
 }
 
 /*************************************************************************/
-static int
-tcpControlProtl(self, opcode, buf, len)
-    XObj	    self;
-    int             opcode, len;
-    char           *buf;
+static int tcpControlProtl(self, opcode, buf, len)
+XObj self;
+int opcode, len;
+char *buf;
 {
     long port;
 
     switch (opcode) {
 
-      case TCP_DUMPSTATEINFO:
-	tcp_dumpstats();
-	return 0;
+    case TCP_DUMPSTATEINFO:
+        tcp_dumpstats();
+        return 0;
 
-      case TCP_GETFREEPROTNUM:
-	checkLen(len, sizeof(long));
-	port = *(long *)buf;
-	if (tcpGetFreePort(((PSTATE *)(self->state))->portstate, &port)) {
-	    return -1;
-	} /* if */
-	*(long *)buf = port;
-	return 0;
+    case TCP_GETFREEPROTNUM:
+        checkLen(len, sizeof(long));
+        port = *(long *)buf;
+        if (tcpGetFreePort(((PSTATE *)(self->state))->portstate, &port)) {
+            return -1;
+        } /* if */
+        *(long *)buf = port;
+        return 0;
 
-      case TCP_RELEASEPROTNUM:
-	checkLen(len, sizeof(long));
-	port = *(long *)buf;
-	tcpReleasePort(((PSTATE *)(self->state))->portstate, port);
-	return 0;
+    case TCP_RELEASEPROTNUM:
+        checkLen(len, sizeof(long));
+        port = *(long *)buf;
+        tcpReleasePort(((PSTATE *)(self->state))->portstate, port);
+        return 0;
 
-      default:
-	return xControl(xGetDown(self,0), opcode, buf, len);
+    default:
+        return xControl(xGetDown(self, 0), opcode, buf, len);
     }
 }
 
 /*************************************************************************/
-static void
-tcpSessnInit(s)
-    XObj s;
+static void tcpSessnInit(s) XObj s;
 {
     xAssert(xIsSession(s));
     s->push = tcpPush;
@@ -716,301 +663,270 @@ tcpSessnInit(s)
 }
 
 /*************************************************************************/
-void
-sorwakeup(so)
-XObj so;
+void sorwakeup(so) XObj so;
 {
-  xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp: sorwakeup on %X", so);
+    xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp: sorwakeup on %X", so);
 }
-    
+
 /*************************************************************************/
-void
-sowwakeup(so)
-XObj so;
+void sowwakeup(so) XObj so;
 {
-  xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp: sowwakeup on %X", so);
-  tcpSemSignal(&sototcpst(so)->waiting);
+    xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp: sowwakeup on %X", so);
+    tcpSemSignal(&sototcpst(so)->waiting);
 }
 
 /*************************************************************************/
 /*ARGSUSED*/
-int
-soreserve(so, send, recv)
+int soreserve(so, send, recv)
 XObj so;
 int send, recv;
 {
-  struct tcpstate *tcpst = sototcpst(so);
-  sbinit(tcpst->snd);
-  return 0;
+    struct tcpstate *tcpst = sototcpst(so);
+    sbinit(tcpst->snd);
+    return 0;
 }
 
 /*************************************************************************/
-void
-socantsendmore(so)
-    XObj so;
+void socantsendmore(so) XObj so;
 {
     xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp:  socantsendmore on %X", so);
 }
 
 /*************************************************************************/
-void
-soisdisconnected(so)
-    XObj so;
+void soisdisconnected(so) XObj so;
 {
     xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp:  soisdisconnected on %X", so);
     if (sototcpst(so)->closed) {
-	/* It was already closed, either by the network or the user */
+        /* It was already closed, either by the network or the user */
     } else {
-	/* deliver close done after we're done handling current message: */
-	xCloseDone(so);
+        /* deliver close done after we're done handling current message: */
+        xCloseDone(so);
     } /* if */
     tcpVAll(&sototcpst(so)->waiting);
 } /* soisdisconnected */
 
 /*************************************************************************/
-void
-soabort(so)
-XObj so;
+void soabort(so) XObj so;
 {
 }
 
 /*************************************************************************/
-void
-socantrcvmore(so)
-    XObj so;
+void socantrcvmore(so) XObj so;
 {
     xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp:  socantrcvmore on %X", so);
-    
+
     sototcpst(so)->closed |= 2;
     if (sototcpst(so)->closed & 1) {
-	/* do nothing, the user already knows that it is closed */
+        /* do nothing, the user already knows that it is closed */
     } else {
-	xCloseDone(so);
+        xCloseDone(so);
     }
 }
 
 /*************************************************************************/
-void
-soisconnected(so)
-    XObj so;
+void soisconnected(so) XObj so;
 {
-    struct tcpstate	*state = sototcpst(so);
-    TcpSem 		*s = &state->waiting;
+    struct tcpstate *state = sototcpst(so);
+    TcpSem *s = &state->waiting;
 
     xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp:  soisconnected on %X", so);
     if (s->waitCount) {
-	xTrace1(tcpp, TR_EVENTS, "tcp:  waking up opener on %X", so);
-	tcpSemSignal(s);
+        xTrace1(tcpp, TR_EVENTS, "tcp:  waking up opener on %X", so);
+        tcpSemSignal(s);
     } else {
-	/*
-	 * I think that this is the time for a open done
-	 */
-	xOpenDone(xGetUp(so), so, xMyProtl(so));
+        /*
+         * I think that this is the time for a open done
+         */
+        xOpenDone(xGetUp(so), so, xMyProtl(so));
     }
 }
 
 /*************************************************************************/
-void
-soisconnecting(so)
-    XObj so;
+void soisconnecting(so) XObj so;
 {
     xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp:  soisconnecting on %X", so);
 }
 
 /*************************************************************************/
-void
-soisdisconnecting(so)
-XObj so;
+void soisdisconnecting(so) XObj so;
 {
     xTrace1(tcpp, TR_MAJOR_EVENTS, "tcp:  soisdisconnecting on %X", so);
 }
 
 /*************************************************************************/
-/* 
+/*
  * sonewconn is called by the input routine to establish a passive open
  */
-XObj
-sonewconn(self, so, hlpType, src, dst, sport, dport)
-    XObj self, so, hlpType;
-    IPhost *src, *dst;
-    int sport, dport;
+XObj sonewconn(self, so, hlpType, src, dst, sport, dport)
+XObj self, so, hlpType;
+IPhost *src, *dst;
+int sport, dport;
 {
-  XObj new;
-  xAssert(xIsProtocol(so));
-  xTrace1(tcpp, TR_MAJOR_EVENTS, "sonewconn on %X", so);
-  new = tcp_establishopen(self, so, hlpType, src, dst, sport, dport);
-  if ( new ) {
-      tcpDuplicatePort(((PSTATE *)self->state)->portstate, dport);
-  }
-  return new;
+    XObj new;
+    xAssert(xIsProtocol(so));
+    xTrace1(tcpp, TR_MAJOR_EVENTS, "sonewconn on %X", so);
+    new = tcp_establishopen(self, so, hlpType, src, dst, sport, dport);
+    if (new) {
+        tcpDuplicatePort(((PSTATE *)self->state)->portstate, dport);
+    }
+    return new;
 }
 
-
 /*************************************************************************/
-/* 
+/*
  * sohasoutofband is called by the input routine to signal the presence
  * of urgent (out-of-band) data
  */
-void
-sohasoutofband(so, oobmark)
-     XObj so;
-     u_int oobmark;
+void sohasoutofband(so, oobmark) XObj so;
+u_int oobmark;
 {
     void *buf[2];
 
     buf[0] = so;
-    buf[1] = (void*) oobmark;
-    xControl(xGetUp(so), TCP_OOBMODE, (char*) buf, sizeof(buf));
+    buf[1] = (void *)oobmark;
+    xControl(xGetUp(so), TCP_OOBMODE, (char *)buf, sizeof(buf));
 } /* sohasoutofband */
 
 /*************************************************************************/
 
-void
-tcpSemWait( ts )
-    TcpSem	*ts;
+void tcpSemWait(ts) TcpSem *ts;
 {
     ts->waitCount++;
     semWait(&ts->s);
     ts->waitCount--;
 }
 
-
-void
-tcpSemSignal( ts )
-    TcpSem	*ts;
+void tcpSemSignal(ts) TcpSem *ts;
 {
     semSignal(&ts->s);
 }
 
-
-void
-tcpVAll( ts )
-    TcpSem	*ts;
+void tcpVAll(ts) TcpSem *ts;
 {
     int i, n;
 
-    n=ts->waitCount;
-    for ( i=0; i < n; i++ ) {
-	semSignal(&ts->s);
+    PROF_START(tcpVAll);
+
+    n = ts->waitCount;
+    for (i = n / 8; i > 0; --i) {
+        UNROLL8(semSignal(&ts->s));
     }
+    for (i = 0; i < (n & 7); ++i) {
+        semSignal(&ts->s);
+    }
+    PROF_END(tcpVAll);
 }
 
-
-void
-tcpSemInit( ts, n )
-    TcpSem	*ts;
-    int		n;
+void tcpSemInit(ts, n) TcpSem *ts;
+int n;
 {
     semInit(&ts->s, n);
     ts->waitCount = 0;
 }
 
 /*************************************************************************/
-static void
-tcp_dumpstats()
-{
-  printf("tcps_badsum %d\n", tcpstat.tcps_badsum);
-  printf("tcps_badoff %d\n", tcpstat.tcps_badoff);
-  printf("tcps_hdrops %d\n", tcpstat.tcps_hdrops);
-  printf("tcps_badsegs %d\n", tcpstat.tcps_badsegs);
-  printf("tcps_unack %d\n", tcpstat.tcps_unack);
-  printf("connections initiated %d\n", tcpstat.tcps_connattempt);
-  printf("connections accepted %d\n", tcpstat.tcps_accepts);
-  printf("connections established %d\n", tcpstat.tcps_connects);
-  printf("connections dropped %d\n", tcpstat.tcps_drops);
-  printf("embryonic connections dropped %d\n", tcpstat.tcps_conndrops);
-  printf("conn. closed (includes drops) %d\n", tcpstat.tcps_closed);
-  printf("segs where we tried to get rtt %d\n", tcpstat.tcps_segstimed);
-  printf("times we succeeded %d\n", tcpstat.tcps_rttupdated);
-  printf("delayed acks sent %d\n", tcpstat.tcps_delack);
-  printf("conn. dropped in rxmt timeout %d\n", tcpstat.tcps_timeoutdrop);
-  printf("retransmit timeouts %d\n", tcpstat.tcps_rexmttimeo);
-  printf("persist timeouts %d\n", tcpstat.tcps_persisttimeo);
-  printf("keepalive timeouts %d\n", tcpstat.tcps_keeptimeo);
-  printf("keepalive probes sent %d\n", tcpstat.tcps_keepprobe);
-  printf("connections dropped in keepalive %d\n", tcpstat.tcps_keepdrops);
-  printf("total packets sent %d\n", tcpstat.tcps_sndtotal);
-  printf("data packets sent %d\n", tcpstat.tcps_sndpack);
-  printf("data bytes sent %d\n", tcpstat.tcps_sndbyte);
-  printf("data packets retransmitted %d\n", tcpstat.tcps_sndrexmitpack);
-  printf("data bytes retransmitted %d\n", tcpstat.tcps_sndrexmitbyte);
-  printf("ack-only packets sent %d\n", tcpstat.tcps_sndacks);
-  printf("window probes sent %d\n", tcpstat.tcps_sndprobe);
-  printf("packets sent with URG only %d\n", tcpstat.tcps_sndurg);
-  printf("window update-only packets sent %d\n", tcpstat.tcps_sndwinup);
-  printf("control (SYN|FIN|RST) packets sent %d\n", tcpstat.tcps_sndctrl);
-  printf("total packets received %d\n", tcpstat.tcps_rcvtotal);
-  printf("packets received in sequence %d\n", tcpstat.tcps_rcvpack);
-  printf("bytes received in sequence %d\n", tcpstat.tcps_rcvbyte);
-  printf("packets received with ccksum errs %d\n", tcpstat.tcps_rcvbadsum);
-  printf("packets received with bad offset %d\n", tcpstat.tcps_rcvbadoff);
-  printf("packets received too short %d\n", tcpstat.tcps_rcvshort);
-  printf("duplicate-only packets received %d\n", tcpstat.tcps_rcvduppack);
-  printf("duplicate-only bytes received %d\n", tcpstat.tcps_rcvdupbyte);
-  printf("packets with some duplicate data %d\n", tcpstat.tcps_rcvpartduppack);
-  printf("dup. bytes in part-dup. packets %d\n", tcpstat.tcps_rcvpartdupbyte);
-  printf("out-of-order packets received %d\n", tcpstat.tcps_rcvoopack);
-  printf("out-of-order bytes received %d\n", tcpstat.tcps_rcvoobyte);
-  printf("packets with data after window %d\n", tcpstat.tcps_rcvpackafterwin);
-  printf("bytes rcvd after window %d\n", tcpstat.tcps_rcvbyteafterwin);
-  printf("packets rcvd after \"close\" %d\n", tcpstat.tcps_rcvafterclose);
-  printf("rcvd window probe packets %d\n", tcpstat.tcps_rcvwinprobe);
-  printf("rcvd duplicate acks %d\n", tcpstat.tcps_rcvdupack);
-  printf("rcvd acks for unsent data %d\n", tcpstat.tcps_rcvacktoomuch);
-  printf("rcvd ack packets %d\n", tcpstat.tcps_rcvackpack);
-  printf("bytes acked by rcvd acks %d\n", tcpstat.tcps_rcvackbyte);
-  printf("rcvd window update packets %d\n", tcpstat.tcps_rcvwinupd);
+static void tcp_dumpstats() {
+    printf("tcps_badsum %d\n", tcpstat.tcps_badsum);
+    printf("tcps_badoff %d\n", tcpstat.tcps_badoff);
+    printf("tcps_hdrops %d\n", tcpstat.tcps_hdrops);
+    printf("tcps_badsegs %d\n", tcpstat.tcps_badsegs);
+    printf("tcps_unack %d\n", tcpstat.tcps_unack);
+    printf("connections initiated %d\n", tcpstat.tcps_connattempt);
+    printf("connections accepted %d\n", tcpstat.tcps_accepts);
+    printf("connections established %d\n", tcpstat.tcps_connects);
+    printf("connections dropped %d\n", tcpstat.tcps_drops);
+    printf("embryonic connections dropped %d\n", tcpstat.tcps_conndrops);
+    printf("conn. closed (includes drops) %d\n", tcpstat.tcps_closed);
+    printf("segs where we tried to get rtt %d\n", tcpstat.tcps_segstimed);
+    printf("times we succeeded %d\n", tcpstat.tcps_rttupdated);
+    printf("delayed acks sent %d\n", tcpstat.tcps_delack);
+    printf("conn. dropped in rxmt timeout %d\n", tcpstat.tcps_timeoutdrop);
+    printf("retransmit timeouts %d\n", tcpstat.tcps_rexmttimeo);
+    printf("persist timeouts %d\n", tcpstat.tcps_persisttimeo);
+    printf("keepalive timeouts %d\n", tcpstat.tcps_keeptimeo);
+    printf("keepalive probes sent %d\n", tcpstat.tcps_keepprobe);
+    printf("connections dropped in keepalive %d\n", tcpstat.tcps_keepdrops);
+    printf("total packets sent %d\n", tcpstat.tcps_sndtotal);
+    printf("data packets sent %d\n", tcpstat.tcps_sndpack);
+    printf("data bytes sent %d\n", tcpstat.tcps_sndbyte);
+    printf("data packets retransmitted %d\n", tcpstat.tcps_sndrexmitpack);
+    printf("data bytes retransmitted %d\n", tcpstat.tcps_sndrexmitbyte);
+    printf("ack-only packets sent %d\n", tcpstat.tcps_sndacks);
+    printf("window probes sent %d\n", tcpstat.tcps_sndprobe);
+    printf("packets sent with URG only %d\n", tcpstat.tcps_sndurg);
+    printf("window update-only packets sent %d\n", tcpstat.tcps_sndwinup);
+    printf("control (SYN|FIN|RST) packets sent %d\n", tcpstat.tcps_sndctrl);
+    printf("total packets received %d\n", tcpstat.tcps_rcvtotal);
+    printf("packets received in sequence %d\n", tcpstat.tcps_rcvpack);
+    printf("bytes received in sequence %d\n", tcpstat.tcps_rcvbyte);
+    printf("packets received with ccksum errs %d\n", tcpstat.tcps_rcvbadsum);
+    printf("packets received with bad offset %d\n", tcpstat.tcps_rcvbadoff);
+    printf("packets received too short %d\n", tcpstat.tcps_rcvshort);
+    printf("duplicate-only packets received %d\n", tcpstat.tcps_rcvduppack);
+    printf("duplicate-only bytes received %d\n", tcpstat.tcps_rcvdupbyte);
+    printf("packets with some duplicate data %d\n", tcpstat.tcps_rcvpartduppack);
+    printf("dup. bytes in part-dup. packets %d\n", tcpstat.tcps_rcvpartdupbyte);
+    printf("out-of-order packets received %d\n", tcpstat.tcps_rcvoopack);
+    printf("out-of-order bytes received %d\n", tcpstat.tcps_rcvoobyte);
+    printf("packets with data after window %d\n", tcpstat.tcps_rcvpackafterwin);
+    printf("bytes rcvd after window %d\n", tcpstat.tcps_rcvbyteafterwin);
+    printf("packets rcvd after \"close\" %d\n", tcpstat.tcps_rcvafterclose);
+    printf("rcvd window probe packets %d\n", tcpstat.tcps_rcvwinprobe);
+    printf("rcvd duplicate acks %d\n", tcpstat.tcps_rcvdupack);
+    printf("rcvd acks for unsent data %d\n", tcpstat.tcps_rcvacktoomuch);
+    printf("rcvd ack packets %d\n", tcpstat.tcps_rcvackpack);
+    printf("bytes acked by rcvd acks %d\n", tcpstat.tcps_rcvackbyte);
+    printf("rcvd window update packets %d\n", tcpstat.tcps_rcvwinupd);
 
-
-  tcpstat.tcps_badsum = 0;
-  tcpstat.tcps_badoff = 0;
-  tcpstat.tcps_hdrops = 0;
-  tcpstat.tcps_badsegs = 0;
-  tcpstat.tcps_unack = 0;
-  tcpstat.tcps_connattempt = 0;
-  tcpstat.tcps_accepts = 0;
-  tcpstat.tcps_connects = 0;
-  tcpstat.tcps_drops = 0;
-  tcpstat.tcps_conndrops = 0;
-  tcpstat.tcps_closed = 0;
-  tcpstat.tcps_segstimed = 0;
-  tcpstat.tcps_rttupdated = 0;
-  tcpstat.tcps_delack = 0;
-  tcpstat.tcps_timeoutdrop = 0;
-  tcpstat.tcps_rexmttimeo = 0;
-  tcpstat.tcps_persisttimeo = 0;
-  tcpstat.tcps_keeptimeo = 0;
-  tcpstat.tcps_keepprobe = 0;
-  tcpstat.tcps_keepdrops = 0;
-  tcpstat.tcps_sndtotal = 0;
-  tcpstat.tcps_sndpack = 0;
-  tcpstat.tcps_sndbyte = 0;
-  tcpstat.tcps_sndrexmitpack = 0;
-  tcpstat.tcps_sndrexmitbyte = 0;
-  tcpstat.tcps_sndacks = 0;
-  tcpstat.tcps_sndprobe = 0;
-  tcpstat.tcps_sndurg = 0;
-  tcpstat.tcps_sndwinup = 0;
-  tcpstat.tcps_sndctrl = 0;
-  tcpstat.tcps_rcvtotal = 0;
-  tcpstat.tcps_rcvpack = 0;
-  tcpstat.tcps_rcvbyte = 0;
-  tcpstat.tcps_rcvbadsum = 0;
-  tcpstat.tcps_rcvbadoff = 0;
-  tcpstat.tcps_rcvshort = 0;
-  tcpstat.tcps_rcvduppack = 0;
-  tcpstat.tcps_rcvdupbyte = 0;
-  tcpstat.tcps_rcvpartduppack = 0;
-  tcpstat.tcps_rcvpartdupbyte = 0;
-  tcpstat.tcps_rcvoopack = 0;
-  tcpstat.tcps_rcvoobyte = 0;
-  tcpstat.tcps_rcvpackafterwin = 0;
-  tcpstat.tcps_rcvbyteafterwin = 0;
-  tcpstat.tcps_rcvafterclose = 0;
-  tcpstat.tcps_rcvwinprobe = 0;
-  tcpstat.tcps_rcvdupack = 0;
-  tcpstat.tcps_rcvacktoomuch = 0;
-  tcpstat.tcps_rcvackpack = 0;
-  tcpstat.tcps_rcvackbyte = 0;
-  tcpstat.tcps_rcvwinupd = 0;
+    tcpstat.tcps_badsum = 0;
+    tcpstat.tcps_badoff = 0;
+    tcpstat.tcps_hdrops = 0;
+    tcpstat.tcps_badsegs = 0;
+    tcpstat.tcps_unack = 0;
+    tcpstat.tcps_connattempt = 0;
+    tcpstat.tcps_accepts = 0;
+    tcpstat.tcps_connects = 0;
+    tcpstat.tcps_drops = 0;
+    tcpstat.tcps_conndrops = 0;
+    tcpstat.tcps_closed = 0;
+    tcpstat.tcps_segstimed = 0;
+    tcpstat.tcps_rttupdated = 0;
+    tcpstat.tcps_delack = 0;
+    tcpstat.tcps_timeoutdrop = 0;
+    tcpstat.tcps_rexmttimeo = 0;
+    tcpstat.tcps_persisttimeo = 0;
+    tcpstat.tcps_keeptimeo = 0;
+    tcpstat.tcps_keepprobe = 0;
+    tcpstat.tcps_keepdrops = 0;
+    tcpstat.tcps_sndtotal = 0;
+    tcpstat.tcps_sndpack = 0;
+    tcpstat.tcps_sndbyte = 0;
+    tcpstat.tcps_sndrexmitpack = 0;
+    tcpstat.tcps_sndrexmitbyte = 0;
+    tcpstat.tcps_sndacks = 0;
+    tcpstat.tcps_sndprobe = 0;
+    tcpstat.tcps_sndurg = 0;
+    tcpstat.tcps_sndwinup = 0;
+    tcpstat.tcps_sndctrl = 0;
+    tcpstat.tcps_rcvtotal = 0;
+    tcpstat.tcps_rcvpack = 0;
+    tcpstat.tcps_rcvbyte = 0;
+    tcpstat.tcps_rcvbadsum = 0;
+    tcpstat.tcps_rcvbadoff = 0;
+    tcpstat.tcps_rcvshort = 0;
+    tcpstat.tcps_rcvduppack = 0;
+    tcpstat.tcps_rcvdupbyte = 0;
+    tcpstat.tcps_rcvpartduppack = 0;
+    tcpstat.tcps_rcvpartdupbyte = 0;
+    tcpstat.tcps_rcvoopack = 0;
+    tcpstat.tcps_rcvoobyte = 0;
+    tcpstat.tcps_rcvpackafterwin = 0;
+    tcpstat.tcps_rcvbyteafterwin = 0;
+    tcpstat.tcps_rcvafterclose = 0;
+    tcpstat.tcps_rcvwinprobe = 0;
+    tcpstat.tcps_rcvdupack = 0;
+    tcpstat.tcps_rcvacktoomuch = 0;
+    tcpstat.tcps_rcvackpack = 0;
+    tcpstat.tcps_rcvackbyte = 0;
+    tcpstat.tcps_rcvwinupd = 0;
 }

--- a/server/netiso/clnp_output.c
+++ b/server/netiso/clnp_output.c
@@ -34,17 +34,17 @@
  */
 
 /***********************************************************
-		Copyright IBM Corporation 1987
+                Copyright IBM Corporation 1987
 
                       All Rights Reserved
 
-Permission to use, copy, modify, and distribute this software and its 
-documentation for any purpose and without fee is hereby granted, 
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
 provided that the above copyright notice appear in all copies and that
-both that copyright notice and this permission notice appear in 
+both that copyright notice and this permission notice appear in
 supporting documentation, and that the name of IBM not be
 used in advertising or publicity pertaining to distribution of the
-software without specific, written prior permission.  
+software without specific, written prior permission.
 
 IBM DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
 ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT SHALL
@@ -59,81 +59,81 @@ SOFTWARE.
 /*
  * ARGO Project, Computer Sciences Dept., University of Wisconsin - Madison
  */
-/* $Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/clnp_output.c,v 1.1.1.1 1995/03/02 21:49:57 mike Exp $ */
+/* $Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/clnp_output.c,v 1.1.1.1 1995/03/02
+ * 21:49:57 mike Exp $ */
 /* $Source: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/clnp_output.c,v $ */
 
-#include <sys/param.h>
-#include <sys/mbuf.h>
 #include <sys/domain.h>
+#include <sys/errno.h>
+#include <sys/mbuf.h>
+#include <sys/param.h>
 #include <sys/protosw.h>
 #include <sys/socket.h>
 #include <sys/socketvar.h>
-#include <sys/errno.h>
 #include <sys/time.h>
 
 #include <net/if.h>
 #include <net/route.h>
 
-#include <netiso/iso.h>
-#include <netiso/iso_var.h>
-#include <netiso/iso_pcb.h>
+#include <netiso/argo_debug.h>
 #include <netiso/clnp.h>
 #include <netiso/clnp_stat.h>
-#include <netiso/argo_debug.h>
+#include <netiso/iso.h>
+#include <netiso/iso_pcb.h>
+#include <netiso/iso_var.h>
 
 static struct clnp_fixed dt_template = {
-	ISO8473_CLNP,	/* network identifier */
-	0,				/* length */
-	ISO8473_V1,		/* version */
-	CLNP_TTL,		/* ttl */
-	CLNP_DT|CNF_SEG_OK|CNF_ERR_OK,		/* type */
-	0,				/* segment length */
-	0				/* checksum */
+    ISO8473_CLNP,                      /* network identifier */
+    0,                                 /* length */
+    ISO8473_V1,                        /* version */
+    CLNP_TTL,                          /* ttl */
+    CLNP_DT | CNF_SEG_OK | CNF_ERR_OK, /* type */
+    0,                                 /* segment length */
+    0                                  /* checksum */
 };
 
 static struct clnp_fixed raw_template = {
-	ISO8473_CLNP,	/* network identifier */
-	0,				/* length */
-	ISO8473_V1,		/* version */
-	CLNP_TTL,		/* ttl */
-	CLNP_RAW|CNF_SEG_OK|CNF_ERR_OK,		/* type */
-	0,				/* segment length */
-	0				/* checksum */
+    ISO8473_CLNP,                       /* network identifier */
+    0,                                  /* length */
+    ISO8473_V1,                         /* version */
+    CLNP_TTL,                           /* ttl */
+    CLNP_RAW | CNF_SEG_OK | CNF_ERR_OK, /* type */
+    0,                                  /* segment length */
+    0                                   /* checksum */
 };
 
 static struct clnp_fixed echo_template = {
-	ISO8473_CLNP,	/* network identifier */
-	0,				/* length */
-	ISO8473_V1,		/* version */
-	CLNP_TTL,		/* ttl */
-	CLNP_EC|CNF_SEG_OK|CNF_ERR_OK,		/* type */
-	0,				/* segment length */
-	0				/* checksum */
+    ISO8473_CLNP,                      /* network identifier */
+    0,                                 /* length */
+    ISO8473_V1,                        /* version */
+    CLNP_TTL,                          /* ttl */
+    CLNP_EC | CNF_SEG_OK | CNF_ERR_OK, /* type */
+    0,                                 /* segment length */
+    0                                  /* checksum */
 };
 
 static struct clnp_fixed echor_template = {
-	ISO8473_CLNP,	/* network identifier */
-	0,				/* length */
-	ISO8473_V1,		/* version */
-	CLNP_TTL,		/* ttl */
-	CLNP_ECR|CNF_SEG_OK|CNF_ERR_OK,		/* type */
-	0,				/* segment length */
-	0				/* checksum */
+    ISO8473_CLNP,                       /* network identifier */
+    0,                                  /* length */
+    ISO8473_V1,                         /* version */
+    CLNP_TTL,                           /* ttl */
+    CLNP_ECR | CNF_SEG_OK | CNF_ERR_OK, /* type */
+    0,                                  /* segment length */
+    0                                   /* checksum */
 };
 
-#ifdef	DECBIT
-u_char qos_option[] = {CLNPOVAL_QOS, 1, 
-	CLNPOVAL_GLOBAL|CLNPOVAL_SEQUENCING|CLNPOVAL_LOWDELAY};
-#endif	/* DECBIT */
+#ifdef DECBIT
+u_char qos_option[] = {CLNPOVAL_QOS, 1, CLNPOVAL_GLOBAL | CLNPOVAL_SEQUENCING | CLNPOVAL_LOWDELAY};
+#endif /* DECBIT */
 
-int				clnp_id = 0;		/* id for segmented dgrams */
+int clnp_id = 0; /* id for segmented dgrams */
 
 /*
  * FUNCTION:		clnp_output
  *
  * PURPOSE:			output the data in the mbuf as a clnp datagram
  *
- *					The data specified by m0 is sent as a clnp datagram. 
+ *					The data specified by m0 is sent as a clnp datagram.
  *					The mbuf chain m0 will be freed when this routine has
  *					returned.
  *
@@ -142,12 +142,12 @@ int				clnp_id = 0;		/* id for segmented dgrams */
  *					be formatted in the mbuf according to clnp rules. Options
  *					will not be freed.
  *
- *					Datalen specifies the length of the data in m0. 
+ *					Datalen specifies the length of the data in m0.
  *
- *					Src and dst are the addresses for the packet. 
+ *					Src and dst are the addresses for the packet.
  *
- *					If route is non-null, it is used as the route for 
- *					the packet. 
+ *					If route is non-null, it is used as the route for
+ *					the packet.
  *
  *					By default, a DT is sent. However, if flags & CNLP_SEND_ER
  *					then an ER will be sent. If flags & CLNP_SEND_RAW, then
@@ -158,7 +158,7 @@ int				clnp_id = 0;		/* id for segmented dgrams */
  *
  * SIDE EFFECTS:	none
  *
- * NOTES:			
+ * NOTES:
  *					Flags are interpretated as follows:
  *						CLNP_NO_SEG - do not allow this pkt to be segmented.
  *						CLNP_NO_ER  - have pkt request ER suppression.
@@ -175,387 +175,377 @@ int				clnp_id = 0;		/* id for segmented dgrams */
  *					to have clnp check that the route has the same dest, but
  *					by avoiding this check, we save a call to iso_addrmatch1.
  */
-clnp_output(m0, isop, datalen, flags)
-struct mbuf			*m0;		/* data for the packet */
-struct isopcb		*isop;		/* iso pcb */
-int					datalen;	/* number of bytes of data in m0 */
-int					flags;		/* flags */
+clnp_output(m0, isop, datalen, flags) struct mbuf *m0; /* data for the packet */
+struct isopcb *isop;                                   /* iso pcb */
+int datalen;                                           /* number of bytes of data in m0 */
+int flags;                                             /* flags */
 {
-	int							error = 0;		/* return value of function */
-	register struct mbuf		*m = m0;		/* mbuf for clnp header chain */
-	register struct clnp_fixed	*clnp;			/* ptr to fixed part of hdr */
-	register caddr_t			hoff;			/* offset into header */
-	int							total_len;		/* total length of packet */
-	struct iso_addr				*src;		/* ptr to source address */
-	struct iso_addr				*dst;		/* ptr to destination address */
-	struct clnp_cache			clc;		/* storage for cache information */
-	struct clnp_cache			*clcp = NULL;	/* ptr to clc */
-	int							hdrlen = 0;
+    int error = 0;                /* return value of function */
+    register struct mbuf *m = m0; /* mbuf for clnp header chain */
+    PROF_START(clnp_output);
+    register struct clnp_fixed *clnp; /* ptr to fixed part of hdr */
+    register caddr_t hoff;            /* offset into header */
+    int total_len;                    /* total length of packet */
+    struct iso_addr *src;             /* ptr to source address */
+    struct iso_addr *dst;             /* ptr to destination address */
+    struct clnp_cache clc;            /* storage for cache information */
+    struct clnp_cache *clcp = NULL;   /* ptr to clc */
+    int hdrlen = 0;
 
-	dst = &isop->isop_faddr->siso_addr;
-	if (isop->isop_laddr == 0) {
-		struct iso_ifaddr *ia = 0;
-		clnp_route(dst, &isop->isop_route, flags, 0, &ia);
-		if (ia == 0 || ia->ia_ifa.ifa_addr->sa_family != AF_ISO)
-			return (ENETUNREACH);
-		src = &ia->ia_addr.siso_addr;
-	} else
-		src = &isop->isop_laddr->siso_addr;
+    dst = &isop->isop_faddr->siso_addr;
+    if (isop->isop_laddr == 0) {
+        struct iso_ifaddr *ia = 0;
+        clnp_route(dst, &isop->isop_route, flags, 0, &ia);
+        if (ia == 0 || ia->ia_ifa.ifa_addr->sa_family != AF_ISO)
+            return (ENETUNREACH);
+        src = &ia->ia_addr.siso_addr;
+    } else
+        src = &isop->isop_laddr->siso_addr;
 
-	IFDEBUG(D_OUTPUT)
-		printf("clnp_output: to %s", clnp_iso_addrp(dst));
-		printf(" from %s of %d bytes\n", clnp_iso_addrp(src), datalen);
-		printf("\toptions x%x, flags x%x, isop_clnpcache x%x\n", 
-			isop->isop_options, flags, isop->isop_clnpcache);
-	ENDDEBUG
+    IFDEBUG(D_OUTPUT)
+    printf("clnp_output: to %s", clnp_iso_addrp(dst));
+    printf(" from %s of %d bytes\n", clnp_iso_addrp(src), datalen);
+    printf("\toptions x%x, flags x%x, isop_clnpcache x%x\n", isop->isop_options, flags,
+           isop->isop_clnpcache);
+    ENDDEBUG
 
-	if (isop->isop_clnpcache != NULL) {
-		clcp = mtod(isop->isop_clnpcache, struct clnp_cache *);
-	}
-	
-	/*
-	 *	Check if cache is valid ...
-	 */
-	IFDEBUG(D_OUTPUT)
-		printf("clnp_output: ck cache: clcp %x\n", clcp);
-		if (clcp != NULL) {
-			printf("\tclc_dst %s\n", clnp_iso_addrp(&clcp->clc_dst));
-			printf("\tisop_opts x%x, clc_opts x%x\n", isop->isop_options,
-				clcp->clc_options);
-			if (isop->isop_route.ro_rt)
-				printf("\tro_rt x%x, rt_flags x%x\n",
-					isop->isop_route.ro_rt, isop->isop_route.ro_rt->rt_flags);
-			printf("\tflags x%x, clc_flags x%x\n", flags, clcp->clc_flags);
-			printf("\tclc_hdr x%x\n", clcp->clc_hdr);
-		}
-	ENDDEBUG
-	if ((clcp != NULL) &&								/* cache exists */
-		(isop->isop_options == clcp->clc_options) && 	/* same options */
-		(iso_addrmatch1(dst, &clcp->clc_dst)) &&		/* dst still same */
-		(isop->isop_route.ro_rt != NULL) &&				/* route exists */
-		(isop->isop_route.ro_rt == clcp->clc_rt) &&		/* and is cached */
-		(isop->isop_route.ro_rt->rt_flags & RTF_UP) &&	/* route still up */
-		(flags == clcp->clc_flags) &&					/* same flags */
-		(clcp->clc_hdr != NULL)) {						/* hdr mbuf exists */
-		/*
-		 *	The cache is valid
-		 */
+    if (isop->isop_clnpcache != NULL) {
+        clcp = mtod(isop->isop_clnpcache, struct clnp_cache *);
+    }
 
-		IFDEBUG(D_OUTPUT)
-			printf("clnp_output: using cache\n");
-		ENDDEBUG
+    /*
+     *	Check if cache is valid ...
+     */
+    IFDEBUG(D_OUTPUT)
+    printf("clnp_output: ck cache: clcp %x\n", clcp);
+    if (clcp != NULL) {
+        printf("\tclc_dst %s\n", clnp_iso_addrp(&clcp->clc_dst));
+        printf("\tisop_opts x%x, clc_opts x%x\n", isop->isop_options, clcp->clc_options);
+        if (isop->isop_route.ro_rt)
+            printf("\tro_rt x%x, rt_flags x%x\n", isop->isop_route.ro_rt,
+                   isop->isop_route.ro_rt->rt_flags);
+        printf("\tflags x%x, clc_flags x%x\n", flags, clcp->clc_flags);
+        printf("\tclc_hdr x%x\n", clcp->clc_hdr);
+    }
+    ENDDEBUG
+    if ((clcp != NULL) &&                              /* cache exists */
+        (isop->isop_options == clcp->clc_options) &&   /* same options */
+        (iso_addrmatch1(dst, &clcp->clc_dst)) &&       /* dst still same */
+        (isop->isop_route.ro_rt != NULL) &&            /* route exists */
+        (isop->isop_route.ro_rt == clcp->clc_rt) &&    /* and is cached */
+        (isop->isop_route.ro_rt->rt_flags & RTF_UP) && /* route still up */
+        (flags == clcp->clc_flags) &&                  /* same flags */
+        (clcp->clc_hdr != NULL)) {                     /* hdr mbuf exists */
+        /*
+         *	The cache is valid
+         */
 
-		m = m_copy(clcp->clc_hdr, 0, (int)M_COPYALL);
-		if (m == NULL) {
-			/*
-			 *	No buffers left to copy cached packet header. Use
-			 *	the cached packet header this time, and
-			 *	mark the hdr as vacant
-			 */
-			m = clcp->clc_hdr;
-			clcp->clc_hdr = NULL;
-		}
-		m->m_next = m0;	/* ASSUMES pkt hdr is 1 mbuf long */
-		clnp = mtod(m, struct clnp_fixed *);
-	} else {
-		struct clnp_optidx	*oidx = NULL;		/* index to clnp options */
+        IFDEBUG(D_OUTPUT)
+        printf("clnp_output: using cache\n");
+        ENDDEBUG
 
-		/*
-		 *	The cache is not valid. Allocate an mbuf (if necessary)
-		 *	to hold cached info. If one is not available, then
-		 *	don't bother with the cache
-		 */
-		INCSTAT(cns_cachemiss);
-		if (flags & CLNP_NOCACHE) {
-			clcp = &clc;
-		} else {
-			if (isop->isop_clnpcache == NULL) {
-				/*
-				 *	There is no clnpcache. Allocate an mbuf to hold one
-				 */
-				if ((isop->isop_clnpcache = m_get(M_DONTWAIT, MT_HEADER))
-					== NULL) {
-					/*
-					 *	No mbufs available. Pretend that we don't want
-					 *	caching this time.
-					 */
-					IFDEBUG(D_OUTPUT)
-						printf("clnp_output: no mbufs to allocate to cache\n");
-					ENDDEBUG
-					flags  |= CLNP_NOCACHE;
-					clcp = &clc;
-				} else {
-					clcp = mtod(isop->isop_clnpcache, struct clnp_cache *);
-				}
-			} else {
-				/*
-				 *	A clnpcache mbuf exists. If the clc_hdr is not null,
-				 *	we must free it, as a new one is about to be created.
-				 */
-				clcp = mtod(isop->isop_clnpcache, struct clnp_cache *);
-				if (clcp->clc_hdr != NULL) {
-					/*
-					 *	The clc_hdr is not null but a clnpcache mbuf exists.
-					 *	This means that there was a cache, but the existing
-					 *	copy of the hdr is no longer valid. Free it now
-					 *	before we lose the pointer to it.
-					 */
-					IFDEBUG(D_OUTPUT)
-						printf("clnp_output: freeing old clc_hdr 0x%x\n",
-						clcp->clc_hdr);
-					ENDDEBUG
-					m_free(clcp->clc_hdr);
-					IFDEBUG(D_OUTPUT)
-						printf("clnp_output: freed old clc_hdr (done)\n");
-					ENDDEBUG
-				}
-			}
-		}
-		IFDEBUG(D_OUTPUT)
-			printf("clnp_output: NEW clcp x%x\n",clcp);
-		ENDDEBUG
-		bzero((caddr_t)clcp, sizeof(struct clnp_cache));
+        m = m_copy(clcp->clc_hdr, 0, (int)M_COPYALL);
+        if (m == NULL) {
+            /*
+             *	No buffers left to copy cached packet header. Use
+             *	the cached packet header this time, and
+             *	mark the hdr as vacant
+             */
+            m = clcp->clc_hdr;
+            clcp->clc_hdr = NULL;
+        }
+        m->m_next = m0; /* ASSUMES pkt hdr is 1 mbuf long */
+        clnp = mtod(m, struct clnp_fixed *);
+    } else {
+        struct clnp_optidx *oidx = NULL; /* index to clnp options */
 
-		if (isop->isop_optindex)
-			oidx = mtod(isop->isop_optindex, struct clnp_optidx *);
+        /*
+         *	The cache is not valid. Allocate an mbuf (if necessary)
+         *	to hold cached info. If one is not available, then
+         *	don't bother with the cache
+         */
+        INCSTAT(cns_cachemiss);
+        if (flags & CLNP_NOCACHE) {
+            clcp = &clc;
+        } else {
+            if (isop->isop_clnpcache == NULL) {
+                /*
+                 *	There is no clnpcache. Allocate an mbuf to hold one
+                 */
+                if ((isop->isop_clnpcache = m_get(M_DONTWAIT, MT_HEADER)) == NULL) {
+                    /*
+                     *	No mbufs available. Pretend that we don't want
+                     *	caching this time.
+                     */
+                    IFDEBUG(D_OUTPUT)
+                    printf("clnp_output: no mbufs to allocate to cache\n");
+                    ENDDEBUG
+                    flags |= CLNP_NOCACHE;
+                    clcp = &clc;
+                } else {
+                    clcp = mtod(isop->isop_clnpcache, struct clnp_cache *);
+                }
+            } else {
+                /*
+                 *	A clnpcache mbuf exists. If the clc_hdr is not null,
+                 *	we must free it, as a new one is about to be created.
+                 */
+                clcp = mtod(isop->isop_clnpcache, struct clnp_cache *);
+                if (clcp->clc_hdr != NULL) {
+                    /*
+                     *	The clc_hdr is not null but a clnpcache mbuf exists.
+                     *	This means that there was a cache, but the existing
+                     *	copy of the hdr is no longer valid. Free it now
+                     *	before we lose the pointer to it.
+                     */
+                    IFDEBUG(D_OUTPUT)
+                    printf("clnp_output: freeing old clc_hdr 0x%x\n", clcp->clc_hdr);
+                    ENDDEBUG
+                    m_free(clcp->clc_hdr);
+                    IFDEBUG(D_OUTPUT)
+                    printf("clnp_output: freed old clc_hdr (done)\n");
+                    ENDDEBUG
+                }
+            }
+        }
+        IFDEBUG(D_OUTPUT)
+        printf("clnp_output: NEW clcp x%x\n", clcp);
+        ENDDEBUG
+        bzero((caddr_t)clcp, sizeof(struct clnp_cache));
 
-		/*
-		 *	Don't allow packets with security, quality of service,
-		 *	priority, or error report options to be sent.
-		 */
-		if ((isop->isop_options) && (oidx)) {
-			if ((oidx->cni_securep) ||
-				(oidx->cni_priorp) ||
-				(oidx->cni_qos_formatp) ||
-				(oidx->cni_er_reason != ER_INVALREAS)) {
-				IFDEBUG(D_OUTPUT)
-					printf("clnp_output: pkt dropped - option unsupported\n");
-				ENDDEBUG
-				m_freem(m0);
-				return(EINVAL);
-			}
-		}
+        if (isop->isop_optindex)
+            oidx = mtod(isop->isop_optindex, struct clnp_optidx *);
 
-		/*
-		 *	Don't allow any invalid flags to be set
-		 */
-		if ((flags & (CLNP_VFLAGS)) != flags) {
-			IFDEBUG(D_OUTPUT)
-				printf("clnp_output: packet dropped - flags unsupported\n");
-			ENDDEBUG
-			INCSTAT(cns_odropped);
-			m_freem(m0);
-			return(EINVAL);
-		}
+        /*
+         *	Don't allow packets with security, quality of service,
+         *	priority, or error report options to be sent.
+         */
+        if ((isop->isop_options) && (oidx)) {
+            if ((oidx->cni_securep) || (oidx->cni_priorp) || (oidx->cni_qos_formatp) ||
+                (oidx->cni_er_reason != ER_INVALREAS)) {
+                IFDEBUG(D_OUTPUT)
+                printf("clnp_output: pkt dropped - option unsupported\n");
+                ENDDEBUG
+                m_freem(m0);
+                return (EINVAL);
+            }
+        }
 
-		/*
-		 *	Don't allow funny lengths on dst; src may be zero in which
-		 *	case we insert the source address based upon the interface
-		 */
-		if ((src->isoa_len > sizeof(struct iso_addr)) || 
-			(dst->isoa_len == 0) ||
-			(dst->isoa_len > sizeof(struct iso_addr))) {
-			m_freem(m0);
-			INCSTAT(cns_odropped);
-			return(ENAMETOOLONG);
-		}
+        /*
+         *	Don't allow any invalid flags to be set
+         */
+        if ((flags & (CLNP_VFLAGS)) != flags) {
+            IFDEBUG(D_OUTPUT)
+            printf("clnp_output: packet dropped - flags unsupported\n");
+            ENDDEBUG
+            INCSTAT(cns_odropped);
+            m_freem(m0);
+            return (EINVAL);
+        }
 
-		/*
-		 *	Grab mbuf to contain header
-		 */
-		MGETHDR(m, M_DONTWAIT, MT_HEADER);
-		if (m == 0) {
-			m_freem(m0);
-			INCSTAT(cns_odropped);
-			return(ENOBUFS);
-		}
-		INCSTAT(cns_sent);
-		m->m_next = m0;
-		clnp = mtod(m, struct clnp_fixed *);
-		clcp->clc_segoff = 0;
+        /*
+         *	Don't allow funny lengths on dst; src may be zero in which
+         *	case we insert the source address based upon the interface
+         */
+        if ((src->isoa_len > sizeof(struct iso_addr)) || (dst->isoa_len == 0) ||
+            (dst->isoa_len > sizeof(struct iso_addr))) {
+            m_freem(m0);
+            INCSTAT(cns_odropped);
+            return (ENAMETOOLONG);
+        }
 
-		/*
-		 *	Fill in all of fixed hdr except lengths and checksum
-		 */
-		if (flags & CLNP_SEND_RAW) {
-			*clnp = raw_template;
-		} else if (flags & CLNP_ECHO) {
-			*clnp = echo_template;
-		} else if (flags & CLNP_ECHOR) {
-			*clnp = echor_template;
-		} else {
-			*clnp = dt_template;
-		}
-		if (flags & CLNP_NO_SEG)
-			clnp->cnf_type &= ~CNF_SEG_OK;
-		if (flags & CLNP_NO_ER)
-			clnp->cnf_type &= ~CNF_ERR_OK;
+        /*
+         *	Grab mbuf to contain header
+         */
+        MGETHDR(m, M_DONTWAIT, MT_HEADER);
+        if (m == 0) {
+            m_freem(m0);
+            INCSTAT(cns_odropped);
+            return (ENOBUFS);
+        }
+        INCSTAT(cns_sent);
+        m->m_next = m0;
+        clnp = mtod(m, struct clnp_fixed *);
+        clcp->clc_segoff = 0;
 
-		/*
-		 *	Route packet; special case for source rt
-		 */
-		if ((isop->isop_options) && CLNPSRCRT_VALID(oidx)) {
-			IFDEBUG(D_OUTPUT)
-				printf("clnp_output: calling clnp_srcroute\n");
-			ENDDEBUG
-			error = clnp_srcroute(isop->isop_options, oidx, &isop->isop_route,
-				&clcp->clc_firsthop, &clcp->clc_ifa, dst);
-		} else {
-			IFDEBUG(D_OUTPUT)
-			ENDDEBUG
-			error = clnp_route(dst, &isop->isop_route, flags, 
-				&clcp->clc_firsthop, &clcp->clc_ifa);
-		}
-		if (error || (clcp->clc_ifa == 0)) {
-			IFDEBUG(D_OUTPUT)
-				printf("clnp_output: route failed, errno %d\n", error);
-				printf("@clcp:\n");
-				dump_buf(clcp, sizeof (struct clnp_cache));
-			ENDDEBUG
-			goto bad;
-		}
-		clcp->clc_rt = isop->isop_route.ro_rt;	/* XXX */
-		clcp->clc_ifp = clcp->clc_ifa->ia_ifp;  /* XXX */
+        /*
+         *	Fill in all of fixed hdr except lengths and checksum
+         */
+        if (flags & CLNP_SEND_RAW) {
+            *clnp = raw_template;
+        } else if (flags & CLNP_ECHO) {
+            *clnp = echo_template;
+        } else if (flags & CLNP_ECHOR) {
+            *clnp = echor_template;
+        } else {
+            *clnp = dt_template;
+        }
+        if (flags & CLNP_NO_SEG)
+            clnp->cnf_type &= ~CNF_SEG_OK;
+        if (flags & CLNP_NO_ER)
+            clnp->cnf_type &= ~CNF_ERR_OK;
 
-		IFDEBUG(D_OUTPUT)
-			printf("clnp_output: packet routed to %s\n", 
-				clnp_iso_addrp(
-					&((struct sockaddr_iso *)clcp->clc_firsthop)->siso_addr));
-		ENDDEBUG
-		
-		/*
-		 *	If src address is not yet specified, use address of 
-		 *	interface. NOTE: this will now update the laddr field in
-		 *	the isopcb. Is this desirable? RAH?
-		 */
-		if (src->isoa_len == 0) {
-			src = &(clcp->clc_ifa->ia_addr.siso_addr);
-			IFDEBUG(D_OUTPUT)
-				printf("clnp_output: new src %s\n", clnp_iso_addrp(src));
-			ENDDEBUG
-		}
+        /*
+         *	Route packet; special case for source rt
+         */
+        if ((isop->isop_options) && CLNPSRCRT_VALID(oidx)) {
+            IFDEBUG(D_OUTPUT)
+            printf("clnp_output: calling clnp_srcroute\n");
+            ENDDEBUG
+            error = clnp_srcroute(isop->isop_options, oidx, &isop->isop_route, &clcp->clc_firsthop,
+                                  &clcp->clc_ifa, dst);
+        } else {
+            IFDEBUG(D_OUTPUT)
+            ENDDEBUG
+            error = clnp_route(dst, &isop->isop_route, flags, &clcp->clc_firsthop, &clcp->clc_ifa);
+        }
+        if (error || (clcp->clc_ifa == 0)) {
+            IFDEBUG(D_OUTPUT)
+            printf("clnp_output: route failed, errno %d\n", error);
+            printf("@clcp:\n");
+            dump_buf(clcp, sizeof(struct clnp_cache));
+            ENDDEBUG
+            goto bad;
+        }
+        clcp->clc_rt = isop->isop_route.ro_rt; /* XXX */
+        clcp->clc_ifp = clcp->clc_ifa->ia_ifp; /* XXX */
 
-		/*
-		 *	Insert the source and destination address,
-		 */
-		hoff = (caddr_t)clnp + sizeof(struct clnp_fixed);
-		CLNP_INSERT_ADDR(hoff, *dst);
-		CLNP_INSERT_ADDR(hoff, *src);
+        IFDEBUG(D_OUTPUT)
+        printf("clnp_output: packet routed to %s\n",
+               clnp_iso_addrp(&((struct sockaddr_iso *)clcp->clc_firsthop)->siso_addr));
+        ENDDEBUG
 
-		/*
-		 *	Leave room for the segment part, if segmenting is selected
-		 */
-		if (clnp->cnf_type & CNF_SEG_OK) {
-			clcp->clc_segoff = hoff - (caddr_t)clnp;
-			hoff += sizeof(struct clnp_segment);
-		}
+        /*
+         *	If src address is not yet specified, use address of
+         *	interface. NOTE: this will now update the laddr field in
+         *	the isopcb. Is this desirable? RAH?
+         */
+        if (src->isoa_len == 0) {
+            src = &(clcp->clc_ifa->ia_addr.siso_addr);
+            IFDEBUG(D_OUTPUT)
+            printf("clnp_output: new src %s\n", clnp_iso_addrp(src));
+            ENDDEBUG
+        }
 
-		clnp->cnf_hdr_len = m->m_len = (u_char)(hoff - (caddr_t)clnp);
-		hdrlen = clnp->cnf_hdr_len;
+        /*
+         *	Insert the source and destination address,
+         */
+        hoff = (caddr_t)clnp + sizeof(struct clnp_fixed);
+        CLNP_INSERT_ADDR(hoff, *dst);
+        CLNP_INSERT_ADDR(hoff, *src);
 
-#ifdef	DECBIT
-		/*
-		 *	Add the globally unique QOS (with room for congestion experienced
-		 *	bit). I can safely assume that this option is not in the options
-		 *	mbuf below because I checked that the option was not specified
-		 *	previously
-		 */
-		if ((m->m_len + sizeof(qos_option)) < MLEN) {
-			bcopy((caddr_t)qos_option, hoff, sizeof(qos_option));
-			clnp->cnf_hdr_len += sizeof(qos_option);
-			hdrlen += sizeof(qos_option);
-			m->m_len += sizeof(qos_option);
-		}
-#endif	/* DECBIT */
+        /*
+         *	Leave room for the segment part, if segmenting is selected
+         */
+        if (clnp->cnf_type & CNF_SEG_OK) {
+            clcp->clc_segoff = hoff - (caddr_t)clnp;
+            hoff += sizeof(struct clnp_segment);
+        }
 
-		/*
-		 *	If an options mbuf is present, concatenate a copy to the hdr mbuf.
-		 */
-		if (isop->isop_options) {
-			struct mbuf *opt_copy = m_copy(isop->isop_options, 0, (int)M_COPYALL);
-			if (opt_copy == NULL) {
-				error = ENOBUFS;
-				goto bad;
-			}
-			/* Link in place */
-			opt_copy->m_next = m->m_next;
-			m->m_next = opt_copy;
+        clnp->cnf_hdr_len = m->m_len = (u_char)(hoff - (caddr_t)clnp);
+        hdrlen = clnp->cnf_hdr_len;
 
-			/* update size of header */
-			clnp->cnf_hdr_len += opt_copy->m_len;
-			hdrlen += opt_copy->m_len;
-		}
+#ifdef DECBIT
+        /*
+         *	Add the globally unique QOS (with room for congestion experienced
+         *	bit). I can safely assume that this option is not in the options
+         *	mbuf below because I checked that the option was not specified
+         *	previously
+         */
+        if ((m->m_len + sizeof(qos_option)) < MLEN) {
+            bcopy((caddr_t)qos_option, hoff, sizeof(qos_option));
+            clnp->cnf_hdr_len += sizeof(qos_option);
+            hdrlen += sizeof(qos_option);
+            m->m_len += sizeof(qos_option);
+        }
+#endif /* DECBIT */
 
-		if (hdrlen > CLNP_HDR_MAX) {
-			error = EMSGSIZE;
-			goto bad;
-		}
+        /*
+         *	If an options mbuf is present, concatenate a copy to the hdr mbuf.
+         */
+        if (isop->isop_options) {
+            struct mbuf *opt_copy = m_copy(isop->isop_options, 0, (int)M_COPYALL);
+            if (opt_copy == NULL) {
+                error = ENOBUFS;
+                goto bad;
+            }
+            /* Link in place */
+            opt_copy->m_next = m->m_next;
+            m->m_next = opt_copy;
 
-		/*
-		 *	Now set up the cache entry in the pcb
-		 */
-		if ((flags & CLNP_NOCACHE) == 0) {
-			if (clcp->clc_hdr = m_copy(m, 0, (int)clnp->cnf_hdr_len)) {
-				clcp->clc_dst  = *dst;
-				clcp->clc_flags = flags;
-				clcp->clc_options = isop->isop_options;
-			}
-		}
-	}
-	/*
-	 *	If small enough for interface, send directly
-	 *	Fill in segmentation part of hdr if using the full protocol
-	 */
-	total_len = clnp->cnf_hdr_len + datalen;
-	if (clnp->cnf_type & CNF_SEG_OK) {
-		struct clnp_segment	seg_part;		/* segment part of hdr */
-		seg_part.cng_id = htons(clnp_id++);
-		seg_part.cng_off = htons(0);
-		seg_part.cng_tot_len = htons(total_len);
-		(void) bcopy((caddr_t)&seg_part, (caddr_t) clnp + clcp->clc_segoff, 
-			sizeof(seg_part));
-	}
-	if (total_len <= SN_MTU(clcp->clc_ifp, clcp->clc_rt)) {
-		HTOC(clnp->cnf_seglen_msb, clnp->cnf_seglen_lsb, total_len);
-		m->m_pkthdr.len = total_len;
-		/*
-		 *	Compute clnp checksum (on header only)
-		 */
-		if (flags & CLNP_NO_CKSUM) {
-			HTOC(clnp->cnf_cksum_msb, clnp->cnf_cksum_lsb, 0);
-		} else {
-			iso_gen_csum(m, CLNP_CKSUM_OFF, (int)clnp->cnf_hdr_len);
-		}
+            /* update size of header */
+            clnp->cnf_hdr_len += opt_copy->m_len;
+            hdrlen += opt_copy->m_len;
+        }
 
-		IFDEBUG(D_DUMPOUT)
-			struct mbuf *mdump = m;
-			printf("clnp_output: sending dg:\n");
-			while (mdump != NULL) {
-				dump_buf(mtod(mdump, caddr_t), mdump->m_len);
-				mdump = mdump->m_next;
-			}
-		ENDDEBUG
+        if (hdrlen > CLNP_HDR_MAX) {
+            error = EMSGSIZE;
+            goto bad;
+        }
 
-		error = SN_OUTPUT(clcp, m);
-		goto done;
-	} else {
-		/*
-		 * Too large for interface; fragment if possible.
-		 */
-		error = clnp_fragment(clcp->clc_ifp, m, clcp->clc_firsthop,
-							total_len, clcp->clc_segoff, flags, clcp->clc_rt);
-		goto done;
-	}
+        /*
+         *	Now set up the cache entry in the pcb
+         */
+        if ((flags & CLNP_NOCACHE) == 0) {
+            if (clcp->clc_hdr = m_copy(m, 0, (int)clnp->cnf_hdr_len)) {
+                clcp->clc_dst = *dst;
+                clcp->clc_flags = flags;
+                clcp->clc_options = isop->isop_options;
+            }
+        }
+    }
+    /*
+     *	If small enough for interface, send directly
+     *	Fill in segmentation part of hdr if using the full protocol
+     */
+    total_len = clnp->cnf_hdr_len + datalen;
+    if (clnp->cnf_type & CNF_SEG_OK) {
+        struct clnp_segment seg_part; /* segment part of hdr */
+        seg_part.cng_id = htons(clnp_id++);
+        seg_part.cng_off = htons(0);
+        seg_part.cng_tot_len = htons(total_len);
+        (void)bcopy((caddr_t)&seg_part, (caddr_t)clnp + clcp->clc_segoff, sizeof(seg_part));
+    }
+    if (total_len <= SN_MTU(clcp->clc_ifp, clcp->clc_rt)) {
+        HTOC(clnp->cnf_seglen_msb, clnp->cnf_seglen_lsb, total_len);
+        m->m_pkthdr.len = total_len;
+        /*
+         *	Compute clnp checksum (on header only)
+         */
+        if (flags & CLNP_NO_CKSUM) {
+            HTOC(clnp->cnf_cksum_msb, clnp->cnf_cksum_lsb, 0);
+        } else {
+            iso_gen_csum(m, CLNP_CKSUM_OFF, (int)clnp->cnf_hdr_len);
+        }
+
+        IFDEBUG(D_DUMPOUT)
+        struct mbuf *mdump = m;
+        printf("clnp_output: sending dg:\n");
+        while (mdump != NULL) {
+            dump_buf(mtod(mdump, caddr_t), mdump->m_len);
+            mdump = mdump->m_next;
+        }
+        ENDDEBUG
+
+        error = SN_OUTPUT(clcp, m);
+        goto done;
+    } else {
+        /*
+         * Too large for interface; fragment if possible.
+         */
+        error = clnp_fragment(clcp->clc_ifp, m, clcp->clc_firsthop, total_len, clcp->clc_segoff,
+                              flags, clcp->clc_rt);
+        goto done;
+    }
 bad:
-	m_freem(m);
+    m_freem(m);
 done:
-	if (error) {
-		clnp_stat.cns_sent--;
-		clnp_stat.cns_odropped++;
-	}
-	return (error);
+    if (error) {
+        clnp_stat.cns_sent--;
+        clnp_stat.cns_odropped++;
+    }
+    PROF_END(clnp_output);
+    return (error);
 }
 
-int clnp_ctloutput()
-{
-}
+int clnp_ctloutput() {}

--- a/server/netiso/iso.c
+++ b/server/netiso/iso.c
@@ -34,17 +34,17 @@
  */
 
 /***********************************************************
-		Copyright IBM Corporation 1987
+                Copyright IBM Corporation 1987
 
                       All Rights Reserved
 
-Permission to use, copy, modify, and distribute this software and its 
-documentation for any purpose and without fee is hereby granted, 
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
 provided that the above copyright notice appear in all copies and that
-both that copyright notice and this permission notice appear in 
+both that copyright notice and this permission notice appear in
 supporting documentation, and that the name of IBM not be
 used in advertising or publicity pertaining to distribution of the
-software without specific, written prior permission.  
+software without specific, written prior permission.
 
 IBM DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
 ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT SHALL
@@ -60,44 +60,45 @@ SOFTWARE.
  * ARGO Project, Computer Sciences Dept., University of Wisconsin - Madison
  */
 /*
- * $Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/iso.c,v 1.1.1.1 1995/03/02 21:49:56 mike Exp $ 
- * $Source: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/iso.c,v $ 
+ * $Header: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/iso.c,v 1.1.1.1 1995/03/02 21:49:56 mike
+ * Exp $ $Source: /n/fast/usr/lsrc/mach/CVS/lites/server/netiso/iso.c,v $
  *
  * iso.c: miscellaneous routines to support the iso address family
  */
 
 #include "iso.h"
 
-#include <sys/param.h>
-#include <sys/systm.h>
+#include <sys/domain.h>
+#include <sys/errno.h>
 #include <sys/ioctl.h>
 #include <sys/mbuf.h>
-#include <sys/domain.h>
+#include <sys/param.h>
 #include <sys/protosw.h>
 #include <sys/socket.h>
 #include <sys/socketvar.h>
-#include <sys/errno.h>
 #include <sys/synch.h>
+#include <sys/systm.h>
 
 #include <net/if.h>
 #include <net/route.h>
 
-#include <netiso/iso.h>
-#include <netiso/iso_var.h>
-#include <netiso/iso_snpac.h>
-#include <netiso/iso_pcb.h>
-#include <netiso/clnp.h>
 #include <netiso/argo_debug.h>
+#include <netiso/clnp.h>
+#include <netiso/iso.h>
+#include <netiso/iso_pcb.h>
+#include <netiso/iso_snpac.h>
+#include <netiso/iso_var.h>
+#include <simd.h>
 #ifdef TUBA
 #include <netiso/tuba_table.h>
 #endif
 
 #if ISO
 
-int	iso_interfaces = 0;		/* number of external interfaces */
-extern	struct ifnet loif;	/* loopback interface */
-int	ether_output();
-void	llc_rtrequest();
+int iso_interfaces = 0;   /* number of external interfaces */
+extern struct ifnet loif; /* loopback interface */
+int ether_output();
+void llc_rtrequest();
 
 /*
  * FUNCTION:		iso_addrmatch1
@@ -106,60 +107,58 @@ void	llc_rtrequest();
  *
  * RETURNS:			true if the addrs match, false if they do not
  *
- * SIDE EFFECTS:	
+ * SIDE EFFECTS:
  *
- * NOTES:			
+ * NOTES:
  */
-iso_addrmatch1(isoaa, isoab)
-register struct iso_addr *isoaa, *isoab;		/* addresses to check */
+iso_addrmatch1(isoaa, isoab) register struct iso_addr *isoaa, *isoab; /* addresses to check */
 {
-	u_int	compare_len;
+    u_int compare_len;
 
-	IFDEBUG(D_ROUTE)
-		printf("iso_addrmatch1: comparing lengths: %d to %d\n", isoaa->isoa_len,
-			isoab->isoa_len);
-		printf("a:\n");
-		dump_buf(isoaa->isoa_genaddr, isoaa->isoa_len);
-		printf("b:\n");
-		dump_buf(isoab->isoa_genaddr, isoab->isoa_len);
-	ENDDEBUG
+    IFDEBUG(D_ROUTE)
+    printf("iso_addrmatch1: comparing lengths: %d to %d\n", isoaa->isoa_len, isoab->isoa_len);
+    printf("a:\n");
+    dump_buf(isoaa->isoa_genaddr, isoaa->isoa_len);
+    printf("b:\n");
+    dump_buf(isoab->isoa_genaddr, isoab->isoa_len);
+    ENDDEBUG
 
-	if ((compare_len = isoaa->isoa_len) != isoab->isoa_len) {
-		IFDEBUG(D_ROUTE)
-			printf("iso_addrmatch1: returning false because of lengths\n");
-		ENDDEBUG
-		return 0;
-	}
-	
+    if ((compare_len = isoaa->isoa_len) != isoab->isoa_len) {
+        IFDEBUG(D_ROUTE)
+        printf("iso_addrmatch1: returning false because of lengths\n");
+        ENDDEBUG
+        return 0;
+    }
+
 #ifdef notdef
-	/* TODO : generalize this to all afis with masks */
-	if(	isoaa->isoa_afi == AFI_37 ) {
-		/* must not compare 2 least significant digits, or for
-		 * that matter, the DSP
-		 */
-		compare_len = ADDR37_IDI_LEN - 1; 
-	}
+    /* TODO : generalize this to all afis with masks */
+    if (isoaa->isoa_afi == AFI_37) {
+        /* must not compare 2 least significant digits, or for
+         * that matter, the DSP
+         */
+        compare_len = ADDR37_IDI_LEN - 1;
+    }
 #endif
 
-	IFDEBUG(D_ROUTE)
-		int i;
-		char *a, *b;
+    IFDEBUG(D_ROUTE)
+    int i;
+    char *a, *b;
 
-		a = isoaa->isoa_genaddr;
-		b = isoab->isoa_genaddr;
+    a = isoaa->isoa_genaddr;
+    b = isoab->isoa_genaddr;
 
-		for (i=0; i<compare_len; i++) {
-			printf("<%x=%x>", a[i]&0xff, b[i]&0xff);
-			if (a[i] != b[i]) {
-				printf("\naddrs are not equal at byte %d\n", i);
-				return(0);
-			}
-		}
-		printf("\n");
-		printf("addrs are equal\n");
-		return (1);
-	ENDDEBUG
-	return (!bcmp(isoaa->isoa_genaddr, isoab->isoa_genaddr, compare_len));
+    for (i = 0; i < compare_len; i++) {
+        printf("<%x=%x>", a[i] & 0xff, b[i] & 0xff);
+        if (a[i] != b[i]) {
+            printf("\naddrs are not equal at byte %d\n", i);
+            return (0);
+        }
+    }
+    printf("\n");
+    printf("addrs are equal\n");
+    return (1);
+    ENDDEBUG
+    return (simd_bcmp(isoaa->isoa_genaddr, isoab->isoa_genaddr, compare_len) == 0);
 }
 
 /*
@@ -169,14 +168,13 @@ register struct iso_addr *isoaa, *isoab;		/* addresses to check */
  *
  * RETURNS:			true if the addrs match, false if they do not
  *
- * SIDE EFFECTS:	
+ * SIDE EFFECTS:
  *
- * NOTES:			
+ * NOTES:
  */
-iso_addrmatch(sisoa, sisob)
-struct sockaddr_iso	*sisoa, *sisob;		/* addresses to check */
+iso_addrmatch(sisoa, sisob) struct sockaddr_iso *sisoa, *sisob; /* addresses to check */
 {
-	return(iso_addrmatch1(&sisoa->siso_addr, &sisob->siso_addr));
+    return (iso_addrmatch1(&sisoa->siso_addr, &sisob->siso_addr));
 }
 #ifdef notdef
 /*
@@ -187,29 +185,28 @@ struct sockaddr_iso	*sisoa, *sisob;		/* addresses to check */
  *
  * RETURNS:			true if same net, false if not
  *
- * SIDE EFFECTS:	
+ * SIDE EFFECTS:
  *
- * NOTES:			
+ * NOTES:
  */
-iso_netmatch(sisoa, sisob)
-struct sockaddr_iso *sisoa, *sisob;
+iso_netmatch(sisoa, sisob) struct sockaddr_iso *sisoa, *sisob;
 {
-	u_char			bufa[sizeof(struct sockaddr_iso)];
-	u_char			bufb[sizeof(struct sockaddr_iso)];
-	register int	lena, lenb;
+    u_char bufa[sizeof(struct sockaddr_iso)];
+    u_char bufb[sizeof(struct sockaddr_iso)];
+    register int lena, lenb;
 
-	lena = iso_netof(&sisoa->siso_addr, bufa);
-	lenb = iso_netof(&sisob->siso_addr, bufb);
+    lena = iso_netof(&sisoa->siso_addr, bufa);
+    lenb = iso_netof(&sisob->siso_addr, bufb);
 
-	IFDEBUG(D_ROUTE)
-		printf("iso_netmatch: comparing lengths: %d to %d\n", lena, lenb);
-		printf("a:\n");
-		dump_buf(bufa, lena);
-		printf("b:\n");
-		dump_buf(bufb, lenb);
-	ENDDEBUG
+    IFDEBUG(D_ROUTE)
+    printf("iso_netmatch: comparing lengths: %d to %d\n", lena, lenb);
+    printf("a:\n");
+    dump_buf(bufa, lena);
+    printf("b:\n");
+    dump_buf(bufb, lenb);
+    ENDDEBUG
 
-	return ((lena == lenb) && (!bcmp(bufa, bufb, lena)));
+    return ((lena == lenb) && (!bcmp(bufa, bufb, lena)));
 }
 #endif /* notdef */
 
@@ -221,49 +218,48 @@ struct sockaddr_iso *sisoa, *sisob;
  *
  * RETURNS:			The hash value.
  *
- * SIDE EFFECTS:	
+ * SIDE EFFECTS:
  *
  * NOTES:			The hash is achieved by exclusive ORing 4 byte
- *					quantities. 
+ *					quantities.
  */
-u_long
-iso_hashchar(buf, len)
-register caddr_t	buf;		/* buffer to pack from */
-register int		len;		/* length of buffer */
+u_long iso_hashchar(buf, len)
+register caddr_t buf; /* buffer to pack from */
+register int len;     /* length of buffer */
 {
-	register u_long	h = 0;
-	register int	i;
+    register u_long h = 0;
+    register int i;
 
-	for (i=0; i<len; i+=4) {
-		register u_long	l = 0;
+    for (i = 0; i < len; i += 4) {
+        register u_long l = 0;
 
-		if ((len - i) < 4) {
-			/* buffer not multiple of 4 */
-			switch (len - i) {
-				case 3:
-					l |= buf[i+2] << 8;
-				case 2:
-					l |= buf[i+1] << 16;
-				case 1:
-					l |= buf[i] << 24;
-					break;
-				default:
-					printf("iso_hashchar: unexpected value x%x\n", len - i);
-					break;
-			}
-		} else {
-			l |= buf[i] << 24;
-			l |= buf[i+1] << 16;
-			l |= buf[i+2] << 8;
-			l |= buf[i+3];
-		}
+        if ((len - i) < 4) {
+            /* buffer not multiple of 4 */
+            switch (len - i) {
+            case 3:
+                l |= buf[i + 2] << 8;
+            case 2:
+                l |= buf[i + 1] << 16;
+            case 1:
+                l |= buf[i] << 24;
+                break;
+            default:
+                printf("iso_hashchar: unexpected value x%x\n", len - i);
+                break;
+            }
+        } else {
+            l |= buf[i] << 24;
+            l |= buf[i + 1] << 16;
+            l |= buf[i + 2] << 8;
+            l |= buf[i + 3];
+        }
 
-		h ^= l;
-	}
-	
-	h ^= (u_long) (len % 4);
+        h ^= l;
+    }
 
-	return(h);
+    h ^= (u_long)(len % 4);
+
+    return (h);
 }
 #ifdef notdef
 /*
@@ -273,35 +269,31 @@ register int		len;		/* length of buffer */
  *
  * RETURNS:			none
  *
- * SIDE EFFECTS:	
+ * SIDE EFFECTS:
  *
- * NOTES:			
+ * NOTES:
  */
-iso_hash(siso, hp)
-struct sockaddr_iso	*siso;		/* address to perform hash on */
-struct afhash		*hp;		/* RETURN: hash info here */
+iso_hash(siso, hp) struct sockaddr_iso *siso; /* address to perform hash on */
+struct afhash *hp;                            /* RETURN: hash info here */
 {
-	u_long			buf[sizeof(struct sockaddr_iso)+1/4];
-	register int	bufsize;
+    u_long buf[sizeof(struct sockaddr_iso) + 1 / 4];
+    register int bufsize;
 
+    bzero(buf, sizeof(buf));
 
-	bzero(buf, sizeof(buf));
+    bufsize = iso_netof(&siso->siso_addr, buf);
+    hp->afh_nethash = iso_hashchar((caddr_t)buf, bufsize);
 
-	bufsize = iso_netof(&siso->siso_addr, buf);
-	hp->afh_nethash = iso_hashchar((caddr_t)buf, bufsize);
+    IFDEBUG(D_ROUTE)
+    printf("iso_hash: iso_netof: bufsize = %d\n", bufsize);
+    ENDDEBUG
 
-	IFDEBUG(D_ROUTE)
-		printf("iso_hash: iso_netof: bufsize = %d\n", bufsize);
-	ENDDEBUG
+    hp->afh_hosthash = iso_hashchar((caddr_t)&siso->siso_addr, siso->siso_addr.isoa_len);
 
-	hp->afh_hosthash = iso_hashchar((caddr_t)&siso->siso_addr, 
-		siso->siso_addr.isoa_len);
-
-	IFDEBUG(D_ROUTE)
-		printf("iso_hash: %s: nethash = x%x, hosthash = x%x\n",
-			clnp_iso_addrp(&siso->siso_addr), hp->afh_nethash, 
-			hp->afh_hosthash);
-	ENDDEBUG
+    IFDEBUG(D_ROUTE)
+    printf("iso_hash: %s: nethash = x%x, hosthash = x%x\n", clnp_iso_addrp(&siso->siso_addr),
+           hp->afh_nethash, hp->afh_hosthash);
+    ENDDEBUG
 }
 /*
  * FUNCTION:		iso_netof
@@ -310,103 +302,101 @@ struct afhash		*hp;		/* RETURN: hash info here */
  *					The network portion of the iso address varies depending
  *					on the type of address. The network portion of the
  *					address will include the IDP. The network portion is:
- *			
+ *
  *						TYPE			DESC
- *					t37					The AFI and x.121 (IDI)
- *					osinet				The AFI, orgid, snetid
- *					rfc986				The AFI, vers and network part of
- *										internet address.
+ *					t37					The AFI and x.121
+ *(IDI) osinet				The AFI, orgid, snetid rfc986				The
+ *AFI, vers and network part of internet address.
  *
  * RETURNS:			number of bytes placed into buf.
  *
- * SIDE EFFECTS:	
+ * SIDE EFFECTS:
  *
  * NOTES:			Buf is assumed to be big enough
  */
-iso_netof(isoa, buf)
-struct iso_addr	*isoa;		/* address */
-caddr_t			buf;		/* RESULT: network portion of address here */
+iso_netof(isoa, buf) struct iso_addr *isoa; /* address */
+caddr_t buf;                                /* RESULT: network portion of address here */
 {
-	u_int		len = 1;	/* length of afi */
+    u_int len = 1; /* length of afi */
 
-	switch (isoa->isoa_afi) {
-		case AFI_37:
-			/*
-			 * Due to classic x.25 tunnel vision, there is no
-			 * net portion of an x.121 address.  For our purposes
-			 * the AFI will do, so that all x.25 -type addresses
-			 * map to the single x.25 SNPA. (Cannot have more than
-			 * one, obviously).
-			 */
+    switch (isoa->isoa_afi) {
+    case AFI_37:
+        /*
+         * Due to classic x.25 tunnel vision, there is no
+         * net portion of an x.121 address.  For our purposes
+         * the AFI will do, so that all x.25 -type addresses
+         * map to the single x.25 SNPA. (Cannot have more than
+         * one, obviously).
+         */
 
-			break;
+        break;
 
-/* 		case AFI_OSINET:*/
-		case AFI_RFC986: {
-			u_short	idi;	/* value of idi */
+        /* 		case AFI_OSINET:*/
+    case AFI_RFC986: {
+        u_short idi; /* value of idi */
 
-			/* osinet and rfc986 have idi in the same place */
-			CTOH(isoa->rfc986_idi[0], isoa->rfc986_idi[1], idi);
+        /* osinet and rfc986 have idi in the same place */
+        CTOH(isoa->rfc986_idi[0], isoa->rfc986_idi[1], idi);
 
-			if (idi == IDI_OSINET)
-/*
- *	Network portion of OSINET address can only be the IDI. Clearly,
- *	with one x25 interface, one could get to several orgids, and
- *	several snetids.
-				len += (ADDROSINET_IDI_LEN + OVLOSINET_ORGID_LEN + 
-						OVLOSINET_SNETID_LEN);
- */
-				len += ADDROSINET_IDI_LEN;
-			else if (idi == IDI_RFC986) {
-				u_long				inetaddr;
-				struct ovl_rfc986	*o986 = (struct ovl_rfc986 *)isoa;
+        if (idi == IDI_OSINET)
+            /*
+             *	Network portion of OSINET address can only be the IDI. Clearly,
+             *	with one x25 interface, one could get to several orgids, and
+             *	several snetids.
+                                            len += (ADDROSINET_IDI_LEN + OVLOSINET_ORGID_LEN +
+                                                            OVLOSINET_SNETID_LEN);
+             */
+            len += ADDROSINET_IDI_LEN;
+        else if (idi == IDI_RFC986) {
+            u_long inetaddr;
+            struct ovl_rfc986 *o986 = (struct ovl_rfc986 *)isoa;
 
-				/* bump len to include idi and version (1 byte) */
-				len += ADDRRFC986_IDI_LEN + 1;
+            /* bump len to include idi and version (1 byte) */
+            len += ADDRRFC986_IDI_LEN + 1;
 
-				/* get inet addr long aligned */
-				bcopy(o986->o986_inetaddr, &inetaddr, sizeof(inetaddr));
-				inetaddr = ntohl(inetaddr);	/* convert to host byte order */
+            /* get inet addr long aligned */
+            bcopy(o986->o986_inetaddr, &inetaddr, sizeof(inetaddr));
+            inetaddr = ntohl(inetaddr); /* convert to host byte order */
 
-				IFDEBUG(D_ROUTE)
-					printf("iso_netof: isoa ");
-					dump_buf(isoa, sizeof(*isoa));
-					printf("iso_netof: inetaddr 0x%x ", inetaddr);
-				ENDDEBUG
+            IFDEBUG(D_ROUTE)
+            printf("iso_netof: isoa ");
+            dump_buf(isoa, sizeof(*isoa));
+            printf("iso_netof: inetaddr 0x%x ", inetaddr);
+            ENDDEBUG
 
-				/* bump len by size of network portion of inet address */
-				if (IN_CLASSA(inetaddr)) {
-					len += 4-IN_CLASSA_NSHIFT/8;
-					IFDEBUG(D_ROUTE)
-						printf("iso_netof: class A net len is now %d\n", len);
-					ENDDEBUG
-				} else if (IN_CLASSB(inetaddr)) {
-					len += 4-IN_CLASSB_NSHIFT/8;
-					IFDEBUG(D_ROUTE)
-						printf("iso_netof: class B net len is now %d\n", len);
-					ENDDEBUG
-				} else {
-					len += 4-IN_CLASSC_NSHIFT/8;
-					IFDEBUG(D_ROUTE)
-						printf("iso_netof: class C net len is now %d\n", len);
-					ENDDEBUG
-				}
-			} else
-				len = 0;
-		} break;
+            /* bump len by size of network portion of inet address */
+            if (IN_CLASSA(inetaddr)) {
+                len += 4 - IN_CLASSA_NSHIFT / 8;
+                IFDEBUG(D_ROUTE)
+                printf("iso_netof: class A net len is now %d\n", len);
+                ENDDEBUG
+            } else if (IN_CLASSB(inetaddr)) {
+                len += 4 - IN_CLASSB_NSHIFT / 8;
+                IFDEBUG(D_ROUTE)
+                printf("iso_netof: class B net len is now %d\n", len);
+                ENDDEBUG
+            } else {
+                len += 4 - IN_CLASSC_NSHIFT / 8;
+                IFDEBUG(D_ROUTE)
+                printf("iso_netof: class C net len is now %d\n", len);
+                ENDDEBUG
+            }
+        } else
+            len = 0;
+    } break;
 
-		default:
-			len = 0;
-	}
+    default:
+        len = 0;
+    }
 
-	bcopy((caddr_t)isoa, buf, len);
-	IFDEBUG(D_ROUTE)
-		printf("iso_netof: isoa ");
-		dump_buf(isoa, len);
-		printf("iso_netof: net ");
-		dump_buf(buf, len);
-	ENDDEBUG
-	return len;
+    bcopy((caddr_t)isoa, buf, len);
+    IFDEBUG(D_ROUTE)
+    printf("iso_netof: isoa ");
+    dump_buf(isoa, len);
+    printf("iso_netof: net ");
+    dump_buf(buf, len);
+    ENDDEBUG
+    return len;
 }
 #endif /* notdef */
 /*
@@ -414,319 +404,302 @@ caddr_t			buf;		/* RESULT: network portion of address here */
  * Ifp is 0 if not an interface-specific ioctl.
  */
 /* ARGSUSED */
-iso_control(so, cmd, data, ifp)
-	struct socket *so;
-	int cmd;
-	caddr_t data;
-	register struct ifnet *ifp;
+iso_control(so, cmd, data, ifp) struct socket *so;
+int cmd;
+caddr_t data;
+register struct ifnet *ifp;
 {
-	register struct iso_ifreq *ifr = (struct iso_ifreq *)data;
-	register struct iso_ifaddr *ia = 0;
-	register struct ifaddr *ifa;
-	struct iso_ifaddr *oia;
-	struct iso_aliasreq *ifra = (struct iso_aliasreq *)data;
-	int error, hostIsNew, maskIsNew;
+    register struct iso_ifreq *ifr = (struct iso_ifreq *)data;
+    register struct iso_ifaddr *ia = 0;
+    register struct ifaddr *ifa;
+    struct iso_ifaddr *oia;
+    struct iso_aliasreq *ifra = (struct iso_aliasreq *)data;
+    int error, hostIsNew, maskIsNew;
 
-	/*
-	 * Find address for this interface, if it exists.
-	 */
-	if (ifp)
-		for (ia = iso_ifaddr; ia; ia = ia->ia_next)
-			if (ia->ia_ifp == ifp)
-				break;
+    /*
+     * Find address for this interface, if it exists.
+     */
+    if (ifp)
+        for (ia = iso_ifaddr; ia; ia = ia->ia_next)
+            if (ia->ia_ifp == ifp)
+                break;
 
-	switch (cmd) {
+    switch (cmd) {
 
-	case SIOCAIFADDR_ISO:
-	case SIOCDIFADDR_ISO:
-		if (ifra->ifra_addr.siso_family == AF_ISO)
-		    for (oia = ia; ia; ia = ia->ia_next) {
-			if (ia->ia_ifp == ifp  &&
-			    SAME_ISOADDR(&ia->ia_addr, &ifra->ifra_addr))
-				break;
-		}
-		if ((so->so_state & SS_PRIV) == 0)
-			return (EPERM);
-		if (ifp == 0)
-			panic("iso_control");
-		if (ia == (struct iso_ifaddr *)0) {
-			struct iso_ifaddr *nia;
-			if (cmd == SIOCDIFADDR_ISO)
-				return (EADDRNOTAVAIL);
+    case SIOCAIFADDR_ISO:
+    case SIOCDIFADDR_ISO:
+        if (ifra->ifra_addr.siso_family == AF_ISO)
+            for (oia = ia; ia; ia = ia->ia_next) {
+                if (ia->ia_ifp == ifp && SAME_ISOADDR(&ia->ia_addr, &ifra->ifra_addr))
+                    break;
+            }
+        if ((so->so_state & SS_PRIV) == 0)
+            return (EPERM);
+        if (ifp == 0)
+            panic("iso_control");
+        if (ia == (struct iso_ifaddr *)0) {
+            struct iso_ifaddr *nia;
+            if (cmd == SIOCDIFADDR_ISO)
+                return (EADDRNOTAVAIL);
 #ifdef TUBA
-			/* XXXXXX can't be done in the proto init routines */
-			if (tuba_tree == 0)
-				tuba_table_init();
+            /* XXXXXX can't be done in the proto init routines */
+            if (tuba_tree == 0)
+                tuba_table_init();
 #endif
-			MALLOC(nia, struct iso_ifaddr *, sizeof(*nia),
-				       M_IFADDR, M_WAITOK);
-			if (nia == (struct iso_ifaddr *)0)
-				return (ENOBUFS);
-			bzero((caddr_t)nia, sizeof(*nia));
-			if (ia = iso_ifaddr) {
-				for ( ; ia->ia_next; ia = ia->ia_next)
-					;
-				ia->ia_next = nia;
-			} else
-				iso_ifaddr = nia;
-			ia = nia;
-			if (ifa = ifp->if_addrlist) {
-				for ( ; ifa->ifa_next; ifa = ifa->ifa_next)
-					;
-				ifa->ifa_next = (struct ifaddr *) ia;
-			} else
-				ifp->if_addrlist = (struct ifaddr *) ia;
-			ia->ia_ifa.ifa_addr = (struct sockaddr *)&ia->ia_addr;
-			ia->ia_ifa.ifa_dstaddr
-					= (struct sockaddr *)&ia->ia_dstaddr;
-			ia->ia_ifa.ifa_netmask
-					= (struct sockaddr *)&ia->ia_sockmask;
-			ia->ia_ifp = ifp;
-			if (ifp != &loif)
-				iso_interfaces++;
-		}
-		break;
+            MALLOC(nia, struct iso_ifaddr *, sizeof(*nia), M_IFADDR, M_WAITOK);
+            if (nia == (struct iso_ifaddr *)0)
+                return (ENOBUFS);
+            bzero((caddr_t)nia, sizeof(*nia));
+            if (ia = iso_ifaddr) {
+                for (; ia->ia_next; ia = ia->ia_next)
+                    ;
+                ia->ia_next = nia;
+            } else
+                iso_ifaddr = nia;
+            ia = nia;
+            if (ifa = ifp->if_addrlist) {
+                for (; ifa->ifa_next; ifa = ifa->ifa_next)
+                    ;
+                ifa->ifa_next = (struct ifaddr *)ia;
+            } else
+                ifp->if_addrlist = (struct ifaddr *)ia;
+            ia->ia_ifa.ifa_addr = (struct sockaddr *)&ia->ia_addr;
+            ia->ia_ifa.ifa_dstaddr = (struct sockaddr *)&ia->ia_dstaddr;
+            ia->ia_ifa.ifa_netmask = (struct sockaddr *)&ia->ia_sockmask;
+            ia->ia_ifp = ifp;
+            if (ifp != &loif)
+                iso_interfaces++;
+        }
+        break;
 
-#define cmdbyte(x)	(((x) >> 8) & 0xff)
-	default:
-		if (cmdbyte(cmd) == 'a')
-			return (snpac_ioctl(so, cmd, data));
-		if (ia == (struct iso_ifaddr *)0)
-			return (EADDRNOTAVAIL);
-		break;
-	}
-	switch (cmd) {
+#define cmdbyte(x) (((x) >> 8) & 0xff)
+    default:
+        if (cmdbyte(cmd) == 'a')
+            return (snpac_ioctl(so, cmd, data));
+        if (ia == (struct iso_ifaddr *)0)
+            return (EADDRNOTAVAIL);
+        break;
+    }
+    switch (cmd) {
 
-	case SIOCGIFADDR_ISO:
-		ifr->ifr_Addr = ia->ia_addr;
-		break;
+    case SIOCGIFADDR_ISO:
+        ifr->ifr_Addr = ia->ia_addr;
+        break;
 
-	case SIOCGIFDSTADDR_ISO:
-		if ((ifp->if_flags & IFF_POINTOPOINT) == 0)
-			return (EINVAL);
-		ifr->ifr_Addr = ia->ia_dstaddr;
-		break;
+    case SIOCGIFDSTADDR_ISO:
+        if ((ifp->if_flags & IFF_POINTOPOINT) == 0)
+            return (EINVAL);
+        ifr->ifr_Addr = ia->ia_dstaddr;
+        break;
 
-	case SIOCGIFNETMASK_ISO:
-		ifr->ifr_Addr = ia->ia_sockmask;
-		break;
+    case SIOCGIFNETMASK_ISO:
+        ifr->ifr_Addr = ia->ia_sockmask;
+        break;
 
-	case SIOCAIFADDR_ISO:
-		maskIsNew = 0; hostIsNew = 1; error = 0;
-		if (ia->ia_addr.siso_family == AF_ISO) {
-			if (ifra->ifra_addr.siso_len == 0) {
-				ifra->ifra_addr = ia->ia_addr;
-				hostIsNew = 0;
-			} else if (SAME_ISOADDR(&ia->ia_addr, &ifra->ifra_addr))
-				hostIsNew = 0;
-		}
-		if (ifra->ifra_mask.siso_len) {
-			iso_ifscrub(ifp, ia);
-			ia->ia_sockmask = ifra->ifra_mask;
-			maskIsNew = 1;
-		}
-		if ((ifp->if_flags & IFF_POINTOPOINT) &&
-		    (ifra->ifra_dstaddr.siso_family == AF_ISO)) {
-			iso_ifscrub(ifp, ia);
-			ia->ia_dstaddr = ifra->ifra_dstaddr;
-			maskIsNew  = 1; /* We lie; but the effect's the same */
-		}
-		if (ifra->ifra_addr.siso_family == AF_ISO &&
-					    (hostIsNew || maskIsNew)) {
-			error = iso_ifinit(ifp, ia, &ifra->ifra_addr, 0);
-		}
-		if (ifra->ifra_snpaoffset)
-			ia->ia_snpaoffset = ifra->ifra_snpaoffset;
-		return (error);
+    case SIOCAIFADDR_ISO:
+        maskIsNew = 0;
+        hostIsNew = 1;
+        error = 0;
+        if (ia->ia_addr.siso_family == AF_ISO) {
+            if (ifra->ifra_addr.siso_len == 0) {
+                ifra->ifra_addr = ia->ia_addr;
+                hostIsNew = 0;
+            } else if (SAME_ISOADDR(&ia->ia_addr, &ifra->ifra_addr))
+                hostIsNew = 0;
+        }
+        if (ifra->ifra_mask.siso_len) {
+            iso_ifscrub(ifp, ia);
+            ia->ia_sockmask = ifra->ifra_mask;
+            maskIsNew = 1;
+        }
+        if ((ifp->if_flags & IFF_POINTOPOINT) && (ifra->ifra_dstaddr.siso_family == AF_ISO)) {
+            iso_ifscrub(ifp, ia);
+            ia->ia_dstaddr = ifra->ifra_dstaddr;
+            maskIsNew = 1; /* We lie; but the effect's the same */
+        }
+        if (ifra->ifra_addr.siso_family == AF_ISO && (hostIsNew || maskIsNew)) {
+            error = iso_ifinit(ifp, ia, &ifra->ifra_addr, 0);
+        }
+        if (ifra->ifra_snpaoffset)
+            ia->ia_snpaoffset = ifra->ifra_snpaoffset;
+        return (error);
 
-	case SIOCDIFADDR_ISO:
-		iso_ifscrub(ifp, ia);
-		if ((ifa = ifp->if_addrlist) == (struct ifaddr *)ia)
-			ifp->if_addrlist = ifa->ifa_next;
-		else {
-			while (ifa->ifa_next &&
-			       (ifa->ifa_next != (struct ifaddr *)ia))
-				    ifa = ifa->ifa_next;
-			if (ifa->ifa_next)
-			    ifa->ifa_next = ((struct ifaddr *)ia)->ifa_next;
-			else
-				printf("Couldn't unlink isoifaddr from ifp\n");
-		}
-		oia = ia;
-		if (oia == (ia = iso_ifaddr)) {
-			iso_ifaddr = ia->ia_next;
-		} else {
-			while (ia->ia_next && (ia->ia_next != oia)) {
-				ia = ia->ia_next;
-			}
-			if (ia->ia_next)
-			    ia->ia_next = oia->ia_next;
-			else
-				printf("Didn't unlink isoifadr from list\n");
-		}
-		IFAFREE((&oia->ia_ifa));
-		break;
+    case SIOCDIFADDR_ISO:
+        iso_ifscrub(ifp, ia);
+        if ((ifa = ifp->if_addrlist) == (struct ifaddr *)ia)
+            ifp->if_addrlist = ifa->ifa_next;
+        else {
+            while (ifa->ifa_next && (ifa->ifa_next != (struct ifaddr *)ia))
+                ifa = ifa->ifa_next;
+            if (ifa->ifa_next)
+                ifa->ifa_next = ((struct ifaddr *)ia)->ifa_next;
+            else
+                printf("Couldn't unlink isoifaddr from ifp\n");
+        }
+        oia = ia;
+        if (oia == (ia = iso_ifaddr)) {
+            iso_ifaddr = ia->ia_next;
+        } else {
+            while (ia->ia_next && (ia->ia_next != oia)) {
+                ia = ia->ia_next;
+            }
+            if (ia->ia_next)
+                ia->ia_next = oia->ia_next;
+            else
+                printf("Didn't unlink isoifadr from list\n");
+        }
+        IFAFREE((&oia->ia_ifa));
+        break;
 
-	default:
-		if (ifp == 0 || ifp->if_ioctl == 0)
-			return (EOPNOTSUPP);
-		return ((*ifp->if_ioctl)(ifp, cmd, data));
-	}
-	return (0);
+    default:
+        if (ifp == 0 || ifp->if_ioctl == 0)
+            return (EOPNOTSUPP);
+        return ((*ifp->if_ioctl)(ifp, cmd, data));
+    }
+    return (0);
 }
 
 /*
  * Delete any existing route for an interface.
  */
-iso_ifscrub(ifp, ia)
-	register struct ifnet *ifp;
-	register struct iso_ifaddr *ia;
+iso_ifscrub(ifp, ia) register struct ifnet *ifp;
+register struct iso_ifaddr *ia;
 {
-	int nsellength = ia->ia_addr.siso_tlen;
-	if ((ia->ia_flags & IFA_ROUTE) == 0)
-		return;
-	ia->ia_addr.siso_tlen = 0;
-	if (ifp->if_flags & IFF_LOOPBACK)
-		rtinit(&(ia->ia_ifa), (int)RTM_DELETE, RTF_HOST);
-	else if (ifp->if_flags & IFF_POINTOPOINT)
-		rtinit(&(ia->ia_ifa), (int)RTM_DELETE, RTF_HOST);
-	else {
-		rtinit(&(ia->ia_ifa), (int)RTM_DELETE, 0);
-	}
-	ia->ia_addr.siso_tlen = nsellength;
-	ia->ia_flags &= ~IFA_ROUTE;
+    int nsellength = ia->ia_addr.siso_tlen;
+    if ((ia->ia_flags & IFA_ROUTE) == 0)
+        return;
+    ia->ia_addr.siso_tlen = 0;
+    if (ifp->if_flags & IFF_LOOPBACK)
+        rtinit(&(ia->ia_ifa), (int)RTM_DELETE, RTF_HOST);
+    else if (ifp->if_flags & IFF_POINTOPOINT)
+        rtinit(&(ia->ia_ifa), (int)RTM_DELETE, RTF_HOST);
+    else {
+        rtinit(&(ia->ia_ifa), (int)RTM_DELETE, 0);
+    }
+    ia->ia_addr.siso_tlen = nsellength;
+    ia->ia_flags &= ~IFA_ROUTE;
 }
 
 /*
  * Initialize an interface's internet address
  * and routing table entry.
  */
-iso_ifinit(ifp, ia, siso, scrub)
-	register struct ifnet *ifp;
-	register struct iso_ifaddr *ia;
-	struct sockaddr_iso *siso;
+iso_ifinit(ifp, ia, siso, scrub) register struct ifnet *ifp;
+register struct iso_ifaddr *ia;
+struct sockaddr_iso *siso;
 {
-	struct sockaddr_iso oldaddr;
-	int s = splimp(), error, nsellength;
+    struct sockaddr_iso oldaddr;
+    int s = splimp(), error, nsellength;
 
-	oldaddr = ia->ia_addr;
-	ia->ia_addr = *siso;
-	/*
-	 * Give the interface a chance to initialize
-	 * if this is its first address,
-	 * and to validate the address if necessary.
-	 */
-	if (ifp->if_ioctl &&
-				(error = (*ifp->if_ioctl)(ifp, SIOCSIFADDR, (caddr_t)ia))) {
-		splx(s);
-		ia->ia_addr = oldaddr;
-		return (error);
-	}
-	if (scrub) {
-		ia->ia_ifa.ifa_addr = (struct sockaddr *)&oldaddr;
-		iso_ifscrub(ifp, ia);
-		ia->ia_ifa.ifa_addr = (struct sockaddr *)&ia->ia_addr;
-	}
-	/* XXX -- The following is here temporarily out of laziness
-	   in not changing every ethernet driver's if_ioctl routine */
-	if (ifp->if_output == ether_output) {
-		ia->ia_ifa.ifa_rtrequest = llc_rtrequest;
-		ia->ia_ifa.ifa_flags |= RTF_CLONING;
-	}
-	/*
-	 * Add route for the network.
-	 */
-	nsellength = ia->ia_addr.siso_tlen;
-	ia->ia_addr.siso_tlen = 0;
-	if (ifp->if_flags & IFF_LOOPBACK) {
-		ia->ia_ifa.ifa_dstaddr = ia->ia_ifa.ifa_addr;
-		error = rtinit(&(ia->ia_ifa), (int)RTM_ADD, RTF_HOST|RTF_UP);
-	} else if (ifp->if_flags & IFF_POINTOPOINT &&
-		 ia->ia_dstaddr.siso_family == AF_ISO)
-		error = rtinit(&(ia->ia_ifa), (int)RTM_ADD, RTF_HOST|RTF_UP);
-	else {
-		rt_maskedcopy(ia->ia_ifa.ifa_addr, ia->ia_ifa.ifa_dstaddr,
-			ia->ia_ifa.ifa_netmask);
-		ia->ia_dstaddr.siso_nlen =
-			min(ia->ia_addr.siso_nlen, (ia->ia_sockmask.siso_len - 6));
-		error = rtinit(&(ia->ia_ifa), (int)RTM_ADD, RTF_UP);
-	}
-	ia->ia_addr.siso_tlen = nsellength;
-	ia->ia_flags |= IFA_ROUTE;
-	splx(s);
-	return (error);
+    oldaddr = ia->ia_addr;
+    ia->ia_addr = *siso;
+    /*
+     * Give the interface a chance to initialize
+     * if this is its first address,
+     * and to validate the address if necessary.
+     */
+    if (ifp->if_ioctl && (error = (*ifp->if_ioctl)(ifp, SIOCSIFADDR, (caddr_t)ia))) {
+        splx(s);
+        ia->ia_addr = oldaddr;
+        return (error);
+    }
+    if (scrub) {
+        ia->ia_ifa.ifa_addr = (struct sockaddr *)&oldaddr;
+        iso_ifscrub(ifp, ia);
+        ia->ia_ifa.ifa_addr = (struct sockaddr *)&ia->ia_addr;
+    }
+    /* XXX -- The following is here temporarily out of laziness
+       in not changing every ethernet driver's if_ioctl routine */
+    if (ifp->if_output == ether_output) {
+        ia->ia_ifa.ifa_rtrequest = llc_rtrequest;
+        ia->ia_ifa.ifa_flags |= RTF_CLONING;
+    }
+    /*
+     * Add route for the network.
+     */
+    nsellength = ia->ia_addr.siso_tlen;
+    ia->ia_addr.siso_tlen = 0;
+    if (ifp->if_flags & IFF_LOOPBACK) {
+        ia->ia_ifa.ifa_dstaddr = ia->ia_ifa.ifa_addr;
+        error = rtinit(&(ia->ia_ifa), (int)RTM_ADD, RTF_HOST | RTF_UP);
+    } else if (ifp->if_flags & IFF_POINTOPOINT && ia->ia_dstaddr.siso_family == AF_ISO)
+        error = rtinit(&(ia->ia_ifa), (int)RTM_ADD, RTF_HOST | RTF_UP);
+    else {
+        rt_maskedcopy(ia->ia_ifa.ifa_addr, ia->ia_ifa.ifa_dstaddr, ia->ia_ifa.ifa_netmask);
+        ia->ia_dstaddr.siso_nlen = min(ia->ia_addr.siso_nlen, (ia->ia_sockmask.siso_len - 6));
+        error = rtinit(&(ia->ia_ifa), (int)RTM_ADD, RTF_UP);
+    }
+    ia->ia_addr.siso_tlen = nsellength;
+    ia->ia_flags |= IFA_ROUTE;
+    splx(s);
+    return (error);
 }
 #ifdef notdef
 
-struct ifaddr *
-iso_ifwithidi(addr)
-	register struct sockaddr *addr;
+struct ifaddr *iso_ifwithidi(addr)
+register struct sockaddr *addr;
 {
-	register struct ifnet *ifp;
-	register struct ifaddr *ifa;
-	register u_int af = addr->sa_family;
+    register struct ifnet *ifp;
+    register struct ifaddr *ifa;
+    register u_int af = addr->sa_family;
 
-	if (af != AF_ISO)
-		return (0);
-	IFDEBUG(D_ROUTE)
-		printf(">>> iso_ifwithidi addr\n");
-		dump_isoaddr( (struct sockaddr_iso *)(addr));
-		printf("\n");
-	ENDDEBUG
-	for (ifp = ifnet; ifp; ifp = ifp->if_next) {
-		IFDEBUG(D_ROUTE)
-			printf("iso_ifwithidi ifnet %s\n", ifp->if_name);
-		ENDDEBUG
-		for (ifa = ifp->if_addrlist; ifa; ifa = ifa->ifa_next) {
-			IFDEBUG(D_ROUTE)
-				printf("iso_ifwithidi address ");
-				dump_isoaddr( (struct sockaddr_iso *)(ifa->ifa_addr));
-			ENDDEBUG
-			if (ifa->ifa_addr->sa_family != addr->sa_family)
-				continue;
+    if (af != AF_ISO)
+        return (0);
+    IFDEBUG(D_ROUTE)
+    printf(">>> iso_ifwithidi addr\n");
+    dump_isoaddr((struct sockaddr_iso *)(addr));
+    printf("\n");
+    ENDDEBUG
+    for (ifp = ifnet; ifp; ifp = ifp->if_next) {
+        IFDEBUG(D_ROUTE)
+        printf("iso_ifwithidi ifnet %s\n", ifp->if_name);
+        ENDDEBUG
+        for (ifa = ifp->if_addrlist; ifa; ifa = ifa->ifa_next) {
+            IFDEBUG(D_ROUTE)
+            printf("iso_ifwithidi address ");
+            dump_isoaddr((struct sockaddr_iso *)(ifa->ifa_addr));
+            ENDDEBUG
+            if (ifa->ifa_addr->sa_family != addr->sa_family)
+                continue;
 
-#define	IFA_SIS(ifa)\
-	((struct sockaddr_iso *)((ifa)->ifa_addr))
+#define IFA_SIS(ifa) ((struct sockaddr_iso *)((ifa)->ifa_addr))
 
-			IFDEBUG(D_ROUTE)
-				printf(" af same, args to iso_eqtype:\n");
-				printf("0x%x ", IFA_SIS(ifa)->siso_addr);
-				printf(" 0x%x\n",
-				&(((struct sockaddr_iso *)addr)->siso_addr));
-			ENDDEBUG
+            IFDEBUG(D_ROUTE)
+            printf(" af same, args to iso_eqtype:\n");
+            printf("0x%x ", IFA_SIS(ifa)->siso_addr);
+            printf(" 0x%x\n", &(((struct sockaddr_iso *)addr)->siso_addr));
+            ENDDEBUG
 
-			if (iso_eqtype(&(IFA_SIS(ifa)->siso_addr), 
-				&(((struct sockaddr_iso *)addr)->siso_addr))) {
-				IFDEBUG(D_ROUTE)
-					printf("ifa_ifwithidi: ifa found\n");
-				ENDDEBUG
-				return (ifa);
-			}
-			IFDEBUG(D_ROUTE)
-				printf(" iso_eqtype failed\n");
-			ENDDEBUG
-		}
-	}
-	return ((struct ifaddr *)0);
+            if (iso_eqtype(&(IFA_SIS(ifa)->siso_addr),
+                           &(((struct sockaddr_iso *)addr)->siso_addr))) {
+                IFDEBUG(D_ROUTE)
+                printf("ifa_ifwithidi: ifa found\n");
+                ENDDEBUG
+                return (ifa);
+            }
+            IFDEBUG(D_ROUTE)
+            printf(" iso_eqtype failed\n");
+            ENDDEBUG
+        }
+    }
+    return ((struct ifaddr *)0);
 }
 
 #endif /* notdef */
 /*
  * FUNCTION:		iso_ck_addr
  *
- * PURPOSE:			return true if the iso_addr passed is 
+ * PURPOSE:			return true if the iso_addr passed is
  *					within the legal size limit for an iso address.
  *
  * RETURNS:			true or false
  *
- * SIDE EFFECTS:	
+ * SIDE EFFECTS:
  *
  */
-iso_ck_addr(isoa)
-struct iso_addr	*isoa;	/* address to check */
+iso_ck_addr(isoa) struct iso_addr *isoa; /* address to check */
 {
-	return (isoa->isoa_len <= 20);
-
+    return (isoa->isoa_len <= 20);
 }
 
 #ifdef notdef
@@ -740,24 +713,23 @@ struct iso_addr	*isoa;	/* address to check */
  *
  * RETURNS:			true if the addresses are the same type
  *
- * SIDE EFFECTS:	
+ * SIDE EFFECTS:
  *
  * NOTES:			By type, I mean rfc986, t37, or osinet
  *
  *					This will first compare afis. If they match, then
  *					if the addr is not t37, the idis must be compared.
  */
-iso_eqtype(isoaa, isoab)
-struct iso_addr	*isoaa;		/* first addr to check */
-struct iso_addr	*isoab;		/* other addr to check */
+iso_eqtype(isoaa, isoab) struct iso_addr *isoaa; /* first addr to check */
+struct iso_addr *isoab;                          /* other addr to check */
 {
-	if (isoaa->isoa_afi == isoab->isoa_afi) {
-		if (isoaa->isoa_afi == AFI_37)
-			return(1);
-		else 
-			return (!bcmp(&isoaa->isoa_u, &isoab->isoa_u, 2));
-	}
-	return(0);
+    if (isoaa->isoa_afi == isoab->isoa_afi) {
+        if (isoaa->isoa_afi == AFI_37)
+            return (1);
+        else
+            return (!bcmp(&isoaa->isoa_u, &isoab->isoa_u, 2));
+    }
+    return (0);
 }
 #endif /* notdef */
 /*
@@ -766,56 +738,53 @@ struct iso_addr	*isoab;		/* other addr to check */
  * PURPOSE:			Find an interface addresss having a given destination
  *					or at least matching the net.
  *
- * RETURNS:			ptr to an interface address 
+ * RETURNS:			ptr to an interface address
  *
- * SIDE EFFECTS:	
+ * SIDE EFFECTS:
  *
- * NOTES:			
+ * NOTES:
  */
-struct iso_ifaddr *
-iso_localifa(siso)
-	register struct sockaddr_iso *siso;
+struct iso_ifaddr *iso_localifa(siso)
+register struct sockaddr_iso *siso;
 {
-	register struct iso_ifaddr *ia;
-	register char *cp1, *cp2, *cp3;
-	register struct ifnet *ifp;
-	struct iso_ifaddr *ia_maybe = 0;
-	/*
-	 * We make one pass looking for both net matches and an exact
-	 * dst addr.
-	 */
-	for (ia = iso_ifaddr; ia; ia = ia->ia_next) {
-		if ((ifp = ia->ia_ifp) == 0 || ((ifp->if_flags & IFF_UP) == 0))
-			continue;
-		if (ifp->if_flags & IFF_POINTOPOINT) {
-			if ((ia->ia_dstaddr.siso_family == AF_ISO) &&
-				SAME_ISOADDR(&ia->ia_dstaddr, siso))
-				return (ia);
-			else
-				if (SAME_ISOADDR(&ia->ia_addr, siso))
-					ia_maybe = ia;
-			continue;
-		}
-		if (ia->ia_sockmask.siso_len) {
-			char *cplim = ia->ia_sockmask.siso_len + (char *)&ia->ia_sockmask;
-			cp1 = ia->ia_sockmask.siso_data;
-			cp2 = siso->siso_data;
-			cp3 = ia->ia_addr.siso_data;
-			while (cp1 < cplim)
-				if (*cp1++ & (*cp2++ ^ *cp3++))
-					goto next;
-			ia_maybe = ia;
-		}
-		if (SAME_ISOADDR(&ia->ia_addr, siso))
-			return ia;
-	next:;
-	}
-	return ia_maybe;
+    register struct iso_ifaddr *ia;
+    register char *cp1, *cp2, *cp3;
+    register struct ifnet *ifp;
+    struct iso_ifaddr *ia_maybe = 0;
+    /*
+     * We make one pass looking for both net matches and an exact
+     * dst addr.
+     */
+    for (ia = iso_ifaddr; ia; ia = ia->ia_next) {
+        if ((ifp = ia->ia_ifp) == 0 || ((ifp->if_flags & IFF_UP) == 0))
+            continue;
+        if (ifp->if_flags & IFF_POINTOPOINT) {
+            if ((ia->ia_dstaddr.siso_family == AF_ISO) && SAME_ISOADDR(&ia->ia_dstaddr, siso))
+                return (ia);
+            else if (SAME_ISOADDR(&ia->ia_addr, siso))
+                ia_maybe = ia;
+            continue;
+        }
+        if (ia->ia_sockmask.siso_len) {
+            char *cplim = ia->ia_sockmask.siso_len + (char *)&ia->ia_sockmask;
+            cp1 = ia->ia_sockmask.siso_data;
+            cp2 = siso->siso_data;
+            cp3 = ia->ia_addr.siso_data;
+            while (cp1 < cplim)
+                if (*cp1++ & (*cp2++ ^ *cp3++))
+                    goto next;
+            ia_maybe = ia;
+        }
+        if (SAME_ISOADDR(&ia->ia_addr, siso))
+            return ia;
+    next:;
+    }
+    return ia_maybe;
 }
 
-#ifdef	TPCONS
+#ifdef TPCONS
 #include <netiso/cons.h>
-#endif	/* TPCONS */
+#endif /* TPCONS */
 /*
  * FUNCTION:		iso_nlctloutput
  *
@@ -823,67 +792,65 @@ iso_localifa(siso)
  *
  * RETURNS:			E*
  *
- * SIDE EFFECTS:	
+ * SIDE EFFECTS:
  *
  * NOTES:			This could embody some of the functions of
  *					rclnp_ctloutput and cons_ctloutput.
  */
-iso_nlctloutput(cmd, optname, pcb, m)
-int			cmd;		/* command:set or get */
-int			optname;	/* option of interest */
-caddr_t		pcb;		/* nl pcb */
-struct mbuf	*m;			/* data for set, buffer for get */
+iso_nlctloutput(cmd, optname, pcb, m) int cmd; /* command:set or get */
+int optname;                                   /* option of interest */
+caddr_t pcb;                                   /* nl pcb */
+struct mbuf *m;                                /* data for set, buffer for get */
 {
-	struct isopcb	*isop = (struct isopcb *)pcb;
-	int				error = 0;	/* return value */
-	caddr_t			data;		/* data for option */
-	int				data_len;	/* data's length */
+    struct isopcb *isop = (struct isopcb *)pcb;
+    int error = 0; /* return value */
+    caddr_t data;  /* data for option */
+    int data_len;  /* data's length */
 
-	IFDEBUG(D_ISO)
-		printf("iso_nlctloutput: cmd %x, opt %x, pcb %x, m %x\n",
-			cmd, optname, pcb, m);
-	ENDDEBUG
+    IFDEBUG(D_ISO)
+    printf("iso_nlctloutput: cmd %x, opt %x, pcb %x, m %x\n", cmd, optname, pcb, m);
+    ENDDEBUG
 
-	if ((cmd != PRCO_GETOPT) && (cmd != PRCO_SETOPT))
-		return(EOPNOTSUPP);
+    if ((cmd != PRCO_GETOPT) && (cmd != PRCO_SETOPT))
+        return (EOPNOTSUPP);
 
-	data = mtod(m, caddr_t);
-	data_len = (m)->m_len;
+    data = mtod(m, caddr_t);
+    data_len = (m)->m_len;
 
-	IFDEBUG(D_ISO)
-		printf("iso_nlctloutput: data is:\n");
-		dump_buf(data, data_len);
-	ENDDEBUG
+    IFDEBUG(D_ISO)
+    printf("iso_nlctloutput: data is:\n");
+    dump_buf(data, data_len);
+    ENDDEBUG
 
-	switch (optname) {
+    switch (optname) {
 
-#ifdef	TPCONS
-		case CONSOPT_X25CRUD:
-			if (cmd == PRCO_GETOPT) {
-				error = EOPNOTSUPP;
-				break;
-			}
+#ifdef TPCONS
+    case CONSOPT_X25CRUD:
+        if (cmd == PRCO_GETOPT) {
+            error = EOPNOTSUPP;
+            break;
+        }
 
-			if (data_len > MAXX25CRUDLEN) {
-				error = EINVAL;
-				break;
-			}
+        if (data_len > MAXX25CRUDLEN) {
+            error = EINVAL;
+            break;
+        }
 
-			IFDEBUG(D_ISO)
-				printf("iso_nlctloutput: setting x25 crud\n");
-			ENDDEBUG
+        IFDEBUG(D_ISO)
+        printf("iso_nlctloutput: setting x25 crud\n");
+        ENDDEBUG
 
-			bcopy(data, (caddr_t)isop->isop_x25crud, (unsigned)data_len);
-			isop->isop_x25crud_len = data_len;
-			break;
-#endif	/* TPCONS */
+        bcopy(data, (caddr_t)isop->isop_x25crud, (unsigned)data_len);
+        isop->isop_x25crud_len = data_len;
+        break;
+#endif /* TPCONS */
 
-		default:
-			error = EOPNOTSUPP;
-	}
-	if (cmd == PRCO_SETOPT)
-		m_freem(m);
-	return error;
+    default:
+        error = EOPNOTSUPP;
+    }
+    if (cmd == PRCO_SETOPT)
+        m_freem(m);
+    return error;
 }
 #endif /* ISO */
 
@@ -894,29 +861,24 @@ struct mbuf	*m;			/* data for set, buffer for get */
  *
  * PURPOSE:			debugging
  *
- * RETURNS:			nada 
+ * RETURNS:			nada
  *
  */
-dump_isoaddr(s)
-	struct sockaddr_iso *s;
+dump_isoaddr(s) struct sockaddr_iso *s;
 {
-	char *clnp_saddr_isop();
-	register int i;
+    char *clnp_saddr_isop();
+    register int i;
 
-	if( s->siso_family == AF_ISO) {
-		printf("ISO address: suffixlen %d, %s\n",
-			s->siso_tlen, clnp_saddr_isop(s));
-	} else if( s->siso_family == AF_INET) {
-		/* hack */
-		struct sockaddr_in *sin = (struct sockaddr_in *)s;
+    if (s->siso_family == AF_ISO) {
+        printf("ISO address: suffixlen %d, %s\n", s->siso_tlen, clnp_saddr_isop(s));
+    } else if (s->siso_family == AF_INET) {
+        /* hack */
+        struct sockaddr_in *sin = (struct sockaddr_in *)s;
 
-		printf("%d.%d.%d.%d: %d", 
-			(sin->sin_addr.s_addr>>24)&0xff,
-			(sin->sin_addr.s_addr>>16)&0xff,
-			(sin->sin_addr.s_addr>>8)&0xff,
-			(sin->sin_addr.s_addr)&0xff,
-			sin->sin_port);
-	}
+        printf("%d.%d.%d.%d: %d", (sin->sin_addr.s_addr >> 24) & 0xff,
+               (sin->sin_addr.s_addr >> 16) & 0xff, (sin->sin_addr.s_addr >> 8) & 0xff,
+               (sin->sin_addr.s_addr) & 0xff, sin->sin_port);
+    }
 }
 
 #endif /* ARGO_DEBUG */

--- a/server/serv/server_defs.h
+++ b/server/serv/server_defs.h
@@ -1,14 +1,14 @@
-/* 
+/*
  * Mach Operating System
  * Copyright (c) 1994 Johannes Helander
  * All Rights Reserved.
- * 
+ *
  * Permission to use, copy, modify and distribute this software and its
  * documentation is hereby granted, provided that both the copyright
  * notice and this permission notice appear in all copies of the
  * software, derivative works or modified versions, and any portions
  * thereof, and that both notices appear in supporting documentation.
- * 
+ *
  * JOHANNES HELANDER ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
  * CONDITION.  JOHANNES HELANDER DISCLAIMS ANY LIABILITY OF ANY KIND
  * FOR ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
@@ -20,7 +20,7 @@
  * lites-950323 from jvh.
  *
  */
-/* 
+/*
  *	File:	server_defs.h
  *	Author:	Johannes Helander, Helsinki University of Technology, 1994.
  *	Date:	February 1994
@@ -45,21 +45,19 @@
 #include <sys/cmu_queue.h>
 #include <sys/zalloc.h>
 
+#include <serv/port_object.h>
+#include <serv/timer.h>
 #include <sys/cdefs.h>
-#include <stdnoreturn.h>
 #include <sys/errno.h>
-#include <sys/time.h>
-#include <sys/resource.h>
-#include <sys/types.h>
+#include <sys/parallel.h>
 #include <sys/param.h>
+#include <sys/proc.h>
+#include <sys/resource.h>
+#include <sys/resourcevar.h>
+#include <sys/time.h>
+#include <sys/types.h>
 #include <sys/ucred.h>
 #include <sys/uio.h>
-#include <sys/ucred.h>
-#include <sys/resourcevar.h>
-#include <sys/proc.h>
-#include <serv/timer.h>
-#include <serv/port_object.h>
-#include <sys/parallel.h>
 #include <sys/vnode.h>
 
 /* TYPES */
@@ -67,7 +65,7 @@
 /* PROTOTYPES */
 
 /* serv_fork.c */
-struct proc * newproc(struct proc *, boolean_t, boolean_t);
+struct proc *newproc(struct proc *, boolean_t, boolean_t);
 
 /* proc_to_task.c */
 mach_port_t task_to_proc_enter(task_t, struct proc *);
@@ -89,26 +87,21 @@ void thread_remove_reverse(struct proc *p, mach_port_t port);
 
 /* server_exec.c */
 int machid_register_process(struct proc *);
-mach_error_t secure_execve(struct proc *, char *, vm_address_t, vm_size_t,
-			   int, int);
-mach_error_t after_exec(struct proc *, vm_address_t *, vm_size_t *, int *,
-			int *, char *, mach_msg_type_number_t *, char *,
-			mach_msg_type_number_t *, char *,
-			mach_msg_type_number_t *, char *,
-			mach_msg_type_number_t *, mach_port_t *);
-
+mach_error_t secure_execve(struct proc *, char *, vm_address_t, vm_size_t, int, int);
+mach_error_t after_exec(struct proc *, vm_address_t *, vm_size_t *, int *, int *, char *,
+                        mach_msg_type_number_t *, char *, mach_msg_type_number_t *, char *,
+                        mach_msg_type_number_t *, char *, mach_msg_type_number_t *, mach_port_t *);
 
 void *malloc(size_t);
 void free(void *);
 
 /* vm_syscalls.c */
-kern_return_t mmap_vm_map(struct proc *, vm_address_t, vm_size_t, boolean_t,
-			  mach_port_t, vm_offset_t, boolean_t, vm_prot_t,
-			  vm_prot_t, vm_inherit_t, vm_address_t *);
+kern_return_t mmap_vm_map(struct proc *, vm_address_t, vm_size_t, boolean_t, mach_port_t,
+                          vm_offset_t, boolean_t, vm_prot_t, vm_prot_t, vm_inherit_t,
+                          vm_address_t *);
 
-mach_error_t file_vm_map(struct proc *, vm_address_t *, vm_size_t,
-			 vm_address_t, boolean_t, struct file *, vm_offset_t,
-			 boolean_t, vm_prot_t, vm_prot_t, vm_inherit_t);
+mach_error_t file_vm_map(struct proc *, vm_address_t *, vm_size_t, vm_address_t, boolean_t,
+                         struct file *, vm_offset_t, boolean_t, vm_prot_t, vm_prot_t, vm_inherit_t);
 
 /* GLOBALS */
 extern mach_port_t default_pager_port;


### PR DESCRIPTION
## Summary
- detect SIMD support in new `simd.h`
- implement `simd_bcmp` with AVX2/SSE2/NEON fallbacks
- use new profiling macros in CLNP and TCP code
- unroll tcpVAll loops
- vectorize address compares in `iso_addrmatch1`
- apply standard attributes in headers

## Testing
- `scripts/run-clang-tidy.sh -checks=modernize-use-nodiscard server/netiso/iso.c` *(fails: could not load compilation database)*