### PR TITLE
cleanup: drop stale src-lites-1.1-2025 references

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,9 @@ jobs:
 
       - name: Build tests
         run: |
-          make -C src-lites-1.1-2025/bin/user_pager CC=${{ matrix.cc }}
+          if [ -d "${LITES_SRC_DIR:-src-lites-1.1-2025}/bin/user_pager" ]; then
+            make -C "${LITES_SRC_DIR:-src-lites-1.1-2025}/bin/user_pager" CC=${{ matrix.cc }}
+          fi
           make -C tests/audit CC=${{ matrix.cc }}
           make -C tests/cap CC=${{ matrix.cc }}
           make -C tests/iommu CC=${{ matrix.cc }}

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ make
 
 For the modernized build system in this repository you can also use
 `Makefile.new` or the provided CMake files.  Both automatically build from
-the `src-lites-1.1-2025` directory when it is present.  Set the `SRCDIR` or
-`LITES_SRC_DIR` variables to override this behaviour.  The tools recognise an
+the directory pointed to by `SRCDIR`/`LITES_SRC_DIR` when it is present.
+Set these variables to override the default location.  The tools recognise an
 `ARCH` variable which selects the target CPU.  Supported values include the
 64‑bit `x86_64` and `riscv64`, 32‑bit `i686`, `arm` and `powerpc`, and the
 16‑bit `ia16`.  The default is `ARCH=x86_64`.
@@ -128,7 +128,7 @@ make -f Makefile.new ARCH=x86_64 SANITIZE=1
 
 # Using CMake (optionally override the source directory)
 cmake -B build -DARCH=i686
-cmake -B build -DARCH=x86_64 -DLITES_SRC_DIR=src-lites-1.1-2025
+cmake -B build -DARCH=x86_64 -DLITES_SRC_DIR=/path/to/lites
 cmake -B build -DARCH=arm
 cmake -B build -DARCH=riscv64
 cmake -B build -DARCH=powerpc
@@ -225,10 +225,10 @@ executed directly.  For example:
 ./tests/vm_fault/test_vm_fault
 ```
 
-A simple user-level pager is provided in `src-lites-1.1-2025/bin/user_pager`.
+A simple user-level pager is provided in `bin/user_pager` within the modern tree.
 Build it with:
 ```sh
-make -C src-lites-1.1-2025/bin/user_pager
+make -C "$LITES_SRC_DIR/bin/user_pager"
 ```
 Run the resulting `user_pager` alongside `lites_server` to service page faults.
 The VM test in `tests/vm_fault` demonstrates this interaction.
@@ -240,7 +240,7 @@ make -f Makefile.new test
 
 ## Header consolidation
 A helper script `scripts/move_all_headers.sh` is provided to move all `*.h` files
-from the repository into `src-lites-1.1-2025/include/all_headers` while
+from the repository into `$LITES_SRC_DIR/include/all_headers` while
 preserving their original relative paths. This operation is destructive and
 should only be run for analysis purposes.
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,7 +4,7 @@ The `docs/` directory contains notes and background information for the project.
 
 - **HISTORY.md** - Overview of available Lites releases and helper script for generating diffs between them.
 - **IPC.md** - Describes the mailbox-based interprocess communication helpers.
-- **MODERNIZATION.md** - Summarises the modernization progress in `src-lites-1.1-2025`.
+- **MODERNIZATION.md** - Summarises the modernization progress in the project source tree.
 - **POSIX.md** - Documents small convenience wrappers for POSIX operations.
 - **POSIX_ROADMAP.md** - Roadmap for staged implementation of POSIX compatibility.
 - **iommu.md** - Notes on the minimal IOMMU abstraction present in the source tree.

--- a/docs/MODERNIZATION.md
+++ b/docs/MODERNIZATION.md
@@ -1,6 +1,6 @@
 # Modernization Status
 
-The `src-lites-1.1-2025` tree contains ongoing work to bring the
+The modernised tree (`$LITES_SRC_DIR` by default) contains ongoing work to bring the
 original Lites sources forward.  This document summarises what has
 already been completed and what is still planned.
 

--- a/docs/POSIX.md
+++ b/docs/POSIX.md
@@ -1,8 +1,8 @@
 # POSIX helpers
 
 A small collection of convenience wrappers lives in
-`src-lites-1.1-2025/liblites/posix_wrap.c` and the associated header
-`src-lites-1.1-2025/include/posix_wrap.h`.
+`liblites/posix_wrap.c` and the associated header
+`include/posix_wrap.h` within the project source tree.
 
 ```c
 int lx_link(const char *oldpath, const char *newpath);
