### PR TITLE
Enable automatic clang tooling database

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(lites LANGUAGES C)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL "Export compile commands")
 set(CMAKE_C_STANDARD 23)
 find_package(BISON)
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ You can also invoke `scripts/run-precommit.sh` which automatically installs
 The clang-tidy hooks rely on `scripts/run-clang-tidy.sh`.  This helper
 ensures a `compile_commands.json` database is generated on demand so
 clang-tidy can analyse the sources even before the project has been built.
+The top-level `CMakeLists.txt` now enables `CMAKE_EXPORT_COMPILE_COMMANDS`
+so the compile database is produced whenever the project is configured.
 
 To try the built binaries under QEMU use `scripts/run-qemu.sh`.  The script
 launches the `lites_server` (and the optional `lites_emulator` when present)

--- a/scripts/run-clang-tidy.sh
+++ b/scripts/run-clang-tidy.sh
@@ -4,13 +4,17 @@ set -euo pipefail
 # Ensure a compile_commands.json exists
 compdb="compile_commands.json"
 if [ ! -f "$compdb" ]; then
-  echo "[run-clang-tidy] Generating $compdb via CMake" >&2
-  if cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON >/dev/null 2>&1; then
-    if [ -f build/compile_commands.json ]; then
-      ln -sf build/compile_commands.json "$compdb"
-    fi
+  if [ -f build/compile_commands.json ]; then
+    ln -sf build/compile_commands.json "$compdb"
   else
-    echo "[run-clang-tidy] Warning: failed to generate compilation database" >&2
+    echo "[run-clang-tidy] Generating $compdb via CMake" >&2
+    if cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON >/dev/null 2>&1; then
+      if [ -f build/compile_commands.json ]; then
+        ln -sf build/compile_commands.json "$compdb"
+      fi
+    else
+      echo "[run-clang-tidy] Warning: failed to generate compilation database" >&2
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Summary
- generate `compile_commands.json` when configuring with CMake
- mention the new behavior in the README
- improve `run-clang-tidy.sh` to reuse an existing build database

## Testing
- `scripts/run-precommit.sh --version` *(fails: pre-commit not installed and network is unavailable)*