### PR TITLE
docs: add LICENSE_MAP for legacy sources

### DIFF
--- a/LICENSE_MAP
+++ b/LICENSE_MAP
@@ -1,0 +1,3242 @@
+| File Path | License | Origin | Last Commit |
+|-----------|---------|--------|-------------|
+| SunOS-4.1.3-413/demo/BUTTONBOX/button_icon.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/BUTTONBOX/button_mask_icon.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/BUTTONBOX/buttons.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/BUTTONBOX/buttontest.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/BUTTONBOX/diag.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/BUTTONBOX/off_off_icon.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/BUTTONBOX/off_on_icon.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/BUTTONBOX/on_off_icon.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/BUTTONBOX/on_on_icon.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/BUTTONBOX/x_buttontest.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/BUTTONBOX/x_diag.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/CDROM/cdrom.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/CDROM/cdrom.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/CDROM/msf.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/CDROM/msf.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/CDROM/player.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/CDROM/player.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/CDROM/prop_ui.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/CDROM/toc.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/CDROM/toc.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/CDROM/x_player.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/CDROM/x_prop.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/CDROM/x_prop_ui.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/DIALBOX/diag.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/DIALBOX/dial_icon.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/DIALBOX/dial_mask_icon.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/DIALBOX/dialtest.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/DIALBOX/dump.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/DIALBOX/pw_circle.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/DIALBOX/x_diag.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/DIALBOX/x_dialtest.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/DIALBOX/x_dump.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/DIALBOX/x_pw_circle.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/gaintool.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/gaintool_ui.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/gaintool_ui.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/libaudio/device_ctl.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/libaudio/filehdr.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/libaudio/gen_ulaw2linear.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/libaudio/hdr_misc.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/libaudio/libaudio_impl.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/libaudio/test_dbl2int.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/libaudio/test_ulaw2linear.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/multimedia/archdep.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/multimedia/audio_device.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/multimedia/audio_errno.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/multimedia/audio_filehdr.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/multimedia/audio_hdr.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/multimedia/libaudio.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/multimedia/ulaw2linear.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/play.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/raw2audio.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/record.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SOUND/soundtool.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/lasertool/button_create.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/lasertool/button_proc.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/lasertool/cycle_create.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/lasertool/cycle_proc.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/lasertool/info_create.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/lasertool/lasertool.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/lasertool/main.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/lasertool/poll.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/lasertool/search_etc_create.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/lasertool/search_etc_proc.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_codes.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_laser.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_addrinq.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_chinq.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_clvdisk.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_eject.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_enter.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_hshake.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_itoa.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_line.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_m_search.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_mark.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_motor.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_repeat.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_replay.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_repvar.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_romvers.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_sbyte.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_search.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_statinq.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_step.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_trkjmp.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/LASERDISC/sony_lib/sony_ucodeinq.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/de_interlace.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/file_panel.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/fileio.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/init_item.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/initialize_items.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/main.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/panel_util.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/save_postscript.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/slider.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/vidcal.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/vidcal_icon.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/vidcal_panel.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/video.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/video_adjust.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/video_cbars.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/video_cursor.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/video_icon.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/video_impl.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/video_mat.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/video_panel.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/video_poll.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/video_pr.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/video_setup.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIDEO/video_win.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/balls.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/bitmap.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/cclear.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/cframedemo.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/chessgame.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/defs.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/demolib.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/demolib.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/demos.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/draw.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/fontsample.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/fract.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/maze.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/mixcolor.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/molecule.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/product.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/rotcube.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/shaded.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/shademo.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/show.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/showmap.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/sqrttbl.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/stringart.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/suncube.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/SUNVIEW/SRCS/vectors.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/XGL/SRCS/P_include.h | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/XGL/SRCS/WS_macros.h | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/XGL/SRCS/mandelbrot.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/XGL/SRCS/quat_utils.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/XGL/SRCS/test_sphere.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/XGL/SRCS/view_3d_set.c | Unknown BSD-like | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| SunOS-4.1.3-413/demo/XGL/SRCS/xgl_logo.c | Unknown | SunOS-4.1.3-413 | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlib.h | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/cachesize32.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/cachesize64.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/cpuid32.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/cpuid64.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/cputype32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/cputype64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/debugbreak32.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/debugbreak64.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/dispatchpatch32.asm | Unknown BSD-like | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/dispatchpatch64.asm | Unknown BSD-like | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/divfixedi32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/divfixedi64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/divfixedv32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/divfixedv64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/instrset32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/instrset64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/libad32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/libad64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/memcmp32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/memcmp64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/memcpy32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/memcpy64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/memmove32.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/memmove64.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/memset32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/memset64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/mersenne32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/mersenne64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/mother32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/mother64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/physseed32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/physseed64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/popcount32.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/popcount64.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/procname32.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/procname64.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/rdtsc32.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/rdtsc64.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/round32.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/round64.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/sfmt32.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/sfmt64.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strcat32.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strcat64.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strcmp32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strcmp64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strcountset32.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strcountset64.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strcountutf832.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strcountutf864.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strcpy32.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strcpy64.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/stricmp32.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/stricmp64.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strlen32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strlen64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strspn32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strspn64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strstr32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strstr64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strtouplow32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/strtouplow64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/substring32.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/substring64.asm | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/unalignedisfaster32.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibSrc/unalignedisfaster64.asm | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/asmlibran.h | GPL | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/inteldispatchpatch/intel_cpu_feature_patch.c | IBM | asmlib | 2025-05-25T16:28:16-07:00 |
+| asmlib/inteldispatchpatch/intel_mkl_feature_patch.c | Unknown | asmlib | 2025-05-25T16:28:16-07:00 |
+| bin/enclave-demo.c | Unknown | bin | 2025-05-23T21:56:02-07:00 |
+| bin/ipc-demo.c | Unknown | bin | 2025-05-25T10:39:50-07:00 |
+| bin/keystore-demo.c | Unknown | bin | 2025-05-23T21:58:37-07:00 |
+| bin/posix-demo.c | Unknown | bin | 2025-05-25T10:27:12-07:00 |
+| bootstrap/assert.h | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/bootstrap.c | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/def_pager_setup.c | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/default_pager.c | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/defs.h | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/dir.h | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/disk_inode.h | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/disk_inode_ffs.h | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/ext2_file_io.c | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/ext2_fs.h | Unknown BSD-like | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/ffs_compat.c | GPL | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/ffs_compat.h | GPL | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/ffs_file_io.c | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/file_io.c | Utah | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/file_io.h | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/fs.h | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/kalloc.c | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/load.c | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/minix_ffs_compat.c | Minix | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/minix_ffs_compat.h | Minix | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/minix_file_io.c | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/minix_fs.h | GPL | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/minix_super.h | GPL | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/queue.h | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/strfcns.c | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/wiring.c | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| bootstrap/wiring.h | CMU | bootstrap | 2025-05-25T16:28:16-07:00 |
+| buf.h | Unknown | buf.h | 2025-05-25T16:28:16-07:00 |
+| conf 2/conf.c | Unknown BSD-like | conf 2 | 2025-05-25T16:28:16-07:00 |
+| conf 2/data.s | Unknown | conf 2 | 2025-05-25T16:28:16-07:00 |
+| conf 2/low.s | Unknown BSD-like | conf 2 | 2025-05-25T16:28:16-07:00 |
+| conf 2/m40.s | Unknown | conf 2 | 2025-05-25T16:28:16-07:00 |
+| conf 2/m45.s | Unknown | conf 2 | 2025-05-25T16:28:16-07:00 |
+| conf 2/mch.s | Unknown BSD-like | conf 2 | 2025-05-25T16:28:16-07:00 |
+| conf 2/mkconf.c | Unknown | conf 2 | 2025-05-25T16:28:16-07:00 |
+| conf 2/sysfix.c | Unknown | conf 2 | 2025-05-25T16:28:16-07:00 |
+| conf.h | Unknown | conf.h | 2025-05-25T16:28:16-07:00 |
+| crypto/keystore.c | Unknown | crypto | 2025-05-23T21:58:01-07:00 |
+| ddekit/assert.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/attribs.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/badgerferret/msg_queue.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/badgerferret/pci.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/condvar.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/ddekit.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/debug.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/initcall.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/inline.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/interrupt.h | Unknown BSD-like | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/lock.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/memory.h | Unknown BSD-like | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/panic.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/pci.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/pgtab.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/printf.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/resources.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/semaphore.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/thread.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/timer.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/types.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| ddekit/usb.h | Unknown | ddekit | 2025-05-25T16:28:16-07:00 |
+| dmr/bio.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/cat.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/dc.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/dh.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/dhdm.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/dhfdm.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/dn.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/dp.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/hp.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/hs.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/ht.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/kl.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/lp.c | Unknown | dmr | 2025-05-26T03:27:28-07:00 |
+| dmr/mem.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/partab.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/pc.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/rf.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/rk.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/rp.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/sys.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/tc.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/tm.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/tty.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/vs.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| dmr/vt.c | Unknown | dmr | 2025-05-25T16:28:16-07:00 |
+| file.h | Unknown | file.h | 2025-05-25T16:28:16-07:00 |
+| filsys.h | Unknown | filsys.h | 2025-05-25T16:28:16-07:00 |
+| i386/boot/boot.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/boot_info_dump.c | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/boot_start.c | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/bsd/boottype.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/bsd/crt0.S | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/bsd/exit.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/bsd/main.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/do_boot.S | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/linux/autoconf.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/linux/config.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/linux/crypt.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/linux/gzip.h | GPL | i386 | 2025-05-26T03:07:52-07:00 |
+| i386/boot/linux/i16_bootsect.S | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/linux/i16_setup.S | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/linux/inflate.c | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/linux/lzw.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/linux/misc.c | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/linux/segment.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/linux/unzip.c | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/malloc.c | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/boot/serial.S | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/bootstrap/exec.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/bootstrap/translate_root.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/bootstrap/translate_root.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/asm.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/bios.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/boolean.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/code16.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/cthreads.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/debug_reg.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/disk.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/dpmi.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/eflags.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/exception.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/exec/elf.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/far_ptr.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/fp_reg.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/ioccom.h | BSD-4-Clause | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/kern_return.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/mach_i386_types.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/multiboot.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/paging.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/pio.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/pmode.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/proc_reg.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/rpc.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/seg.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/syscall_sw.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/thread_status.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/time_stamp.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/trap.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/tss.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/vcpi.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/vm_param.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/machine/vm_types.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/proc_ops.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/sa/stdarg.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/include/mach/setjmp.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/aha.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/asc.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/at3c501.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/blit.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/com.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/de6c.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/eaha.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/evc.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/fd.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/hd.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/hpp.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/lpr.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/mach_machine_routines.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/ne.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/ns8390.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/nscsi.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/par.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/pc586.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/platforms.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/rc.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/sbic.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/sci.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/sii.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/siop.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/ul.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/wd.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/bogus/wt.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/chips/busses.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/dos_buf.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/dos_check_err.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/dos_close.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/dos_fstat.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/dos_gettimeofday.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/dos_io.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/dos_open.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/dos_read.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/dos_rename.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/dos_seek.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/dos_tcgetattr.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/dos_unlink.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/dos_write.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/i16/gdt.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/i16/gdt_sels.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/i16/i16_crt0.S | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/i16/i16_crt0.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/i16/i16_dos.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/i16/i16_dos_mem.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/i16/i16_exit.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/i16/i16_main.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/i16/i16_putchar.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/i16/i16_vcpi.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/i16/i16_xms.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/i16/idt.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/i16/phys_mem_sources.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/dos/putchar.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/ast.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/ast_check.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/ast_types.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/cpu_number.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/cswitch.S | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/db_disasm.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/db_interface.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/db_machdep.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/db_trace.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/debug.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/debug_i386.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/debug_trace.S | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/eflags.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/fpu.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/fpu.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/gdt.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/gdt.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/hardclock.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/idt.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/idt.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/idt_inittab.S | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/io_emulate.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/io_emulate.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/io_map.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/io_port.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/iopb.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/iopb.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/ipl.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/ktss.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/ktss.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/kttd_interface.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/kttd_machdep.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/ldt.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/ldt.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/lock.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/locore.S | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/loose_ends.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/mach_param.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/machine_routines.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/machspl.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/mp_desc.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/mp_desc.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/pcb.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/phys.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/pic.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/pic.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/pio.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/pit.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/pit.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/pmap.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/proc_reg.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/sched_param.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/seg.c | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/seg.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/setjmp.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/spl.S | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/spl.h | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/thread.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/time_stamp.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/timer.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/trap.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/trap.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/tss.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/user_ldt.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/user_ldt.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/vm_param.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/vm_tuning.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/xpr.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386/zalloc.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/asm_startup.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/autoconf.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/blit.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/blitreg.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/blituser.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/blitvar.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/boothdr.S | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/com.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/comreg.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/conf.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/cons_conf.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/cram.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/dev_hdr.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/device_emul.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/disk.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/ds8390.h | BSD-4-Clause | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/eisa.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/fd.c | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/fdreg.h | CMU | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/if_hpp.c | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/if_ns.c | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/if_nsreg.h | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/if_ul.c | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/if_wd.c | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/block/cmd640.c | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/block/floppy.c | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/block/genhd.c | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/block/ide-cd.c | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/block/ide.c | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/block/ide.h | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/block/ide_modes.h | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/block/rz1000.c | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/block/triton.c | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/bitops.h | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/byteorder.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/delay.h | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/dma.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/errno.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/fcntl.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/floppy.h | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/io.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/ioctl.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/irq.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/page.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/param.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/processor.h | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/ptrace.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/resource.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/segment.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/sigcontext.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/signal.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/socket.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/stat.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/statfs.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/string.h | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/system.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/termios.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/types.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/asm/unistd.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/autoconf.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/binfmts.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/bios32.h | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/blk.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/blkdev.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/cdrom.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/config.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/delay.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/errno.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/etherdevice.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/fcntl.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/fd.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/fdreg.h | IBM | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/fs.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/genhd.h | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/hdreg.h | IBM | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/head.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/if.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/if_arp.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/if_ether.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/if_tr.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/igmp.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/in.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/inet.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/interrupt.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/ioctl.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/ioport.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/ip.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/ipc.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/kdev_t.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/kernel.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/kernel_stat.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/limits.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/linkage.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/locks.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/major.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/malloc.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/math_emu.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/mc146818rtc.h | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/minix_fs.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/minix_fs_sb.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/mm.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/module.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/mount.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/net.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/netdevice.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/nfs.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/notifier.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/pagemap.h | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/param.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/pci.h | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/personality.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/proc_fs.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/ptrace.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/quota.h | BSD-4-Clause | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/resource.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/route.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/sched.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/scsi.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/scsicam.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/sem.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/signal.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/skbuff.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/smp.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/socket.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/sockios.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/stat.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/stddef.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/string.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/tasks.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/tcp.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/termios.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/time.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/timer.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/tqueue.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/trdevice.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/tty.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/tty_driver.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/tty_ldisc.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/types.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/uio.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/unistd.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/utsname.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/version.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/vfs.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/vm86.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/linux/wait.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/af_unix.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/arp.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/atalkcall.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/ax25.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/ax25call.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/checksum.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/datalink.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/icmp.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/ip.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/ip_alias.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/ip_forward.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/ipip.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/ipx.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/ipxcall.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/netlink.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/netrom.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/nrcall.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/p8022.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/p8022call.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/protocol.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/psnap.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/psnapcall.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/rarp.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/raw.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/route.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/slhc.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/snmp.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/sock.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/tcp.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/include/net/udp.h | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/linux_autoirq.c | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/linux_block.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/linux_dma.c | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/linux_emul.h | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/linux_init.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/linux_irq.c | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/linux_kmem.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/linux_misc.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/linux_net.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/linux_port.c | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/linux_printk.c | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/linux_sched.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/linux_soft.c | GPL | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/linux_timer.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/linux_version.c | Utah | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/linux_vsprintf.c | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/net/3c501.c | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/net/3c503.c | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/net/3c503.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/net/3c505.c | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/net/3c505.h | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/net/3c507.c | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/net/3c509.c | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/net/3c59x.c | Unknown | i386 | 2025-05-25T16:28:16-07:00 |
+| i386/kernel/i386at/gpl/linux/net/8390.c | Unknown BSD-like | i386 | 2025-05-25T16:28:16-07:00 |
+| include/Mach/a.out.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/alert.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/alloca.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/assert.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/boolean.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/boot.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/cdefs.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/cthread_internals.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/cthreads.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/ctype.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/default_pager_types.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/elf.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/errno.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/error.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/errorlib.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/exception.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/exec.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/exec/a.out.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/fcntl.h | Unknown | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/flick_mach3.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/flick_mach3_glue.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/flick_mach3mig_glue.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/host_info.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/inline.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/ioctl.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/kern_return.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/limits.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/lmm.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/mach_param.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/mach_traps.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/mach_types.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/machine.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/macro_help.h | Unknown | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/malloc.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/memory.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/memory_object.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/message.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/mig_errors.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/mig_support.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/mman.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/msg_type.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/norma_special_ports.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/notify.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/options.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/pc_sample.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/policy.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/port.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/proc_ops.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/processor_info.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/profil.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/profilparam.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/reboot.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/rpc.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/signal.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/stat.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/std_types.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/stddef.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/stdio.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/stdlib.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/string.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/strings.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/syscall_sw.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/task_info.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/task_special_ports.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/termios.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/thread_info.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/thread_special_ports.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/thread_status.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/thread_switch.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/time 2.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/time.h | Utah | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/time_value.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/types.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/unistd.h | Unknown | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/version.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/vm_attributes.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/vm_inherit.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/vm_param.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/vm_prot.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/Mach/vm_statistics.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/SYS.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/alpha/ansi.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/alpha/cpu.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/alpha/endian.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/alpha/limits.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/alpha/param.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/alpha/ptrace.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/alpha/signal.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/alpha/stdarg.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/alpha/trap.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/alpha/types.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/alpha/va-alpha.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/alpha/vmparam.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/arp.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/audit.h | Unknown | include | 2025-05-26T03:37:12-07:00 |
+| include/auth.h | Unknown | include | 2025-05-26T16:04:21-07:00 |
+| include/bid.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/bidctl.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/bind.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/blast.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/c23_arch.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/cap.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/chan.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/crypt.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/device/audio_status.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/device/bpf.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/device/device_types.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/device/disk_status.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/device/net_status.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/device/tape_status.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/device/tty_status.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/diagnostic.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/dirent.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/dns.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/enclave.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/eon.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/eth.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/eth_host.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/event 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/event.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/gateway.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/gc 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/gc.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/gethost 2.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/gethost.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/gmp.h | GPL | include | 2025-05-25T16:28:16-07:00 |
+| include/i386/ansi.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/i386/asm.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/i386/cpu.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/i386/endian.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/i386/exec.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/i386/limits.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/i386/param.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/i386/ptrace.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/i386/signal.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/i386/stdarg.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/i386/svr4_machdep.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/i386/trap.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/i386/types.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/i386/varargs.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/i386/vmparam.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/icmp.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/id128.h | Unknown | include | 2025-05-26T03:37:12-07:00 |
+| include/idmap 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/idmap.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/inet.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/ip.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/ip_host.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/ipc_queue.h | Unknown | include | 2025-05-25T10:26:49-07:00 |
+| include/join.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/keystore.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/km.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/list 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/list.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/llc.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/mach.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/mach_debug/hash_info.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/mach_debug/ipc_info.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/mach_debug/mach_debug_types.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/mach_debug/pc_info.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/mach_debug/vm_info.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/mach_debug/zone_info.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/mach_error.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/mach_init.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/md5hash 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/md5hash.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/mips/SYS.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/mips/ansi.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/mips/cpu.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/mips/endian.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/mips/limits.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/mips/param.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/mips/ptrace.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/mips/signal.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/mips/stdarg.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/mips/trap.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/mips/types.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/mips/vmparam.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/mrouting.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/mselect.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/msg 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/msg.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/msg_s 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/msg_s.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/netmask 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/netmask.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/ns532/ansi.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/ns532/cpu.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/ns532/endian.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/ns532/exec.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/ns532/limits.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/ns532/param.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/ns532/ptrace.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/ns532/signal.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/ns532/stdarg.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/ns532/types.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/ns532/varargs.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/ns532/vmparam.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/oddlibs/fd_set.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/oddlibs/netdb.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/oddlibs/netinet/in.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/oddlibs/p_defs.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/oddlibs/pid.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/oddlibs/ssize.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/adopt.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/agent.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/agent.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/async.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/async.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/bound.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/class_id.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/class_id.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/common.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/defaults.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/defaults.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/inform.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/init_reboot.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/interface.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/interface.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/ipc_action.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/ipc_action.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/packet.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/packet.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/release.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/renew.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/request.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/script_handler.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/script_handler.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/select.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/states.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/states.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/util.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpagent/util.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/dhcpinfo/dhcpinfo.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/ifparse/ifparse.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/sbin/netstrategy/netstrategy.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/chat/chat.c | Public domain | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/dns-sd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/finger.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/ftp/auth.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/ftp/cmds.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/ftp/cmds_gss.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/ftp/cmdtab.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/ftp/domacro.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/ftp/ftp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/ftp/ftp_var.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/ftp/getpass.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/ftp/glob.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/ftp/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/ftp/pclose.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/ftp/ruserpass.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/ftp/secure.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/nc/atomicio.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/nc/atomicio.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/nc/netcat.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/nc/socks.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/nc/strtonum.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/nc/strtonum.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/nca/ncab2clf.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/netstat/netstat.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/netstat/unix.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/auth.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/cbcp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/cbcp.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/ccp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/ccp.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/chap.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/chap.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/chap_ms.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/chap_ms.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/demand.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/eui64.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/fsm.c | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/fsm.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/ipcp.c | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/ipcp.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/ipv6cp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/ipv6cp.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/lcp.c | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/lcp.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/magic.c | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/magic.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/main.c | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/mschap_test.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/multilink.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/options.c | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/patchlevel.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/pathnames.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/minconn.c | GPL | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/passprompt.c | GPL | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/pppoe.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/pppd.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/sys-solaris.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/upap.c | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/upap.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppd/utils.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppdump/bsd-comp.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppdump/deflate.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppdump/ppp-comp.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppdump/pppdump.c | GPL | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppdump/zlib.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppdump/zlib.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/pppstats/pppstats.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/rcp.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/rdate.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/rdist/defs.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/rdist/docmd.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/rdist/expand.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/rdist/krb5defs.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/rdist/lookup.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/rdist/main.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/rdist/server.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/rlogin.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/rsh.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/ruptime.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/rwho.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/talk/ctl.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/talk/ctl.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/talk/ctl_transact.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/talk/display.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/talk/get_addrs.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/talk/get_names.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/talk/init_disp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/talk/invite.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/talk/io.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/talk/look_up.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/talk/msgs.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/talk/talk.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/talk/talk.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/talk/talk_ctl.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/auth.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/auth.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/authenc.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/commands.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/defines.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/enc_des.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/encrypt.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/encrypt.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/externs.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/general.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/genget.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/kerberos5.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/main.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/network.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/ring.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/ring.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/sys_bsd.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/telnet.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/terminal.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/types.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/telnet/utilities.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/tftp/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/tftp/tftp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/tftp/tftpprivate.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/tftp/tftpsubs.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/whois.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/6to4relay.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/arp.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/gettable.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/hostconfig.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/htable/htable.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/htable/htable.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/if_mpadm.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/defs.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/ifconfig.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/ifconfig.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/revarp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ilbadm/ilbadm.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ilbadm/ilbadm.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ilbadm/ilbadm_hc.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ilbadm/ilbadm_import.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ilbadm/ilbadm_nat.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ilbadm/ilbadm_rules.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ilbadm/ilbadm_sg.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ilbadm/ilbadm_stats.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ilbadm/ilbadm_subr.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.comsat.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.fingerd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/COPYRIGHT.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/access.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/acl.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/authenticate.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/authenticate.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/authuser.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/ckconfig.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/config.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/conversions.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/conversions.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/domain.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/extensions.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/extensions.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/ftpcount.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/ftpd.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/ftprestart.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/ftpshut.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/getpwnam.c | Unknown | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/getpwnam.h | Unknown | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/glob.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/gssutil.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/gssutil.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/hostacc.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/hostacc.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/inet.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/logwtmp.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/pathnames.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/paths.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/popen.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/private.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/privatepw.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/privs.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/proto.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/rdservers.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/realpath.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/restrict.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/routevector.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/strcasestr.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/strsep.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/timeout.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/vers.c | Unknown | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/wu_config.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/wu_fnmatch.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/wu_fnmatch.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/xferlog.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.rarpd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/in.rdisc.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.rexecd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.rlogind.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.rshd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.rwhod.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.talkd/announce.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.talkd/ctl.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.talkd/in.talkd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.talkd/print.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.talkd/process.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.talkd/table.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.talkd/talkd_impl.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.telnetd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/in.tftpd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/inetadm/inetadm.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/inetconv/inetconv.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ipaddrsel.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ipmpstat/ipmpstat.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ipqosconf/ipqosconf.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ipqosconf/ipqosconf.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ipsecutils/ikeadm.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ipsecutils/ipsecalgs.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ipsecutils/ipsecconf.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ipsecutils/ipseckey.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/kssl/kssladm/kssladm.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/kssl/kssladm/kssladm.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/kssl/kssladm/kssladm_create.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/kssl/kssladm/kssladm_delete.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/kssl/kssladm/ksslutil.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/kssl/ksslcfg/ksslcfg.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/kssl/ksslcfg/ksslcfg.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/kssl/ksslcfg/ksslcfg_create.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/kssl/ksslcfg/ksslcfg_delete.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ndd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ping/ping.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ping/ping.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ping/ping_aux.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/ping/ping_aux6.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/route.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/routeadm/routeadm.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/at.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/fakewin.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/fw.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/fw_lib.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/fw_rpc.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/nfs4_cmn.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/nfs4_prot.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/nfs4_xdr.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/nis_clnt.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/ntp.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/slp.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_aarp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_adsp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_aecho.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_apple.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_arp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_atp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_bparam.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_bpdu.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_capture.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_ctl.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_dhcp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_dhcpv6.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_display.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_dns.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_ether.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_filter.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_http.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_icmp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_igmp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_ip.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_ipaddr.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_ipsec.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_isis.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_ldap.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_mip.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_mip.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_mount.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_nbp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_netbios.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_nfs.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_nfs.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_nfs3.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_nfs4.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_nfs_acl.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_nis.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_nisplus.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_nlm.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_ntp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_ospf.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_ospf.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_ospf6.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_ospf6.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_pf.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_pmap.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_ppp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_ppp.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_pppoe.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_rip.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_rip6.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_rpc.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_rpcprint.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_rpcsec.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_rport.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_rquota.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_rstat.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_rtmp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_sctp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_slp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_smb.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_socks.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_solarnet.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_tcp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_tftp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_trill.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_udp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_vlan.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_zip.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/soconfig.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/sppptun/sppptun.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/syncinit.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/syncloop.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/traceroute/traceroute.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/traceroute/traceroute.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/traceroute/traceroute_aux.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/traceroute/traceroute_aux6.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/wificonfig/wificonfig.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/parisc/ansi.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/parisc/cpu.h | Utah | include | 2025-05-25T16:28:16-07:00 |
+| include/parisc/endian.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/parisc/exec.h | Utah | include | 2025-05-25T16:28:16-07:00 |
+| include/parisc/limits.h | Utah | include | 2025-05-25T16:28:16-07:00 |
+| include/parisc/param.h | Utah | include | 2025-05-25T16:28:16-07:00 |
+| include/parisc/proc.h | Utah | include | 2025-05-25T16:28:16-07:00 |
+| include/parisc/ptrace.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/parisc/regalias.h | Utah | include | 2025-05-25T16:28:16-07:00 |
+| include/parisc/signal.h | Utah | include | 2025-05-25T16:28:16-07:00 |
+| include/parisc/stdarg.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/parisc/trap.h | Utah | include | 2025-05-25T16:28:16-07:00 |
+| include/parisc/types.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/parisc/vmparam.h | Utah | include | 2025-05-25T16:28:16-07:00 |
+| include/part 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/part.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/event_monitor.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/hostbyname.c | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/hoststr.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/idmap/idmap.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/idmap/idmap_init.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/idmap/idmap_internal.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/idmap/idmap_templ.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/idmap/tests/mapTest.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/idmap/tests/mapTestCor.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/idmap/tests/mapTestCor2.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/idmap/tests/mapTestPerf.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/include/compose.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/include/x_stdio.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/list.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/msg.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/msg_internal.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/netmask.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/ocsum.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/part.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/prottbl.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/prottbl_i.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/prottbl_parse.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/romopt.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/rwlock.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/sessn_gc.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/upi.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/upi_defaults.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pi/xk_debug.c | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/posix.h | Unknown | include | 2025-05-25T10:36:17-07:00 |
+| include/posix_ipc.h | Unknown | include | 2025-05-26T16:04:21-07:00 |
+| include/posix_wrap.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/prot/auth.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/protocols.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/prottbl 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/prottbl.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/pthread.h | Unknown | include | 2025-05-25T10:38:55-07:00 |
+| include/romopt 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/romopt.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/rwlock 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/rwlock.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/sarProt.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/search.h | Public domain | include | 2025-05-25T16:28:16-07:00 |
+| include/select.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/servers/machid_lib.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/servers/machid_types.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/servers/netname_defs.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/shahash 2.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/shahash.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/sim.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/string.h | BSD-4-Clause | include | 2025-05-26T03:15:54-07:00 |
+| include/sunrpc.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/svr4/cmd/calendar/calprog.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cat/cat.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/finger.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/ftp/cmds.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/ftp/cmdtab.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/ftp/domacro.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/ftp/ftp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/ftp/ftp_var.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/ftp/getpass.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/ftp/glob.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/ftp/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/ftp/pclose.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/ftp/ruserpass.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/netstat/if.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/netstat/inet.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/netstat/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/netstat/route.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/netstat/unix.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/rcp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/rdate.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/rlogin.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/rsh.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/ruptime.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/rwho.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/talk/ctl.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/talk/ctl.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/talk/ctl_transact.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/talk/display.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/talk/get_addrs.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/talk/get_names.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/talk/init_disp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/talk/invite.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/talk/io.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/talk/look_up.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/talk/msgs.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/talk/talk.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/talk/talk.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/talk/talk_ctl.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/telnet.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/tftp/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/tftp/tftp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/tftp/tftpsubs.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.bin/whois.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/arp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/gettable.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/htable/htable.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/htable/htable.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/ifconfig.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.bootp/bootp.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.bootp/bootpd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.bootp/bootpd.h | CMU | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.bootp/hash.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.bootp/hash.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.bootp/readfile.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.comsat.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.fingerd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.ftpd/ftpd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.ftpd/getusershell.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.ftpd/logwtmp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.ftpd/popen.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.ftpd/vers.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/db.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/db_dump.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/db_load.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/db_lookup.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/db_reload.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/db_save.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/db_update.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/ns.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/ns_forw.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/ns_init.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/ns_main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/ns_maint.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/ns_req.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/ns_resp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/ns_sort.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/tools/nslookup/debug.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/tools/nslookup/getinfo.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/tools/nslookup/list.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/tools/nslookup/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/tools/nslookup/res.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/tools/nslookup/send.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/tools/nslookup/skip.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/tools/nslookup/subr.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/tools/nstest.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.named/version.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.rarpd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.rexecd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.rlogind.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/af.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/af.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/defs.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/if.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/inet.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/input.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/interface.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/output.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/protocol.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/startup.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/table.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/tables.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/timer.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/tools/query.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/tools/trace.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/trace.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.routed/trace.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.rshd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.rwhod.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.talkd/announce.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.talkd/ctl.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.talkd/in.talkd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.talkd/print.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.talkd/process.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.talkd/table.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.telnetd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.tftpd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/in.tnamed.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/inetd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/ping.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/route.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/slink/builtin.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/slink/defs.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/slink/exec.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/slink/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/slink/parse.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmd-inet/usr.sbin/trpt.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cmp/cmp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/compress/compress.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/cpiopc/cpiopc.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/ctrace/constants.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/ctrace/global.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/ctrace/lookup.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/ctrace/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/ctrace/runtime.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/ctrace/trace.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/dbfconv/dbfconv.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/dbfconv/local.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/dbfconv/nlsstr.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/devmgmt/confck/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/devmgmt/devattr/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/devmgmt/devfree/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/devmgmt/devreserv/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/devmgmt/getdev/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/devmgmt/getdgrp/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/devmgmt/getvol/getvol.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/devmgmt/listdgrp/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/devmgmt/putdev/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/devmgmt/putdgrp/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/diff3/diff3prog.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/du/du.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/echo/echo.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/init/init.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/join/join.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/last/last.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/layers/deodx.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/layers/layers.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/layers/misc/ismpx.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/layers/misc/jterm.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/layers/misc/jwin.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/layers/relogin.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/layers/set_enc.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/layers/sxtstat.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/layers/wtinit/pcheck.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/layers/wtinit/proto.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/layers/wtinit/proto.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/layers/wtinit/wtinit.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/layers/xtraces.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/layers/xts.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/layers/xtstats.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/layers/xtt.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/mesg/mesg.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/mkfifo/mkfifo.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/mkmsgs/mkmsgs.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/nice/nice.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/priocntl/priocntl.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/priocntl/priocntl.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/priocntl/rtpriocntl.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/priocntl/subr.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/priocntl/tspriocntl.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/proto-cmd/contents.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/proto-cmd/fixswap.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/proto-cmd/links.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/proto-cmd/machine_type.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/proto-cmd/mkflist.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/proto-cmd/not_found.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/proto-cmd/setmods.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/proto-cmd/x286.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/pwd/pwd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/rmount/fqn.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/rmount/mntlock.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/rmount/rd_rmnttab.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/rmount/rmnttry.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/rmount/rmount.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/rmount/rumount.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/rmount/wr_rmnttab.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/rpcinfo/rpcinfo.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/setmnt/setmnt.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/setpgrp/setpgrp.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/cmd/common/cc.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/dump/common/debug.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/dump/common/dump.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/dump/common/dump.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/dump/common/dumpmap.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/dump/common/fcns.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/aouthdr.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/ar.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/bool.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/ccstypes.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/dwarf.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/elf.h | Unknown | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/filehdr.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/ldfcn.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/libelf.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/linenum.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/link.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/patch.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/reloc.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/scnhdr.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/storclass.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/syms.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/sys/auxv.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/sys/elf.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/sys/elf_386.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/sys/elf_860.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/sys/elf_M32.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/sys/elf_SPARC.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/sys/elftypes.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/sys/etype_I386.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/sys/etype_I860.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/sys/etype_M32.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/sys/etype_SPARC.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/sys/etype_UTS.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/common/sys/etype_VAX.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/i386/paths.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/i386/sgs.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/inc/i386/tv.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/lex/common/once.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/lex/common/sub1.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/lex/common/sub2.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sgs/strip/common/main.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/split/split.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/strings/strings.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/strings/x.out.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/sulogin/sulogin.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/tabs/tabs.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/tee/tee.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/tty/tty.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/valtools/ckdate.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/valtools/ckgid.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/valtools/ckint.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/valtools/ckitem.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/valtools/ckkeywd.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/valtools/ckpath.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/valtools/ckrange.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/valtools/ckstr.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/valtools/cktime.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/valtools/ckuid.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/valtools/ckyorn.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/valtools/puttext.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/valtools/usage.h | Unknown | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/misc/ctags.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/misc/fold.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/misc/mkstr.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/misc/xstr.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/bcopy.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_addr.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_argv.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_cmds.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_cmds2.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_cmdsub.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_data.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_extern.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_get.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_io.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_put.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_re.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_re.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_set.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_subr.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_temp.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_temp.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_tty.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_tty.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_tune.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_unix.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_v.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_vadj.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_vars.h | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_vget.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_vis.h | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_vmain.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_voper.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_vops.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_vops2.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_vops3.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_vput.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ex_vwind.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/expreserve.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/exrecover.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ovdoprnt.s | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/ovprintf.c | BSD-4-Clause | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/vi/port/printf.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/wall/wall.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/whodo/whodo.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/svr4/cmd/write/write.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/sys/acct.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/aout.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/assert.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/audit.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/auth.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/buf.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/cdefs.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/clist.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/cmu_queue.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/coff.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/conf.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/device.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/dir.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/dirent.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/disk.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/disklabel.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/diskslice.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/dkbad.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/dkstat.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/dmap.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/domain.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/elf.h | Utah | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/errno.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/exec.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/exec_file.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/fbio.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/fcntl.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/file.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/filedesc.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/filio.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/gmon.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/gprof.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/ioccom.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/ioctl.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/ioctl_compat.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/ipc.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/kernel.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/ktrace.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/macro_help.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/malloc.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/map.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/mbuf.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/mman.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/mount.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/msgbuf.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/mtio.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/namei.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/parallel.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/param.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/proc.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/protosw.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/ptrace.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/queue.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/reboot.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/resource.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/resourcevar.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/select.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/shared_lock.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/signal.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/signalvar.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/socket.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/socketvar.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/sockio.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/som.h | Utah | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/stat.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/synch.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/sysctl.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/syslimits.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/syslog.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/systm.h | BSD-4-Clause | include | 2025-05-26T03:15:54-07:00 |
+| include/sys/table.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/tablet.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/termios.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/time.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/timeb.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/times.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/tprintf.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/trace.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/tty.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/ttychars.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/ttycom.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/ttydefaults.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/ttydev.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/types.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/ucred.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/uio.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/un.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/unistd.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/unpcb.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/user.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/ushared.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/utsname.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/ux_exception.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/vadvise.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/vcmd.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/vlimit.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/vmmeter.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/vnode.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/vsio.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/wait.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/sys/zalloc.h | CMU | include | 2025-05-25T16:28:16-07:00 |
+| include/sysv4 2.h | GPL | include | 2025-05-26T12:20:38-07:00 |
+| include/sysv4 3.h | GPL | include | 2025-05-26T12:20:38-07:00 |
+| include/sysv4.h | Unknown | include | 2025-05-26T12:20:38-07:00 |
+| include/sysvr3.cpio/32/usr/src/cmd/lp/cmd/lpadmin/send_message.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/sysvr3.cpio/32/usr/src/cmd/lp/cmd/lpstat/add_mounted.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/sysvr3.cpio/32/usr/src/cmd/lp/cmd/lpstat/send_message.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/sysvr3.cpio/32/usr/src/cmd/lp/lib/filters/dumpfilters.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/sysvr3.cpio/32/usr/src/cmd/lp/lib/filters/filtertable.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/sysvr3.cpio/32/usr/src/cmd/lp/lib/filters/loadfilters.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/sysvr3.cpio/32/usr/src/cmd/lp/model/drain.output.c | Unknown BSD-like | include | 2025-05-26T12:20:38-07:00 |
+| include/tcp.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/time.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/tm-sysv4.h | GPL | include | 2025-05-26T12:20:38-07:00 |
+| include/trace 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/trace.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/udp.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/upi 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/upi.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/upi_inline 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/upi_inline.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/vcache.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/vchan.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/vdisorder.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/vdrop.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/vm.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/vmux.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/vnet.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/vsize.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/vtap.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/x86_64/ansi.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/x86_64/asm.h | Unknown | include | 2025-05-25T16:28:16-07:00 |
+| include/x86_64/cpu.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/x86_64/endian.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/x86_64/exec.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/x86_64/limits.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/x86_64/param.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/x86_64/ptrace.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/x86_64/signal.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/x86_64/stdarg.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/x86_64/trap.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/x86_64/types.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/x86_64/varargs.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/x86_64/vmparam.h | BSD-4-Clause | include | 2025-05-25T16:28:16-07:00 |
+| include/x_util 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/x_util.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/xk_debug 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/xk_debug.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/xkernel 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/xkernel.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/xkpm.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/xm-sysv4.h | GPL | include | 2025-05-26T12:20:38-07:00 |
+| include/xtime 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/xtime.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/xtype 2.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| include/xtype.h | Unknown BSD-like | include | 2025-05-25T16:28:16-07:00 |
+| ino.h | Unknown | ino.h | 2025-05-25T16:31:15-07:00 |
+| inode.h | Unknown | inode.h | 2025-05-25T16:31:15-07:00 |
+| iommu/iommu 2.c | Unknown | iommu | 2025-05-25T16:31:15-07:00 |
+| iommu/iommu 2.h | Unknown | iommu | 2025-05-25T16:31:15-07:00 |
+| iommu/iommu.c | Unknown | iommu | 2025-05-25T16:31:15-07:00 |
+| iommu/iommu.h | Unknown | iommu | 2025-05-25T16:31:15-07:00 |
+| ipc.c | Unknown | ipc.c | 2025-05-25T10:39:50-07:00 |
+| ken/alloc.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/clock.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/fio.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/iget.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/main.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/malloc.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/nami.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/pipe.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/prf.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/rdwri.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/sig.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/slp.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/subr.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/sys1.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/sys2.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/sys3.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/sys4.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/sysent.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/text.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| ken/trap.c | Unknown | ken | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/float-conv.c | IBM | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/hdr-utils.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/hdr-utils.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/mach-msg-intr.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/mach-xfer.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/machmsg_int.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/machnetipc.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/machripc_internal.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/machripc_xfer.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/nns.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/nns.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/nns_boot.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/nns_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/nns_procs.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/port-maint.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/port-maint_internal.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/ssr.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/ssr.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/netipc/ssr_internal.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/gen/xk_lproxy.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/gen/xk_lproxyS.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/gen/xk_lproxyU.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/gen/xk_uproxy.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/gen/xk_uproxyS.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/gen/xk_uproxyU.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/lproxy.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/lproxy.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/lproxy_user.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/proxy_offset.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/proxy_util.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/proxy_util.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/proxy_util_ink.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/proxy_util_ook.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/uproxy.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/uproxy.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/xk_mig_sizes.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/xk_mig_t.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/proxy/xk_mms.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/gen/xsi_server.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/gen/xsi_user.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/gen/xsi_user.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/msg_stream.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/msg_stream.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/util.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/util.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/xk_msg_server.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/xksocket.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/xksocket.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/xsi.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/xsi_bench.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/xsi_bench.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/xsi_main.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/xsi_notify.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/xsi_notify.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/xsi_services.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/xsi_services.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api 2/socket/xsi_types.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/float-conv.c | IBM | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/hdr-utils.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/hdr-utils.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/mach-msg-intr.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/mach-xfer.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/machmsg_int.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/machnetipc.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/machripc_internal.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/machripc_xfer.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/nns.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/nns.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/nns_boot.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/nns_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/nns_procs.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/port-maint.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/port-maint_internal.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/ssr.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/ssr.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/netipc/ssr_internal.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/proxy/lproxy.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/proxy/lproxy.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/proxy/lproxy_user.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/proxy/proxy_offset.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/proxy/proxy_util.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/proxy/proxy_util.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/proxy/proxy_util_ink.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/proxy/proxy_util_ook.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/proxy/uproxy.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/proxy/uproxy.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/proxy/xk_mig_sizes.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/proxy/xk_mig_t.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/proxy/xk_mms.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/gen/xsi_server.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/gen/xsi_user.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/gen/xsi_user.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/msg_stream.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/msg_stream.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/util.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/util.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/xk_msg_server.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/xksocket.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/xksocket.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/xsi.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/xsi_bench.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/xsi_bench.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/xsi_main.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/xsi_notify.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/xsi_notify.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/xsi_services.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/xsi_services.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/api/socket/xsi_types.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers 2/ethdrv/ether.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers 2/ethdrv/ether_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers 2/ns8390/if_ns8390.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers 2/xec596/xec596.c | Unknown | kern | 2025-05-26T03:38:58-07:00 |
+| kern/Mach Kernel/drivers 2/xklance/xklance.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers 2/xmed/t.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers 2/xmed/tcopy.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers 2/xmed/tcopy2.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers 2/xmed/tregdefs.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers 2/xmed/xmed.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers 2/xmed/xmed_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers 2/xmed/xmed_util.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers 2/xmed/xmed_util.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers/ethdrv/ether.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers/ethdrv/ether_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers/ns8390/if_ns8390.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers/xec596/xec596.c | Unknown | kern | 2025-05-26T03:38:58-07:00 |
+| kern/Mach Kernel/drivers/xklance/xklance.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers/xmed/t.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers/xmed/tcopy.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers/xmed/tcopy2.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers/xmed/tregdefs.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers/xmed/xmed.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers/xmed/xmed_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers/xmed/xmed_util.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/drivers/xmed/xmed_util.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/assert.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/config.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/event_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/kern_process_msg.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/platform.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/process.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/process_msg.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/rpc/auth.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/rpc/auth_des.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/rpc/auth_unix.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/rpc/clnt.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/rpc/key_prot.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/rpc/pmap_clnt.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/rpc/pmap_prot.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/rpc/pmap_rmt.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/rpc/raw.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/rpc/rpc.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/rpc/rpc_msg.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/rpc/svc.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/rpc/svc_auth.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/rpc/types.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/rpc/xdr.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/shepherd.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/utah/x_libc.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/x_libc.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/xk_mach.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include 2/xk_malloc.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/assert.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/config.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/event_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/kern_process_msg.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/platform.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/process.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/process_msg.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/rpc/auth.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/rpc/auth_des.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/rpc/auth_unix.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/rpc/clnt.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/rpc/key_prot.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/rpc/pmap_clnt.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/rpc/pmap_prot.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/rpc/pmap_rmt.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/rpc/raw.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/rpc/rpc.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/rpc/rpc_msg.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/rpc/svc.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/rpc/svc_auth.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/rpc/types.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/rpc/xdr.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/shepherd.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/utah/x_libc.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/x_libc.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/xk_mach.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/include/xk_malloc.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/arp.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/arp_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/arp_table.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/assert.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/auth.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/bid.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/bid_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/bidctl.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/bidctl_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/bind.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/blast.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/blast_internal.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/blast_mask16.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/blast_mask32.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/blast_mask64.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/blast_stack.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/chan.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/chan_internal.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/compose.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/config.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/crypt.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/dns.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/eth.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/eth_host.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/eth_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/event.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/event_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/gc.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/gethost.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/hdr-utils.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/icmp.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/icmp_internal.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/idmap.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/insque.h | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/ip.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/ip_host.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/ip_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/join.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/join_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/kern_process_msg.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/km.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/list.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/lproxy.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/lproxy_user.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/machripc_internal.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/machripc_xfer.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/md5hash.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/mselect.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/msg.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/msg_internal.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/msg_s.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/msg_stream.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/netmask.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/nns.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/nns_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/part.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/platform.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/port-maint_internal.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/port_mgr.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/port_mgr.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/process.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/process_msg.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/prottbl.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/prottbl_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/proxy_offset.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/proxy_util.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/rat.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/rat_internal.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/romopt.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/route.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/route_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/rrx.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/rrx_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/rwlock.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/sb.h | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/select.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/select_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/shahash.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/shepherd.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/sim.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/simsimeth_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/site.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/srx.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/srx_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/ssr.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/ssr_internal.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/sunrpc.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/sunrpc_error.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/sunrpc_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/tcp.h | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/tcp_debug.h | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/tcp_fsm.h | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/tcp_internal.h | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/tcp_port.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/tcp_seq.h | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/tcp_timer.h | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/tcp_var.h | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/tcpip.h | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/trace.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/udp.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/udp_internal.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/udp_port.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/upi.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/upi_inline.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/uproxy.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/util.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/vcache.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/vcache_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/vchan.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/vchan_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/vdisorder.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/vdisorder_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/vdrop.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/vdrop_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/vmux.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/vmux_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/vnet.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/vnet_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/vsize.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/vsize_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/vtap.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/vtap_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/x_libc.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/x_stdio.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/x_util.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xfer.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xfer_i.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xk_debug.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xk_mach.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xk_malloc.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xk_mig_sizes.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xk_mig_t.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xkernel.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xkpm.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xkpm_test.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xksocket.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xsi.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xsi_bench.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xsi_notify.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xsi_services.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xsi_types.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xtime.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/include/xtype.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/input_process.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/ptbl_static.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/utils.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/xk_flags.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/xkern.local/initRom.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/xkern.local/protTbl.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/xkern.local/protocols.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/xkern.local/protocols.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/xkern.local/ptblData.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/xkern.local/ptblData.old.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/xkern.local/ptbl_static.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel 2/xkern.local/traceLevels.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/arp.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/arp_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/arp_table.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/assert.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/auth.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/bid.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/bid_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/bidctl.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/bidctl_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/bind.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/blast.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/blast_internal.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/blast_mask16.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/blast_mask32.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/blast_mask64.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/blast_stack.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/chan.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/chan_internal.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/compose.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/config.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/crypt.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/dns.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/eth.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/eth_host.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/eth_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/event.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/event_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/gc.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/gethost.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/hdr-utils.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/icmp.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/icmp_internal.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/idmap.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/insque.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/ip.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/ip_host.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/ip_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/join.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/join_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/kern_process_msg.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/km.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/list.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/lproxy.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/lproxy_user.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/machripc_internal.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/machripc_xfer.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/md5hash.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/mselect.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/msg.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/msg_internal.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/msg_s.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/msg_stream.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/netmask.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/nns.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/nns_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/part.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/platform.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/port-maint_internal.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/port_mgr.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/port_mgr.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/process.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/process_msg.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/prottbl.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/prottbl_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/proxy_offset.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/proxy_util.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/rat.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/rat_internal.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/romopt.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/route.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/route_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/rrx.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/rrx_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/rwlock.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/sb.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/select.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/select_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/shahash.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/shepherd.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/sim.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/simsimeth_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/site.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/srx.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/srx_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/ssr.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/ssr_internal.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/sunrpc.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/sunrpc_error.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/sunrpc_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/tcp.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/tcp_debug.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/tcp_fsm.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/tcp_internal.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/tcp_port.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/tcp_seq.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/tcp_timer.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/tcp_var.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/tcpip.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/trace.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/udp.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/udp_internal.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/udp_port.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/upi.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/upi_inline.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/uproxy.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/util.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/vcache.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/vcache_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/vchan.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/vchan_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/vdisorder.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/vdisorder_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/vdrop.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/vdrop_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/vmux.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/vmux_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/vnet.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/vnet_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/vsize.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/vsize_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/vtap.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/vtap_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/x_libc.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/x_stdio.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/x_util.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xfer.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xfer_i.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xk_debug.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xk_mach.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xk_malloc.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xk_mig_sizes.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xk_mig_t.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xkernel.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xkpm.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xkpm_test.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xksocket.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xsi.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xsi_bench.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xsi_notify.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xsi_services.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xsi_types.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xtime.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/include/xtype.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/input_process.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/ptbl_static.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/utils.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/xk_flags.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/xkern.local/initRom.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/xkern.local/protTbl.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/xkern.local/protocols.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/xkern.local/protocols.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/xkern.local/ptblData.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/xkern.local/ptbl_static.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/inkernel/xkern.local/traceLevels.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/machkernel 2/device/device_init.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/machkernel 2/ipc/ipc_kmsg.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/machkernel 2/kern/ipc_kobject.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/machkernel 2/kern/ipc_mig.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/machkernel 2/kern/kalloc.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/machkernel 2/mips/parse_args.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/machkernel/device/device_init.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/machkernel/ipc/ipc_kmsg.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/machkernel/kern/ipc_kobject.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/machkernel/kern/ipc_mig.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/machkernel/kern/kalloc.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/machkernel/mips/parse_args.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk 2/alloc.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk 2/event.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk 2/init.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk 2/input_proc.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk 2/malloc.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk 2/options.h | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk 2/process.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk 2/stack.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk 2/time.c | Unknown BSD-like | kern | 2025-05-26T03:38:58-07:00 |
+| kern/Mach Kernel/pxk 2/trace.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk 2/traceLevels.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk 2/utils.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk 2/xk_machine.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk/alloc.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk/event.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk/init.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk/input_proc.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk/malloc.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk/options.h | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk/process.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk/stack.c | CMU | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk/time.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk/trace.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk/traceLevels.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk/utils.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/pxk/xk_machine.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/netipc/test/nnstest.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/netipc/test/unxk.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/accept.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/bind.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/close.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/connect.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/dup.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/dup2.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/fcntl.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/fork.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/getpeername.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/getservbyname.c | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/getservbyport.c | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/getservent.c | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/getsockname.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/getsockopt.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/ioctl.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/listen.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/read.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/readv.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/recv.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/recvfrom.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/recvmsg.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/select.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/send.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/sendmsg.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/sendto.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/setsockopt.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/socket.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_accept.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_bind.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_close.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_connect.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_dup.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_dup2.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_fcntl.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_fork.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_getpeernm.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_getsocknm.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_getsockopt.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_ioctl.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_listen.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_read.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_readv.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_recv.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_recvfrom.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_recvmsg.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_select.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_send.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_sendmsg.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_sendto.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_setsockopt.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_socket.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_write.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/syscalls/sc_writev.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/tst/rtrip.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/tst/truput.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/vfork.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/write.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/writev.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/xsi_main.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user 2/socket/xsi_main.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/netipc/test/nnstest.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/netipc/test/unxk.h | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/accept.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/bind.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/close.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/connect.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/dup.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/dup2.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/fcntl.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/fork.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/getpeername.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/getservbyname.c | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/getservbyport.c | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/getservent.c | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/getsockname.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/getsockopt.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/ioctl.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/listen.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/read.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/readv.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/recv.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/recvfrom.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/recvmsg.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/select.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/send.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/sendmsg.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/sendto.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/setsockopt.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/socket.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_accept.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_bind.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_close.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_connect.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_dup.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_dup2.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_fcntl.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_fork.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_getpeernm.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_getsocknm.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_getsockopt.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_ioctl.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_listen.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_read.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_readv.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_recv.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_recvfrom.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_recvmsg.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_select.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_send.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_sendmsg.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_sendto.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_setsockopt.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_socket.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_write.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/syscalls/sc_writev.s | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/tst/rtrip.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/tst/truput.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/vfork.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/write.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/writev.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/xsi_main.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/Mach Kernel/user/socket/xsi_main.h | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/audit.c | Unknown | kern | 2025-05-26T03:37:12-07:00 |
+| kern/auth.c | Unknown | kern | 2025-05-26T03:37:12-07:00 |
+| kern/bcmp.c | BSD-4-Clause | kern | 2025-05-26T03:27:28-07:00 |
+| kern/cerror.S | BSD-4-Clause | kern | 2025-05-25T16:31:15-07:00 |
+| kern/insque.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/ipc_queue.c | Unknown | kern | 2025-05-25T10:26:49-07:00 |
+| kern/protTbl.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/protocols.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/ptblData.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/ptblData.o2.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| kern/ptbl_static.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/qsort.c | BSD-4-Clause | kern | 2025-05-26T03:07:52-07:00 |
+| kern/remque.c | Unknown BSD-like | kern | 2025-05-25T16:31:15-07:00 |
+| kern/sched.c | Unknown | kern | 2025-05-25T01:51:27-07:00 |
+| kern/sched.h | Unknown | kern | 2025-05-25T01:51:27-07:00 |
+| kern/spinlock.h | Unknown | kern | 2025-05-25T01:51:27-07:00 |
+| kern/traceLevels.c | Unknown | kern | 2025-05-25T16:31:15-07:00 |
+| liblites/alpha/ntoh.c | Unknown BSD-like | liblites | 2025-05-25T16:31:15-07:00 |
+| liblites/bcmp.c | BSD-4-Clause | liblites | 2025-05-25T16:31:15-07:00 |
+| liblites/enclave.c | Unknown | liblites | 2025-05-25T16:31:15-07:00 |
+| liblites/exec_file.c | Unknown BSD-like | liblites | 2025-05-25T16:31:15-07:00 |
+| liblites/i386/in_cksum.c | BSD-4-Clause | liblites | 2025-05-25T16:31:15-07:00 |
+| liblites/i386/ntoh.S | CMU | liblites | 2025-05-25T16:31:15-07:00 |
+| liblites/libmach/doprnt.c | CMU | liblites | 2025-05-26T12:20:38-07:00 |
+| liblites/libmach/error_codes.c | CMU | liblites | 2025-05-26T12:20:38-07:00 |
+| liblites/libmach/errorlib.h | CMU | liblites | 2025-05-26T12:20:38-07:00 |
+| liblites/libmach/exit.c | CMU | liblites | 2025-05-26T12:20:38-07:00 |
+| liblites/libmach/get_privileged_ports.c | CMU | liblites | 2025-05-26T12:20:38-07:00 |
+| liblites/libmach/i386/SYS.h | Unknown | liblites | 2025-05-26T12:20:38-07:00 |
+| liblites/libmach/i386/_setjmp.s | CMU | liblites | 2025-05-26T12:20:38-07:00 |
+| liblites/libmach/i386/bcopy.s | CMU | liblites | 2025-05-26T12:20:38-07:00 |
+| liblites/libmach/i386/bzero.s | CMU | liblites | 2025-05-26T12:20:38-07:00 |
+| liblites/libmach/i386/crt0.c | CMU | liblites | 2025-05-26T12:20:38-07:00 |
+| liblites/libmach/i386/fork.s | CMU | liblites | 2025-05-26T12:20:38-07:00 |
+| liblites/libmach/i386/gcc.s | CMU | liblites | 2025-05-26T12:20:38-07:00 |
+| liblites/libmach/i386/memcpy.s | CMU | liblites | 2025-05-26T12:20:38-07:00 |
+| liblites/memcmp.c | BSD-4-Clause | liblites | 2025-05-25T16:31:15-07:00 |
+| liblites/mips/ntoh.c | Unknown BSD-like | liblites | 2025-05-25T16:31:15-07:00 |
+| liblites/ns532/in_cksum.c | BSD-4-Clause | liblites | 2025-05-25T16:31:15-07:00 |
+| liblites/ns532/misc_asm.S | Unknown BSD-like | liblites | 2025-05-25T16:31:15-07:00 |
+| liblites/posix_wrap.c | Unknown | liblites | 2025-05-25T16:31:15-07:00 |
+| liblites/x86_64/in_cksum.c | BSD-4-Clause | liblites | 2025-05-25T16:31:15-07:00 |
+| liblites/x86_64/ntoh.S | CMU | liblites | 2025-05-25T16:31:15-07:00 |
+| libposix/posix.c | Unknown | libposix | 2025-05-25T16:31:15-07:00 |
+| libposix/pthread.c | Unknown | libposix | 2025-05-25T16:31:15-07:00 |
+| netbsd/drivers/simeth/sim_ether.c | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/drivers/simeth/sim_ether_i.h | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/include/assert.h | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/include/config.h | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/include/event_i.h | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/include/machine.h | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/include/platform.h | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/include/process.h | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/include/x_libc.h | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/pxk/alloc.c | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/pxk/alloc_old.c | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/pxk/event.c | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/pxk/init.c | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/pxk/machine.c | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/pxk/process.c | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/pxk/redefines.c | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/pxk/start_thread.c | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/pxk/time.c | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/pxk/trace.c | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| netbsd/pxk/utils.c | Unknown BSD-like | netbsd | 2025-05-25T16:31:15-07:00 |
+| param.h | Unknown | param.h | 2025-05-25T16:31:15-07:00 |
+| posix.c | Unknown | posix.c | 2025-05-25T10:36:17-07:00 |
+| proc.h | Unknown | proc.h | 2025-05-25T16:31:15-07:00 |
+| protocols/arp/arp.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/arp/arp_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/arp/arp_rom.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/arp/arp_table.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/arp/arp_table.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/bid/bid.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/bid/bid_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/bidctl/bidctl.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/bidctl/bidctl_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/bidctl/bidctl_id.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/bidctl/bidctl_state.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/bidctl/bidctl_timer.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/blast/blast.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/blast/blast_control.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/blast/blast_debug.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/blast/blast_hdr.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/blast/blast_input.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/blast/blast_internal.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/blast/blast_mask16.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/blast/blast_mask32.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/blast/blast_mask64.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/blast/blast_output.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/blast/blast_stack.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/blast/blast_stack.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/blast/blast_util.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/chan/chan.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/chan/chan_client.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/chan/chan_debug.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/chan/chan_internal.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/chan/chan_mapchain.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/chan/chan_server.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/eth/eth.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/eth/eth_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/icmp/icmp.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/icmp/icmp_internal.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/icmp/icmp_reqrep.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/ip/ip.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/ip/ip_control.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/ip/ip_frag.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/ip/ip_gc.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/ip/ip_hdr.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/ip/ip_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/ip/ip_input.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/ip/ip_rom.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/ip/ip_util.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/ip/iproute.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/ip/route.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/ip/route_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/join/join.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/join/join_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/machnetipc/rrx.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/machnetipc/rrx.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/machnetipc/rrx_hdr.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/machnetipc/rrx_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/machnetipc/srx.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/machnetipc/srx.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/machnetipc/srx_hdr.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/machnetipc/srx_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/machnetipc/xfer.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/machnetipc/xfer.h | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/machnetipc/xfer_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/machnetipc/xfertest.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/pmap/xkpm.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/rat/rat.c | Unknown | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/rat/rat.h | Unknown | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/rat/rat_internal.h | Unknown | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/select/multi_select.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/select/select.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/select/select_common.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/select/select_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/simsimeth/simsimeth.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/simsimeth/simsimeth_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/sunrpc/sunrpc.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/sunrpc/sunrpc_client.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/sunrpc/sunrpc_ctl.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/sunrpc/sunrpc_error.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/sunrpc/sunrpc_error.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/sunrpc/sunrpc_hdr.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/sunrpc/sunrpc_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/sunrpc/sunrpc_server.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/tcp-tahoe/in_hacks.c | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp-tahoe/insque.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp-tahoe/sb.c | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp-tahoe/sb.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp-tahoe/tcp_debug.c | BSD-4-Clause | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/tcp-tahoe/tcp_debug.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp-tahoe/tcp_fsm.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp-tahoe/tcp_hdr.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/tcp-tahoe/tcp_input.c | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp-tahoe/tcp_internal.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp-tahoe/tcp_output.c | BSD-4-Clause | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/tcp-tahoe/tcp_port.c | Unknown | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp-tahoe/tcp_port.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp-tahoe/tcp_seq.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp-tahoe/tcp_subr.c | BSD-4-Clause | protocols | 2025-05-26T03:28:49-07:00 |
+| protocols/tcp-tahoe/tcp_timer.c | BSD-4-Clause | protocols | 2025-05-26T10:18:58-07:00 |
+| protocols/tcp-tahoe/tcp_timer.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp-tahoe/tcp_usrreq.c | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp-tahoe/tcp_var.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp-tahoe/tcp_x.c | BSD-4-Clause | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/tcp-tahoe/tcpip.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp/in_hacks.c | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp/insque.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp/sb.c | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp/sb.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp/tcp_debug.c | BSD-4-Clause | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/tcp/tcp_debug.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp/tcp_fsm.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp/tcp_hdr.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/tcp/tcp_input.c | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp/tcp_internal.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp/tcp_output.c | BSD-4-Clause | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/tcp/tcp_port.c | Unknown | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp/tcp_port.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp/tcp_seq.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp/tcp_subr.c | BSD-4-Clause | protocols | 2025-05-26T03:28:49-07:00 |
+| protocols/tcp/tcp_timer.c | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp/tcp_timer.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp/tcp_usrreq.c | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp/tcp_var.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/tcp/tcp_x.c | BSD-4-Clause | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/tcp/tcpip.h | BSD-4-Clause | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/blasttest.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/chantest.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/common_test.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/test/common_test_async.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/test/common_test_rpc.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/enabletest.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/ethtest.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/icmptest.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/iproutetest.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/iptest.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/rarptest.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/sartest.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/sunrpctest.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/tcptest.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/udpcrypttest.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/udptest.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/unixTcpClient.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/unixTcpServer.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/unixUdpClient.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/unixUdpServer.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/xkpm_client.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/test/xkpm_server.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/test/xkpm_test.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/test/xrpc_conc_test.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/test/xrpctest.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/udp/udp.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/udp/udp_internal.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/udp/udp_port.c | Unknown | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/udp/udp_port.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/util/port_mgr.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/util/port_mgr.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/vcache/vcache.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/vcache/vcache_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/vcache/vcache_list.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/vchan/vchan.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/vchan/vchan_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/vdisorder/vdisorder.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/vdisorder/vdisorder_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/vdrop/vdrop.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/vdrop/vdrop_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/vmux/vmux.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/vmux/vmux_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/vnet/vnet.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/vnet/vnet_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/vsize/vsize.c | Unknown BSD-like | protocols | 2025-05-26T03:15:54-07:00 |
+| protocols/vsize/vsize_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/vtap/vtap.c | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| protocols/vtap/vtap_i.h | Unknown BSD-like | protocols | 2025-05-25T16:31:15-07:00 |
+| reg.h | Unknown | reg.h | 2025-05-25T16:31:15-07:00 |
+| seg.h | Unknown | seg.h | 2025-05-25T16:31:15-07:00 |
+| server/i386/conf.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/i386/i386_exception.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/i386/misc_asm.S | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/i386/second_syscalls.S | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/i386/serv_machdep.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/audit.c | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/auth.c | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/cap.c | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/init_main.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/kern_acct.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/kern_descrip.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/kern_exec.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/kern_exit.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/kern_malloc.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/kern_proc.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/kern_prot.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/kern_resource.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/kern_sig.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/kern_subr.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/kern_sysctl.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/kern_time.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/kern_xxx.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/subr_log.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/subr_prf.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/subr_xxx.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/sys_generic.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/sys_process.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/sys_socket.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/tty.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/tty_compat.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/tty_conf.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/tty_pty.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/tty_subr.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/tty_tb.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/tty_tty.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/uipc_domain.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/uipc_mbuf.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/uipc_proto.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/uipc_socket.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/uipc_socket2.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/uipc_syscalls.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/uipc_usrreq.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/vfs_bio.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/vfs_cache.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/vfs_cluster.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/vfs_conf.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/vfs_init.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/vfs_lookup.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/vfs_subr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/vfs_syscalls.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/vfs_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/kern/vnode.c | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/mips/conf.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/mips/mips_exception.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/mips/misc_asm.S | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/mips/second_syscalls.S | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/mips/serv_machdep.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/deadfs/dead_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/fdesc/fdesc.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/fdesc/fdesc_vfsops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/fdesc/fdesc_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/fifofs/fifo.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/fifofs/fifo_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/kernfs/kernfs.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/kernfs/kernfs_vfsops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/kernfs/kernfs_vnops.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/nullfs/null.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/nullfs/null_subr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/nullfs/null_vfsops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/nullfs/null_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/portal/portal.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/portal/portal_vfsops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/portal/portal_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/procfs/procfs.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/procfs/procfs_ctl.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/procfs/procfs_fpregs.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/procfs/procfs_mem.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/procfs/procfs_note.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/procfs/procfs_regs.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/procfs/procfs_status.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/procfs/procfs_subr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/procfs/procfs_vfsops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/procfs/procfs_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/specfs/spec_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/specfs/specdev.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/umapfs/umap.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/umapfs/umap_subr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/umapfs/umap_vfsops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/umapfs/umap_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/union/libc.opendir.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/union/union.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/union/union_subr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/union/union_vfsops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/miscfs/union/union_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/bpf.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/bpf.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/bpf_compat.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/bpf_filter.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/bpfdesc.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/if.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/if.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/if_arp.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/if_dl.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/if_ethersubr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/if_llc.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/if_loop.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/if_ppp.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/net/if_ppp.h | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/net/if_sl.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/if_slvar.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/if_types.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/netisr.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/radix.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/radix.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/raw_cb.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/raw_cb.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/raw_usrreq.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/route.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/route.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/rtsock.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/slcompress.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/slcompress.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/net/slip.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/ccitt_proto.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/dll.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/hd_debug.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/hd_input.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/hd_output.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/hd_subr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/hd_timer.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/hd_var.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/hdlc.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/if_x25subr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/llc_input.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/llc_output.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/llc_subr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/llc_timer.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/llc_var.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/pk.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/pk_acct.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/pk_debug.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/pk_input.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/pk_llcsubr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/pk_output.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/pk_subr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/pk_timer.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/pk_usrreq.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/pk_var.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/x25.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/x25_sockaddr.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/x25acct.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netccitt/x25err.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/icmp_var.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/if_ether.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/if_ether.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/igmp.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/igmp.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/igmp_var.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/in.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/in.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/in_cksum.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/in_pcb.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/in_pcb.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/in_proto.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/in_systm.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/in_var.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/ip.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/ip_icmp.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/ip_icmp.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/ip_input.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/ip_mroute.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/ip_mroute.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/ip_output.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/ip_var.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/raw_ip.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/tcp.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/tcp_debug.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/tcp_debug.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/tcp_fsm.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/tcp_input.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/tcp_output.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/tcp_seq.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/tcp_subr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/tcp_timer.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/tcp_timer.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/tcp_usrreq.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/tcp_var.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/tcpip.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/udp.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/udp_usrreq.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netinet/udp_var.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/argo_debug.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/clnl.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/clnp.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/clnp_debug.c | BSD-4-Clause | server | 2025-05-26T10:18:58-07:00 |
+| server/netiso/clnp_er.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/clnp_frag.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/clnp_input.c | BSD-4-Clause | server | 2025-05-26T10:18:58-07:00 |
+| server/netiso/clnp_options.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/clnp_output.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/clnp_raw.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/clnp_stat.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/clnp_subr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/clnp_timer.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/cltp_usrreq.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/cltp_var.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/cons.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/cons_pcb.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/eonvar.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/esis.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/esis.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/idrp_usrreq.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/if_cons.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/if_eon.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/iso.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/iso.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/iso_chksum.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/iso_errno.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/iso_pcb.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/iso_pcb.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/iso_proto.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/iso_snpac.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/iso_snpac.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/iso_var.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/simd.h | Unknown | server | 2025-05-26T10:18:58-07:00 |
+| server/netiso/tp_astring.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_clnp.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_cons.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_driver.c | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_emit.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_events.h | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_inet.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_input.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_ip.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_iso.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_meas.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_meas.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_output.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_param.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_pcb.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_pcb.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_seq.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_stat.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_states.h | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_subr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_subr2.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_timer.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_timer.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_tpdu.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_trace.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_trace.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_user.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tp_usrreq.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tuba_subr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tuba_table.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tuba_table.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/tuba_usrreq.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/xebec/debug.h | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/xebec/llparse.c | Public domain | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/xebec/llparse.h | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/xebec/llscan.c | Public domain | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/xebec/main.c | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/xebec/main.h | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/xebec/malloc.c | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/xebec/malloc.h | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/xebec/procs.c | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/xebec/procs.h | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/xebec/putdriver.c | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/xebec/sets.c | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/xebec/sets.h | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/xebec/test_def.h | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/xebec/xebec.c | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netiso/xebec/xebec.h | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/idp.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/idp_usrreq.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/idp_var.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/ns.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/ns.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/ns_cksum.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/ns_error.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/ns_error.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/ns_if.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/ns_input.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/ns_ip.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/ns_output.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/ns_pcb.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/ns_pcb.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/ns_proto.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/sp.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/spidp.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/spp_debug.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/spp_debug.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/spp_timer.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/spp_usrreq.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/netns/spp_var.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfs.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfs_bio.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfs_node.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfs_nqlease.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfs_serv.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfs_socket.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfs_srvcache.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfs_subs.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfs_syscalls.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfs_vfsops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfs_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfsdiskless.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfsm_subs.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfsmount.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfsnode.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfsrtt.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfsrvcache.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nfsv2.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/nqnfs.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/rpcv2.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/nfs/xdr_subs.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ns532/conf.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/ns532/ns532_exception.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/ns532/second_syscalls.S | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/ns532/serv_machdep.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/parisc/Nbsd_server.c | Utah | server | 2025-05-25T16:31:15-07:00 |
+| server/parisc/conf.c | Utah | server | 2025-05-25T16:31:15-07:00 |
+| server/parisc/in_cksum.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/parisc/machdep.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/parisc/mem.c | Utah | server | 2025-05-25T16:31:15-07:00 |
+| server/parisc/parisc_exception.c | Utah | server | 2025-05-25T16:31:15-07:00 |
+| server/parisc/rpc.S | Utah | server | 2025-05-25T16:31:15-07:00 |
+| server/parisc/second_syscalls.S | Utah | server | 2025-05-25T16:31:15-07:00 |
+| server/parisc/serv_machdep.c | Utah | server | 2025-05-25T16:31:15-07:00 |
+| server/parisc/vm_machdep.c | Utah | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/bsd_msg.h | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/bsd_server.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/bsd_server_side.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/bsd_types.h | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/cmu_syscalls.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/cprocs.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/device.h | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/device_reply_hdlr.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/device_utils.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/disk_io.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/ether_io.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/gprof_support.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/import_mach.h | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/inittodr.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/mach_init_ports.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/netisr.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/port_object.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/port_object.h | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/proc_to_task.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/second_cons.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/second_traps.S | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/select.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/sendsig.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/serv_fork.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/serv_synch.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/serv_syscalls.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/server_defs.h | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/server_exec.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/server_init.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/signal_user.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/synch_prim.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/syscall_subr.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/syscall_subr.h | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/tape_io.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/tape_io.h | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/timer.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/timer.h | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/ux_server_loop.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/ux_syscall.c | CMU | server | 2025-05-26T03:37:12-07:00 |
+| server/serv/vm_glue.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/vm_syscalls.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/vn_pager.h | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/vn_pager_misc.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/xmm_interface.c | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/serv/zalloc.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/ext2_alloc.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/ext2_balloc.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/ext2_extern.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/ext2_fs.h | Utah | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/ext2_fs_i.h | Utah | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/ext2_fs_sb.h | Utah | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/ext2_inode.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/ext2_inode_cnv.c | Utah | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/ext2_linux_balloc.c | Utah | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/ext2_linux_ialloc.c | Utah | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/ext2_lookup.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/ext2_readwrite.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/ext2_subr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/ext2_vfsops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/ext2_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/fs.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/generic-bitops.h | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/i386-bitops.h | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ext2fs/x86_64-bitops.h | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ffs/ffs_alloc.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ffs/ffs_balloc.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ffs/ffs_extern.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ffs/ffs_inode.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ffs/ffs_subr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ffs/ffs_tables.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ffs/ffs_vfsops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ffs/ffs_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ffs/fs.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/lfs/lfs.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/lfs/lfs_alloc.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/lfs/lfs_balloc.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/lfs/lfs_bio.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/lfs/lfs_cksum.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/lfs/lfs_debug.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/lfs/lfs_extern.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/lfs/lfs_inode.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/lfs/lfs_segment.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/lfs/lfs_subr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/lfs/lfs_syscalls.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/lfs/lfs_vfsops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/lfs/lfs_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/mfs/mfs_extern.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/mfs/mfs_vfsops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/mfs/mfs_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/mfs/mfsiom.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/mfs/mfsnode.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/minixfs/minix_fs.h | Minix | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/minixfs/minixfs_lookup.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/minixfs/minixfs_lookup.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/minixfs/minixfs_vfsops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/minixfs/minixfs_vfsops.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/minixfs/minixfs_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/minixfs/minixfs_vnops.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/dinode.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/dir.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/inode.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/lockf.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/quota.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/ufs_bmap.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/ufs_disksubr.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/ufs_extern.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/ufs_ihash.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/ufs_inode.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/ufs_lockf.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/ufs_lookup.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/ufs_quota.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/ufs_readwrite.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/ufs_vfsops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/ufs_vnops.c | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/ufs/ufs/ufsmount.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/vm/vm.h | BSD-4-Clause | server | 2025-05-25T16:31:15-07:00 |
+| server/vm/vm_handlers.c | Unknown | server | 2025-05-25T16:31:15-07:00 |
+| server/x86_64/conf.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/x86_64/i386_exception.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/x86_64/misc_asm.S | CMU | server | 2025-05-25T16:31:15-07:00 |
+| server/x86_64/second_syscalls.S | Unknown BSD-like | server | 2025-05-25T16:31:15-07:00 |
+| server/x86_64/serv_machdep.c | CMU | server | 2025-05-25T16:31:15-07:00 |
+| sunos/drivers/simeth/sim_ether.c | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/drivers/simeth/sim_ether_i.h | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/include/assert.h | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/include/config.h | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/include/event_i.h | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/include/machine.h | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/include/platform.h | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/include/process.h | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/include/x_libc.h | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/pxk/alloc.c | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/pxk/alloc_old.c | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/pxk/event.c | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/pxk/init.c | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/pxk/machine.c | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/pxk/process.c | Unknown BSD-like | sunos | 2025-05-26T03:07:52-07:00 |
+| sunos/pxk/redefines.c | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/pxk/start_thread.c | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/pxk/time.c | Unknown BSD-like | sunos | 2025-05-26T03:07:52-07:00 |
+| sunos/pxk/trace.c | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| sunos/pxk/utils.c | Unknown BSD-like | sunos | 2025-05-25T16:31:15-07:00 |
+| systm.h | Unknown | systm.h | 2025-05-25T16:31:15-07:00 |
+| tests/audit/test_audit.c | Unknown | tests | 2025-05-26T16:04:21-07:00 |
+| tests/cap/test_cap.c | Unknown | tests | 2025-05-26T16:04:21-07:00 |
+| tests/fifo_test/test_fifo.c | Unknown | tests | 2025-05-26T16:04:21-07:00 |
+| tests/iommu/test_iommu.c | Unknown | tests | 2025-05-26T16:04:21-07:00 |
+| tests/pipe/test_pipe.c | Unknown | tests | 2025-05-25T10:36:17-07:00 |
+| tests/posix/test_posix.c | Unknown | tests | 2025-05-26T16:04:21-07:00 |
+| tests/spawn_wait/child.c | Unknown | tests | 2025-05-25T10:36:17-07:00 |
+| tests/spawn_wait/test_spawn_wait.c | Unknown | tests | 2025-05-25T10:36:17-07:00 |
+| tests/vm_fault/test_vm_fault.c | Unknown | tests | 2025-05-26T16:04:21-07:00 |
+| tests/xec596/test_xec596_init.c | Unknown | tests | 2025-05-26T03:38:58-07:00 |
+| text.h | Unknown | text.h | 2025-05-25T16:31:15-07:00 |
+| tty.h | Unknown | tty.h | 2025-05-25T16:31:15-07:00 |
+| user.h | Unknown | user.h | 2025-05-25T16:31:15-07:00 |
+| util/compose/compose.c | Unknown BSD-like | util | 2025-05-25T16:31:15-07:00 |
+| util/compose/compose_hp700.h | Unknown BSD-like | util | 2025-05-25T16:31:15-07:00 |
+| util/compose/compose_intelx86.h | Unknown BSD-like | util | 2025-05-25T16:31:15-07:00 |
+| util/compose/compose_mips.h | Unknown BSD-like | util | 2025-05-25T16:31:15-07:00 |
+| util/compose/compose_sparc.h | Unknown BSD-like | util | 2025-05-25T16:31:15-07:00 |
+| util/compose/compose_sun.h | Unknown | util | 2025-05-25T16:31:15-07:00 |
+| util/compose/error.c | Unknown BSD-like | util | 2025-05-25T16:31:15-07:00 |
+| util/compose/global.h | Unknown BSD-like | util | 2025-05-25T16:31:15-07:00 |
+| util/compose/parse.c | Unknown BSD-like | util | 2025-05-25T16:31:15-07:00 |
+| util/compose/util.c | Unknown BSD-like | util | 2025-05-25T16:31:15-07:00 |
+| util/dirname.c | Unknown BSD-like | util | 2025-05-25T16:31:15-07:00 |
+| util/fperm.c | Unknown BSD-like | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/alloca.c | Unknown | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/ar.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/arscan.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/commands.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/commands.h | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/default.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/dep.h | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/dir.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/expand.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/file.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/file.h | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/function.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/getloadavg.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/getopt.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/getopt.h | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/getopt1.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/glob/fnmatch.c | Unknown BSD-like | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/glob/fnmatch.h | Unknown BSD-like | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/glob/glob.c | Unknown BSD-like | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/glob/glob.h | Unknown BSD-like | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/implicit.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/job.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/job.h | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/main.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/make.h | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/misc.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/read.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/remake.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/remote-cstms.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/remote-stub.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/rule.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/rule.h | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/signame.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/signame.h | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/variable.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/variable.h | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/version.c | Unknown | util | 2025-05-25T16:31:15-07:00 |
+| util/make/gmake-3.66/vpath.c | GPL | util | 2025-05-25T16:31:15-07:00 |
+| util/pfakeether.c | Unknown | util | 2025-05-25T16:31:15-07:00 |
+| util/phostnumber.c | Unknown | util | 2025-05-25T16:31:15-07:00 |
+| util/pnetnum.c | Unknown | util | 2025-05-25T16:31:15-07:00 |
+| util/promfile.c | Unknown | util | 2025-05-25T16:31:15-07:00 |
+| util/ptbldump/ptblData.c | Unknown | util | 2025-05-25T16:31:15-07:00 |
+| util/ptbldump/ptbldump.c | Unknown BSD-like | util | 2025-05-25T16:31:15-07:00 |
+| util/random_int.c | Unknown | util | 2025-05-25T16:31:15-07:00 |

--- a/README.md
+++ b/README.md
@@ -235,3 +235,9 @@ from the repository into `$LITES_SRC_DIR/include/all_headers` while
 preserving their original relative paths. This operation is destructive and
 should only be run for analysis purposes.
 
+
+## Licensing
+
+All historical source files retain their original license headers.  A summary of
+these legacy notices is recorded in [LICENSE_MAP](LICENSE_MAP).  See the
+[LICENSE](LICENSE) file for an overview of the major terms.


### PR DESCRIPTION
## Summary
- generate license map for historical source files
- reference `LICENSE_MAP` in the README licensing section

## Testing
- `make -f Makefile.new test` *(fails: Mach headers not found)*