### PR TITLE
Clean up references to obsolete header inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,18 +75,9 @@ cmake -B build -DLITES_MACH_DIR=openmach \
       -DLITES_MACH_LIB_DIR=openmach/lib
 cmake --build build
 ```
-
 ## Header inventory
 
-The repository contains many header files spread across historical trees.
-Their paths are listed in [headers_inventory.csv](headers_inventory.csv) for
-easy reference. Each row in the CSV shows the path to a header relative to the
-repository root.
-
-To gather all these headers into a single directory run
-`scripts/flatten-headers.sh`. The script copies every header into the
-`flattened_include/` directory and automatically renames duplicates by
-embedding the original path in the filename.
+Use `scripts/flatten-headers.sh` to gather all header files from across the repository. The script copies each header into the `flattened_include/` directory and automatically renames duplicates by embedding the original path in the filename.
 
 ## Building
 

--- a/docs/POSIX_ROADMAP.md
+++ b/docs/POSIX_ROADMAP.md
@@ -12,10 +12,8 @@ missing pieces.
   `Makefile.new` and CMake support for the `src-lites-1.1-2025` tree.
   Additional tooling such as Meson is planned but not yet present.
   Cross‑compilation helpers live in `setup.sh`.
-* **Header consolidation** – The `headers_inventory.csv` file and the
-  `scripts/flatten-headers.sh` script aid in gathering headers from the
-  historical sources.  Modernisation tasks include re‑enabling
-  architectures beyond x86 and cleaning up obsolete prototypes.
+* **Header consolidation** – The `scripts/flatten-headers.sh` script gathers headers from the historical sources.
+  Modernisation tasks include re‑enabling architectures beyond x86 and cleaning up obsolete prototypes.
 * **Documentation pipeline** – Existing documentation resides under
   `docs/` with topics such as [`MODERNIZATION.md`](MODERNIZATION.md)
   and [`POSIX.md`](POSIX.md).


### PR DESCRIPTION
## Summary
- remove outdated mention of `headers_inventory.csv`
- explain `flatten-headers.sh` on its own
- drop CSV reference in POSIX roadmap

## Testing
- `pre-commit` *(fails: command not found)*