### PR TITLE
Use unified vmspace struct for forks

### DIFF
--- a/server/serv/vm_glue.c
+++ b/server/serv/vm_glue.c
@@ -70,7 +70,7 @@
 #include <sys/user.h>
 #include <sys/assert.h>
 
-#include <vm/vm.h>
+#include "../../libos/vm.h"
 
 #include <machine/cpu.h>
 
@@ -87,7 +87,7 @@ static struct vmspace *vmspace_fork(struct vmspace *ovs, struct proc *p2)
 #else
 	vs = &p2->p_realvmspace;
 #endif
-	memcpy(vs, ovs, sizeof(*vs));
+	*vs = *ovs;
 	vs->vm_refcnt = 1;
 	vs->vm_shm = 0;
 	return vs;


### PR DESCRIPTION
## Summary
- include the shared VM header from `libos`
- copy vmspace via assignment instead of memcpy

## Testing
- `make -n` *(fails: can't cd to /usr/obj/lites)*