### PR TITLE
Generate license map and reference in docs

### DIFF
--- a/docs/MODERNIZATION.md
+++ b/docs/MODERNIZATION.md
@@ -12,6 +12,8 @@ already been completed and what is still planned.
 - Support for 64‑bit (`ARCH=x86_64`) and 32‑bit (`ARCH=i686`) builds.
 - Pre‑commit configuration for consistent formatting and clang‑tidy
   checking.
+- A generated `LICENSE_MAP` summarises the license excerpt, origin and
+  last modification date for every source file via `scripts/gen-license-map.sh`.
 
 ## Open items
 

--- a/libposix/posix.c
+++ b/libposix/posix.c
@@ -1,3 +1,4 @@
+/* See LICENSE_MAP for license and origin information */
 #include "../include/posix.h"
 #include <errno.h>
 #include <stdarg.h>

--- a/libposix/pthread.c
+++ b/libposix/pthread.c
@@ -1,3 +1,4 @@
+/* See LICENSE_MAP for license and origin information */
 #include "pthread.h"
 #include <mach/cthreads.h>
 

--- a/scripts/gen-license-map.sh
+++ b/scripts/gen-license-map.sh
@@ -8,22 +8,11 @@ OUT_FILE="LICENSE_MAP"
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
-find . -type f \( -name '*.c' -o -name '*.h' -o -name '*.S' -o -name '*.s' -o -name '*.asm' \) | sort | while read -r file; do
+find . -type f \( -name '*.c' -o -name '*.h' -o -name '*.S' -o -name '*.s' -o -name '*.asm' \) \
+  | sort | while read -r file; do
   header=$(sed -n '1,20p' "$file")
-  license="UNKNOWN"
-  if echo "$header" | grep -qi "GNU GENERAL PUBLIC LICENSE"; then
-    license="GPL"
-  elif echo "$header" | grep -qi "Carnegie Mellon"; then
-    license="CMU"
-  elif echo "$header" | grep -qi "University of California"; then
-    license="BSD"
-  elif echo "$header" | grep -qi "University of Utah"; then
-    license="UTAH"
-  elif echo "$header" | grep -qi "IBM"; then
-    license="IBM"
-  fi
-
+  excerpt=$(echo "$header" | head -n 3 | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g')
   origin=$(echo "$header" | grep -i "Copyright" | head -n 1 | sed 's/^\s*[#* ]*//')
   timestamp=$(git log -1 --format=%cI -- "$file" 2>/dev/null || echo "unknown")
-  printf "%s\t%s\t%s\t%s\n" "$file" "$license" "$origin" "$timestamp" >> "$OUT_FILE"
+  printf "%s\t%s\t%s\t%s\n" "$file" "$excerpt" "$origin" "$timestamp" >> "$OUT_FILE"
 done


### PR DESCRIPTION
## Summary
- expand `gen-license-map.sh` to gather license excerpts, origin and time stamp
- note the new `LICENSE_MAP` in modernization notes
- add short headers referencing the map in POSIX sources

## Testing
- `pre-commit run --files scripts/gen-license-map.sh docs/MODERNIZATION.md libposix/pthread.c libposix/posix.c` *(fails: command not found)*