### PR TITLE
Create libos VM layer

### DIFF
--- a/libos/vm.c
+++ b/libos/vm.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <sys/socket.h>
 
-#include "../../include/vm.h"
+#include "vm.h"
 
 /*
  * Basic virtual memory handlers. These are placeholders for

--- a/libos/vm.h
+++ b/libos/vm.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+
+/* Minimal Mach compatible types used by the modernised VM layer. */
+typedef int            kern_return_t;
+typedef uintptr_t      vm_offset_t;
+typedef int            vm_prot_t;
+typedef int            mach_port_t;
+
+typedef struct { int dummy; } mutex_t;
+
+#ifndef KERN_SUCCESS
+#define KERN_SUCCESS 0
+#endif
+
+#ifndef KERN_FAILURE
+#define KERN_FAILURE 1
+#endif
+
+/* Protection bits */
+#ifndef VM_PROT_READ
+#define VM_PROT_READ     0x1
+#define VM_PROT_WRITE    0x2
+#define VM_PROT_EXECUTE  0x4
+#endif
+
+/* Address space descriptor used by the modernised VM layer. */
+typedef struct aspace {
+    vm_offset_t pml_root;  /* page map level root */
+    mach_port_t pager_cap; /* capability for associated pager */
+    mutex_t vm_lock;       /* protects mappings */
+} aspace_t;
+
+/* Information passed to the user level pager when a page fault occurs. */
+typedef struct pf_info {
+    vm_offset_t addr;  /* faulting address */
+    vm_prot_t   prot;  /* access that caused the fault */
+    int         flags; /* future use */
+} pf_info_t;
+
+/* Shareable process virtual address space (BSD compatibility). */
+struct vmspace {
+    int     vm_refcnt;      /* number of references */
+    void    *vm_shm;        /* SYS5 shared memory private data XXX */
+/* we copy from vm_startcopy to the end of the structure on fork */
+#define vm_startcopy vm_rssize
+    segsz_t vm_rssize;      /* current resident set size in pages */
+    segsz_t vm_swrss;       /* resident set size before last swap */
+    segsz_t vm_tsize;       /* text size (pages) XXX */
+    segsz_t vm_dsize;       /* data size (pages) XXX */
+    segsz_t vm_ssize;       /* stack size (pages) */
+    caddr_t vm_taddr;       /* user virtual address of text XXX */
+    caddr_t vm_daddr;       /* user virtual address of data XXX */
+    caddr_t vm_maxsaddr;    /* user VA at max stack growth */
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ target_compile_options(test_iommu PRIVATE -std=gnu2x -Wall -Wextra -Werror)
 
 add_executable(test_vm_fault
     vm_fault/test_vm_fault.c
-    ${_src_dir}/server/vm/vm_handlers.c
+    ${_src_dir}/libos/vm.c
     ../posix.c)
 target_compile_options(test_vm_fault PRIVATE -std=gnu2x -Wall -Wextra -Werror)
 target_include_directories(test_vm_fault PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)

--- a/tests/vm_fault/Makefile
+++ b/tests/vm_fault/Makefile
@@ -1,6 +1,6 @@
 CC ?= clang
 # Additional compile flags from the top-level build system are appended.
-CFLAGS += -std=gnu23 -Wall -Wextra -Werror
+CFLAGS += -std=gnu23 -Wall -Wextra -Werror -I$(SRC_DIR)/include
 
 all: test_vm_fault
 
@@ -10,11 +10,11 @@ ifndef LITES_SRC_DIR
 $(error LITES_SRC_DIR must be set)
 endif
 SRC_DIR := $(LITES_SRC_DIR)
-VM_SRC := $(SRC_DIR)/server/vm/vm_handlers.c
+VM_SRC := $(SRC_DIR)/libos/vm.c
 ifneq ($(wildcard $(VM_SRC)),)
 VM_PATH := $(VM_SRC)
 else
-VM_PATH := ../../server/vm/vm_handlers.c
+VM_PATH := ../../libos/vm.c
 endif
 
 test_vm_fault: test_vm_fault.c $(VM_PATH) ../../posix.c

--- a/tests/vm_fault/test_vm_fault.c
+++ b/tests/vm_fault/test_vm_fault.c
@@ -6,7 +6,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#include "vm.h"
+#include "../../libos/vm.h"
 
 extern kern_return_t vm_fault_entry(aspace_t *, vm_offset_t, vm_prot_t);
 extern kern_return_t unmap_frame(aspace_t *, vm_offset_t);


### PR DESCRIPTION
## Summary
- start new `libos` folder with VM subsystem
- merge modern VM types with legacy `vmspace` in `libos/vm.h`
- move VM handler implementation to `libos/vm.c`
- update tests to use the new location

## Testing
- `make -C tests/vm_fault LITES_SRC_DIR=../..` *(fails: unrecognized command-line option ‘-std=gnu23’)*