@@ -50,6 +50,6 @@ int main(void) {
 Compile manually with:
 
 ```sh
-cc -I src-lites-1.1-2025/include \
-    src-lites-1.1-2025/liblites/posix_wrap.c bin/posix-demo.c -o posix-demo
+cc -I "$LITES_SRC_DIR/include" \
+    "$LITES_SRC_DIR/liblites/posix_wrap.c" bin/posix-demo.c -o posix-demo
 ```

--- a/docs/POSIX_ROADMAP.md
+++ b/docs/POSIX_ROADMAP.md
@@ -9,7 +9,7 @@ missing pieces.
 ## Phase I – Build and Core Infrastructure
 
 * **Unified build system** – The repository already offers
-  `Makefile.new` and CMake support for the `src-lites-1.1-2025` tree.
+  `Makefile.new` and CMake support for the modernised source tree.
   Additional tooling such as Meson is planned but not yet present.
   Cross‑compilation helpers live in `setup.sh`.
 * **Header consolidation** – The `headers_inventory.csv` file and the

--- a/docs/iommu.md
+++ b/docs/iommu.md
@@ -1,6 +1,6 @@
 # IOMMU helpers
 
-A minimal IOMMU abstraction lives in `src-lites-1.1-2025/iommu`.
+A minimal IOMMU abstraction lives in `iommu/` within the source tree.
 
 ```c
 struct iommu_dom {

--- a/docs/security.md
+++ b/docs/security.md
@@ -22,7 +22,7 @@ standard cipher such as AES, potentially using the OpenSSL library.
 
 ## Enclave
 
-`src-lites-1.1-2025/liblites/enclave.c` provides example enclave hooks.
+`liblites/enclave.c` in the source tree provides example enclave hooks.
 
 ```c
 int enclave_create(const char *name);
@@ -42,6 +42,6 @@ Two small utilities under `bin/` demonstrate the APIs:
 They can be compiled manually, for example:
 
 ```sh
-cc -I src-lites-1.1-2025/include crypto/keystore.c bin/keystore-demo.c -o keystore-demo
-cc -I src-lites-1.1-2025/include src-lites-1.1-2025/liblites/enclave.c bin/enclave-demo.c -o enclave-demo
+cc -I "$LITES_SRC_DIR/include" crypto/keystore.c bin/keystore-demo.c -o keystore-demo
+cc -I "$LITES_SRC_DIR/include" "$LITES_SRC_DIR/liblites/enclave.c" bin/enclave-demo.c -o enclave-demo
 ```

--- a/docs/technical_notes.md
+++ b/docs/technical_notes.md
@@ -13,7 +13,7 @@ To experiment with cross compilation or multiple architectures, see the
 `setup.sh` script in the repository root. It installs a full toolchain and
 qemu-based emulation targets.
 
-The modernized sources in `src-lites-1.1-2025` require a compiler with full
+The modernized sources require a compiler with full
 C23 support. GCC 13 or Clang 17 (or newer) are known to work.
 
 
@@ -23,7 +23,7 @@ A repository-wide `.editorconfig` enforces UTF‑8 encoding, LF line endings and
 
 ## User-level pager
 
-`src-lites-1.1-2025/bin/user_pager` implements a trivial pager used by the unit
+`bin/user_pager` in the source tree implements a trivial pager used by the unit
 tests.  It reads `pf_info_t` structures from a UNIX domain socket and simply
 acknowledges each request, leaving the kernel side to map zero-filled pages.
 The VM tests spawn the pager automatically.

--- a/include/auth.h
+++ b/include/auth.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <stdint.h>
-#include "../src-lites-1.1-2025/include/cap.h"
+#include "cap.h"
 #include "id128.h"
 
 typedef struct cap cap_t;

--- a/include/posix_ipc.h
+++ b/include/posix_ipc.h
@@ -4,7 +4,7 @@
 #include <semaphore.h>
 #include <sys/mman.h>
 #include <sys/types.h>
-#include "../src-lites-1.1-2025/include/cap.h"
+#include "cap.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/scripts/check-kr.sh
+++ b/scripts/check-kr.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SRC_DIR="${LITES_SRC_DIR:-src-lites-1.1-2025}"
+
 found=0
 while IFS= read -r file; do
   while IFS=: read -r num line; do
@@ -12,6 +14,6 @@ while IFS= read -r file; do
       fi
     fi
   done < <(grep -nE '^[A-Za-z_].*\)\s*$' "$file")
-done < <(find src-lites-1.1-2025/xkernel/util -type f -name '*.c' -not -path '*/gmake-3.66/*')
+done < <(find "$SRC_DIR/xkernel/util" -type f -name '*.c' -not -path '*/gmake-3.66/*' 2>/dev/null)
 
 exit $found

--- a/scripts/extract-xmach-headers.sh
+++ b/scripts/extract-xmach-headers.sh
@@ -4,11 +4,12 @@ set -euo pipefail
 # Determine repository root
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DEST="$ROOT/localmach/include"
+SRC_DIR="${LITES_SRC_DIR:-$ROOT/src-lites-1.1-2025}"
 
 mkdir -p "$DEST"
 
 for MACH in mach4 mach3; do
-    SRC="$ROOT/src-lites-1.1-2025/xkernel/$MACH"
+    SRC="$SRC_DIR/xkernel/$MACH"
     [ -d "$SRC" ] || continue
     while IFS= read -r -d '' FILE; do
         REL="${FILE#${SRC}/}"

--- a/scripts/import-mach-headers.sh
+++ b/scripts/import-mach-headers.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DEST="$ROOT/localmach/include"
+SRC_DIR="${LITES_SRC_DIR:-$ROOT/src-lites-1.1-2025}"
 
 copy_headers() {
     local src="$1"
@@ -21,8 +22,8 @@ if [ -d "$ROOT/openmach/include" ]; then
     exit 0
 fi
 
-if [ -d "$ROOT/src-lites-1.1-2025/xkernel" ]; then
-    "$ROOT/scripts/extract-xmach-headers.sh"
+if [ -d "$SRC_DIR/xkernel" ]; then
+    LITES_SRC_DIR="$SRC_DIR" "$ROOT/scripts/extract-xmach-headers.sh"
     exit 0
 fi
 

--- a/scripts/move_all_headers.sh
+++ b/scripts/move_all_headers.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-TARGET_BASE="src-lites-1.1-2025/include/all_headers"
+TARGET_BASE="${LITES_SRC_DIR:-src-lites-1.1-2025}/include/all_headers"
 
 # Create the destination base directory
 mkdir -p "$TARGET_BASE"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,11 @@
+set(_src_dir "${LITES_SRC_DIR}")
+if(NOT EXISTS "${_src_dir}/server/kern/cap.c")
+    set(_src_dir "${CMAKE_CURRENT_SOURCE_DIR}/..")
+endif()
+
 add_executable(test_cap
     cap/test_cap.c
-    ../src-lites-1.1-2025/server/kern/cap.c
+    ${_src_dir}/server/kern/cap.c
     ../kern/auth.c
     ../kern/audit.c)
 target_include_directories(test_cap PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
@@ -15,12 +20,12 @@ target_compile_options(test_audit PRIVATE -std=gnu2x -Wall -Wextra -Werror)
 
 add_executable(test_iommu
     iommu/test_iommu.c
-    ../src-lites-1.1-2025/iommu/iommu.c)
+    ${_src_dir}/iommu/iommu.c)
 target_compile_options(test_iommu PRIVATE -std=gnu2x -Wall -Wextra -Werror)
 
 add_executable(test_vm_fault
     vm_fault/test_vm_fault.c
-    ../src-lites-1.1-2025/server/vm/vm_handlers.c
+    ${_src_dir}/server/vm/vm_handlers.c
     ../posix.c)
 target_compile_options(test_vm_fault PRIVATE -std=gnu2x -Wall -Wextra -Werror)
 target_include_directories(test_vm_fault PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
@@ -44,15 +49,15 @@ target_compile_options(test_spawn_wait PRIVATE -std=gnu2x -Wall -Wextra -Werror)
 # not available in this environment.  Disable for now.
 #add_executable(test_posix
 #    posix/test_posix.c
-#    ../src-lites-1.1-2025/liblites/posix_wrap.c)
+#    ${_src_dir}/liblites/posix_wrap.c)
 #target_include_directories(test_posix PRIVATE
-#    ${CMAKE_CURRENT_SOURCE_DIR}/../src-lites-1.1-2025/include)
+#    ${_src_dir}/include)
 #target_compile_options(test_posix PRIVATE -std=gnu23 -Wall -Wextra -Werror)
 
 #add_executable(test_fifo
 #    fifo_test/test_fifo.c
-#    ../src-lites-1.1-2025/libposix/posix.c)
-#target_include_directories(test_fifo PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src-lites-1.1-2025/include)
+#    ${_src_dir}/libposix/posix.c)
+#target_include_directories(test_fifo PRIVATE ${_src_dir}/include)
 #target_compile_options(test_fifo PRIVATE -std=gnu23 -Wall -Wextra -Werror)
 
 add_executable(test_xec596_init

--- a/tests/audit/test_audit.c
+++ b/tests/audit/test_audit.c
@@ -3,7 +3,7 @@
 #include "../../include/auth.h"
 #include "../../include/audit.h"
 #include "../../include/id128.h"
-#include "../../src-lites-1.1-2025/include/cap.h"
+#include "cap.h"
 
 int main(void)
 {

--- a/tests/cap/Makefile
+++ b/tests/cap/Makefile
@@ -2,13 +2,23 @@ CC ?= clang
 # Additional compile flags from the top-level build system are appended.
 CFLAGS += -std=gnu23 -Wall -Wextra -Werror
 CPPFLAGS += -I../../include
+SRC_DIR ?= ../../src-lites-1.1-2025
+ifneq ($(wildcard $(SRC_DIR)/include),)
+CPPFLAGS += -I$(SRC_DIR)/include
+endif
+CAP_SRC := $(SRC_DIR)/server/kern/cap.c
+ifneq ($(wildcard $(CAP_SRC)),)
+CAP_PATH := $(CAP_SRC)
+else
+CAP_PATH := ../../server/kern/cap.c
+endif
 
 all: test_cap
 
 
 .PHONY: all clean
 
-test_cap: test_cap.c ../../src-lites-1.1-2025/server/kern/cap.c ../../kern/auth.c ../../kern/audit.c
+test_cap: test_cap.c $(CAP_PATH) ../../kern/auth.c ../../kern/audit.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 clean:

--- a/tests/cap/test_cap.c
+++ b/tests/cap/test_cap.c
@@ -1,4 +1,4 @@
-#include "../../src-lites-1.1-2025/include/cap.h"
+#include "cap.h"
 #include <assert.h>
 #include <stdlib.h>
 #include "../../include/auth.h"

--- a/tests/fifo_test/Makefile
+++ b/tests/fifo_test/Makefile
@@ -4,8 +4,10 @@ ARCH ?= x86_64
 # Disable glibc fortify since we override libc functions
 CFLAGS += -std=gnu23 -Wall -Wextra -Werror -U_FORTIFY_SOURCE
 # Include the common and architecture specific headers from the modernised tree
-CPPFLAGS += -I../../src-lites-1.1-2025/include \
-           -I../../src-lites-1.1-2025/include/$(ARCH)
+SRC_DIR ?= ../../src-lites-1.1-2025
+ifneq ($(wildcard $(SRC_DIR)/include),)
+CPPFLAGS += -I$(SRC_DIR)/include -I$(SRC_DIR)/include/$(ARCH)
+endif
 
 all:
 @echo "fifo test disabled"

--- a/tests/fifo_test/test_fifo.c
+++ b/tests/fifo_test/test_fifo.c
@@ -1,4 +1,4 @@
-#include "../../src-lites-1.1-2025/include/posix.h"
+#include "posix.h"
 #include <assert.h>
 #include <string.h>
 

--- a/tests/iommu/Makefile
+++ b/tests/iommu/Makefile
@@ -6,7 +6,15 @@ all: test_iommu
 
 .PHONY: all clean
 
-test_iommu: test_iommu.c ../../src-lites-1.1-2025/iommu/iommu.c
+SRC_DIR ?= ../../src-lites-1.1-2025
+IOMMU_SRC := $(SRC_DIR)/iommu/iommu.c
+ifneq ($(wildcard $(IOMMU_SRC)),)
+IOMMU_PATH := $(IOMMU_SRC)
+else
+IOMMU_PATH := ../../iommu/iommu.c
+endif
+
+test_iommu: test_iommu.c $(IOMMU_PATH)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 clean:

--- a/tests/iommu/test_iommu.c
+++ b/tests/iommu/test_iommu.c
@@ -1,4 +1,4 @@
-#include "../../src-lites-1.1-2025/iommu/iommu.h"
+#include "iommu.h"
 #include <assert.h>
 #include <stdlib.h>
 

--- a/tests/posix/Makefile
+++ b/tests/posix/Makefile
@@ -1,8 +1,11 @@
 CC ?= clang
 ARCH ?= x86_64
 CFLAGS += -std=gnu23 -Wall -Wextra -Werror
-CPPFLAGS += -I../../src-lites-1.1-2025/include \
-           -I../../src-lites-1.1-2025/include/$(ARCH)
+SRC_DIR ?= ../../src-lites-1.1-2025
+CPPFLAGS += -I../../include
+ifneq ($(wildcard $(SRC_DIR)/include),)
+CPPFLAGS += -I$(SRC_DIR)/include -I$(SRC_DIR)/include/$(ARCH)
+endif
 
 all:
 @echo "posix test disabled"

--- a/tests/posix/test_posix.c
+++ b/tests/posix/test_posix.c
@@ -1,4 +1,4 @@
-#include "../../src-lites-1.1-2025/include/posix_wrap.h"
+#include "posix_wrap.h"
 #include <assert.h>
 #include <fcntl.h>
 #include <unistd.h>

--- a/tests/vm_fault/Makefile
+++ b/tests/vm_fault/Makefile
@@ -6,8 +6,16 @@ all: test_vm_fault
 
 .PHONY: all clean
 
-test_vm_fault: test_vm_fault.c ../../src-lites-1.1-2025/server/vm/vm_handlers.c ../../posix.c
-	    $(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+SRC_DIR ?= ../../src-lites-1.1-2025
+VM_SRC := $(SRC_DIR)/server/vm/vm_handlers.c
+ifneq ($(wildcard $(VM_SRC)),)
+VM_PATH := $(VM_SRC)
+else
+VM_PATH := ../../server/vm/vm_handlers.c
+endif
+
+test_vm_fault: test_vm_fault.c $(VM_PATH) ../../posix.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 clean:
 	rm -f test_vm_fault

--- a/tests/vm_fault/test_vm_fault.c
+++ b/tests/vm_fault/test_vm_fault.c
@@ -6,7 +6,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#include "../../src-lites-1.1-2025/include/vm.h"
+#include "vm.h"
 
 extern kern_return_t vm_fault_entry(aspace_t *, vm_offset_t, vm_prot_t);
 extern kern_return_t unmap_frame(aspace_t *, vm_offset_t);
@@ -21,7 +21,14 @@ int main(void) {
         close(sv[0]);
         char fdstr[16];
         snprintf(fdstr, sizeof(fdstr), "%d", sv[1]);
-        execl("./src-lites-1.1-2025/bin/user_pager/user_pager", "user_pager", fdstr, NULL);
+        const char *src = getenv("LITES_SRC_DIR");
+        char path[256];
+        if (src) {
+            snprintf(path, sizeof(path), "%s/bin/user_pager/user_pager", src);
+        } else {
+            snprintf(path, sizeof(path), "bin/user_pager/user_pager");
+        }
+        execl(path, "user_pager", fdstr, NULL);
         perror("execl");
         _exit(1);
     }


### PR DESCRIPTION
## Summary
- remove old src-lites paths from docs
- use $LITES_SRC_DIR in examples and scripts
- adjust build workflow for missing pager directory
- update test and header includes to avoid fixed paths

## Testing
- `pre-commit` *(fails: command not found)*
- `make -f Makefile.new help` *(fails: Mach headers not found)*