### PR TITLE
Enable clang-tidy in build

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,3 @@
-Checks: '-*,clang-analyzer-*'
+Checks: '-*,clang-analyzer-*,bugprone-*,performance-*'
 WarningsAsErrors: ''
 ExtraArgs: ['-std=c23']
-ExtraArgsCC: ['-std=c++17']

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,20 @@
 cmake_minimum_required(VERSION 3.5)
 project(lites LANGUAGES C)
 set(CMAKE_C_STANDARD 23)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+option(ENABLE_CLANG_TIDY "Run clang-tidy during the build" OFF)
+if(ENABLE_CLANG_TIDY)
+    find_program(CLANG_TIDY_EXE NAMES clang-tidy)
+    if(CLANG_TIDY_EXE)
+        set(CMAKE_C_CLANG_TIDY ${CLANG_TIDY_EXE})
+        set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXE})
+        add_custom_target(clang-tidy
+            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run-clang-tidy.sh
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            COMMENT "Run clang-tidy analysis")
+    endif()
+endif()
 find_package(BISON)
 
 # Allow selecting the build architecture with -DARCH=i686 or ARCH=x86_64

--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ The clang-tidy hooks rely on `scripts/run-clang-tidy.sh`.  This helper
 ensures a `compile_commands.json` database is generated on demand so
 clang-tidy can analyse the sources even before the project has been built.
 
+Alternatively CMake can drive clang-tidy directly.  Enable the optional
+`ENABLE_CLANG_TIDY` flag to add a `clang-tidy` target:
+
+```sh
+cmake -DENABLE_CLANG_TIDY=ON -B build
+cmake --build build --target clang-tidy
+```
+
 To try the built binaries under QEMU use `scripts/run-qemu.sh`.  The script
 launches the `lites_server` (and the optional `lites_emulator` when present)
 inside QEMU for either `x86_64` or `i686`:


### PR DESCRIPTION
## Summary
- update clang-tidy config with additional checks
- export compile database and add clang-tidy option in CMake
- document clang-tidy usage in README

## Testing
- `scripts/run-precommit.sh --files CMakeLists.txt README.md .clang-tidy` *(fails: Could not install pre-commit)*
- `cmake -S . -B build -DENABLE_CLANG_TIDY=ON` *(fails: Mach headers not found)*
