### PR TITLE
Cleanup: drop old src-lites fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,9 @@ jobs:
 
       - name: Build tests
         run: |
-          if [ -d "${LITES_SRC_DIR:-src-lites-1.1-2025}/bin/user_pager" ]; then
-            make -C "${LITES_SRC_DIR:-src-lites-1.1-2025}/bin/user_pager" CC=${{ matrix.cc }}
+          : "${LITES_SRC_DIR?Set LITES_SRC_DIR to the legacy source tree}"
+          if [ -d "$LITES_SRC_DIR/bin/user_pager" ]; then
+            make -C "$LITES_SRC_DIR/bin/user_pager" CC=${{ matrix.cc }}
           fi
           make -C tests/audit CC=${{ matrix.cc }}
           make -C tests/cap CC=${{ matrix.cc }}

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ make
 ```
 
 For the modernized build system in this repository you can also use
-`Makefile.new` or the provided CMake files.  Both automatically build from
-the directory pointed to by `SRCDIR`/`LITES_SRC_DIR` when it is present.
-Set these variables to override the default location.  The tools recognise an
+`Makefile.new` or the provided CMake files.  Both build from the directory
+specified by `SRCDIR`/`LITES_SRC_DIR`.  Set this variable to point at the
+legacy source tree.  The tools recognise an
 `ARCH` variable which selects the target CPU.  Supported values include the
 64‑bit `x86_64` and `riscv64`, 32‑bit `i686`, `arm` and `powerpc`, and the
 16‑bit `ia16`.  The default is `ARCH=x86_64`.

--- a/docs/MODERNIZATION.md
+++ b/docs/MODERNIZATION.md
@@ -1,6 +1,6 @@
 # Modernization Status
 
-The modernised tree (`$LITES_SRC_DIR` by default) contains ongoing work to bring the
+The modernised tree (in `$LITES_SRC_DIR`) contains ongoing work to bring the
 original Lites sources forward.  This document summarises what has
 already been completed and what is still planned.
 

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,11 @@ bison = find_program('bison', required : false)
 
 # Build the IPC demo
 rt = cc.find_library('rt', required : false)
-inc = include_directories('.', 'src-lites-1.1-2025/include')
+lites_src_dir = run_command('sh', '-c', 'echo "$LITES_SRC_DIR"').stdout().strip()
+if lites_src_dir == ''
+  error('LITES_SRC_DIR must be set')
+endif
+inc = include_directories('.', join_paths(lites_src_dir, 'include'))
 executable('ipc-demo',
            ['ipc.c', 'bin/ipc-demo.c'],
            include_directories : inc,

--- a/scripts/check-kr.sh
+++ b/scripts/check-kr.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SRC_DIR="${LITES_SRC_DIR:-src-lites-1.1-2025}"
+if [ -z "${LITES_SRC_DIR:-}" ]; then
+  echo "LITES_SRC_DIR must be set" >&2
+  exit 1
+fi
+SRC_DIR="$LITES_SRC_DIR"
 
 found=0
 while IFS= read -r file; do

--- a/scripts/extract-xmach-headers.sh
+++ b/scripts/extract-xmach-headers.sh
@@ -4,7 +4,11 @@ set -euo pipefail
 # Determine repository root
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DEST="$ROOT/localmach/include"
-SRC_DIR="${LITES_SRC_DIR:-$ROOT/src-lites-1.1-2025}"
+if [ -z "${LITES_SRC_DIR:-}" ]; then
+    echo "LITES_SRC_DIR must be set" >&2
+    exit 1
+fi
+SRC_DIR="$LITES_SRC_DIR"
 
 mkdir -p "$DEST"
 

--- a/scripts/import-mach-headers.sh
+++ b/scripts/import-mach-headers.sh
@@ -3,7 +3,11 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DEST="$ROOT/localmach/include"
-SRC_DIR="${LITES_SRC_DIR:-$ROOT/src-lites-1.1-2025}"
+if [ -z "${LITES_SRC_DIR:-}" ]; then
+    echo "LITES_SRC_DIR must be set" >&2
+    exit 1
+fi
+SRC_DIR="$LITES_SRC_DIR"
 
 copy_headers() {
     local src="$1"

--- a/scripts/move_all_headers.sh
+++ b/scripts/move_all_headers.sh
@@ -5,7 +5,11 @@
 
 set -euo pipefail
 
-TARGET_BASE="${LITES_SRC_DIR:-src-lites-1.1-2025}/include/all_headers"
+if [ -z "${LITES_SRC_DIR:-}" ]; then
+  echo "LITES_SRC_DIR must be set" >&2
+  exit 1
+fi
+TARGET_BASE="$LITES_SRC_DIR/include/all_headers"
 
 # Create the destination base directory
 mkdir -p "$TARGET_BASE"

--- a/tests/cap/Makefile
+++ b/tests/cap/Makefile
@@ -2,7 +2,10 @@ CC ?= clang
 # Additional compile flags from the top-level build system are appended.
 CFLAGS += -std=gnu23 -Wall -Wextra -Werror
 CPPFLAGS += -I../../include
-SRC_DIR ?= ../../src-lites-1.1-2025
+ifndef LITES_SRC_DIR
+$(error LITES_SRC_DIR must be set)
+endif
+SRC_DIR := $(LITES_SRC_DIR)
 ifneq ($(wildcard $(SRC_DIR)/include),)
 CPPFLAGS += -I$(SRC_DIR)/include
 endif

--- a/tests/fifo_test/Makefile
+++ b/tests/fifo_test/Makefile
@@ -4,7 +4,10 @@ ARCH ?= x86_64
 # Disable glibc fortify since we override libc functions
 CFLAGS += -std=gnu23 -Wall -Wextra -Werror -U_FORTIFY_SOURCE
 # Include the common and architecture specific headers from the modernised tree
-SRC_DIR ?= ../../src-lites-1.1-2025
+ifndef LITES_SRC_DIR
+$(error LITES_SRC_DIR must be set)
+endif
+SRC_DIR := $(LITES_SRC_DIR)
 ifneq ($(wildcard $(SRC_DIR)/include),)
 CPPFLAGS += -I$(SRC_DIR)/include -I$(SRC_DIR)/include/$(ARCH)
 endif
@@ -17,7 +20,7 @@ prepare:
 
 .PHONY: all clean
 
-#test_fifo: test_fifo.c ../../src-lites-1.1-2025/libposix/posix.c
+#test_fifo: test_fifo.c $(LITES_SRC_DIR)/libposix/posix.c
 #$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 clean:

--- a/tests/iommu/Makefile
+++ b/tests/iommu/Makefile
@@ -6,7 +6,10 @@ all: test_iommu
 
 .PHONY: all clean
 
-SRC_DIR ?= ../../src-lites-1.1-2025
+ifndef LITES_SRC_DIR
+$(error LITES_SRC_DIR must be set)
+endif
+SRC_DIR := $(LITES_SRC_DIR)
 IOMMU_SRC := $(SRC_DIR)/iommu/iommu.c
 ifneq ($(wildcard $(IOMMU_SRC)),)
 IOMMU_PATH := $(IOMMU_SRC)

--- a/tests/posix/Makefile
+++ b/tests/posix/Makefile
@@ -1,7 +1,10 @@
 CC ?= clang
 ARCH ?= x86_64
 CFLAGS += -std=gnu23 -Wall -Wextra -Werror
-SRC_DIR ?= ../../src-lites-1.1-2025
+ifndef LITES_SRC_DIR
+$(error LITES_SRC_DIR must be set)
+endif
+SRC_DIR := $(LITES_SRC_DIR)
 CPPFLAGS += -I../../include
 ifneq ($(wildcard $(SRC_DIR)/include),)
 CPPFLAGS += -I$(SRC_DIR)/include -I$(SRC_DIR)/include/$(ARCH)
@@ -15,7 +18,7 @@ prepare:
 
 .PHONY: all clean
 
-#test_posix: test_posix.c ../../src-lites-1.1-2025/liblites/posix_wrap.c
+#test_posix: test_posix.c $(LITES_SRC_DIR)/liblites/posix_wrap.c
 #$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 

--- a/tests/vm_fault/Makefile
+++ b/tests/vm_fault/Makefile
@@ -6,7 +6,10 @@ all: test_vm_fault
 
 .PHONY: all clean
 
-SRC_DIR ?= ../../src-lites-1.1-2025
+ifndef LITES_SRC_DIR
+$(error LITES_SRC_DIR must be set)
+endif
+SRC_DIR := $(LITES_SRC_DIR)
 VM_SRC := $(SRC_DIR)/server/vm/vm_handlers.c
 ifneq ($(wildcard $(VM_SRC)),)
 VM_PATH := $(VM_SRC)


### PR DESCRIPTION
## Summary
- require `LITES_SRC_DIR` everywhere instead of using `src-lites-1.1-2025`
- update build scripts and tests to check for the variable
- refresh workflow and documentation

## Testing
- `pre-commit` *(fails: command not found)*
- `make -C tests/cap --dry-run LITES_SRC_DIR=somepath`