### PR TITLE
Standardize BSD version constants

### DIFF
--- a/bootstrap/fs.h
+++ b/bootstrap/fs.h
@@ -41,6 +41,7 @@
  *
  *	@(#)fs.h	7.7 (Berkeley) 5/9/89
  */
+#include <legacy_bsd/bsd_compat.h>
 
 /*
  * Each disk drive contains some number of file systems.
@@ -244,7 +245,6 @@ struct	fs
 /*
  * Rotational layout table format types
  */
-#define FS_42POSTBLFMT		-1	/* 4.2BSD rotational table format */
 #define FS_DYNAMICPOSTBLFMT	1	/* dynamic rotational table format */
 /*
  * Macros for access to superblock array structures

--- a/include/sys/param.h
+++ b/include/sys/param.h
@@ -39,9 +39,7 @@
  *	@(#)param.h	8.2 (Berkeley) 1/21/94
  */
 
-#define	BSD	199306		/* System version (year & month). */
-#define BSD4_3	1
-#define BSD4_4	1
+#include <legacy_bsd/bsd_compat.h>
 
 #ifndef NULL
 #define	NULL	0

--- a/legacy_bsd/include/bsd_compat.h
+++ b/legacy_bsd/include/bsd_compat.h
@@ -1,0 +1,15 @@
+#ifndef BSD_COMPAT_H
+#define BSD_COMPAT_H
+
+/* Common BSD version constants used across the tree */
+#define BSD     199306          /* System version (year & month) */
+#define BSD4_3  1
+#define BSD4_4  1
+
+/* Fast file system format identifiers */
+#define FS_42INODEFMT       -1  /* 4.2BSD inode format */
+#define FS_44INODEFMT       2   /* 4.4BSD inode format */
+#define FS_42POSTBLFMT      -1  /* 4.2BSD rotational table format */
+#define FS_DYNAMICPOSTBLFMT 1   /* dynamic rotational table format */
+
+#endif /* BSD_COMPAT_H */

--- a/server/ufs/ffs/fs.h
+++ b/server/ufs/ffs/fs.h
@@ -32,6 +32,7 @@
  *
  *	@(#)fs.h	8.7 (Berkeley) 4/19/94
  */
+#include <legacy_bsd/bsd_compat.h>
 
 /*
  * Each disk drive contains some number of file systems.
@@ -254,8 +255,6 @@ struct fs {
  */
 #define	FS_MAGIC	0x011954	/* the fast filesystem magic number */
 #define	FS_OKAY		0x7c269d38	/* superblock checksum */
-#define FS_42INODEFMT	-1		/* 4.2BSD inode format */
-#define FS_44INODEFMT	2		/* 4.4BSD inode format */
 /*
  * Preference for optimization.
  */
@@ -265,8 +264,6 @@ struct fs {
 /*
  * Rotational layout table format types
  */
-#define FS_42POSTBLFMT		-1	/* 4.2BSD rotational table format */
-#define FS_DYNAMICPOSTBLFMT	1	/* dynamic rotational table format */
 /*
  * Macros for access to superblock array structures
  */


### PR DESCRIPTION
## Summary
- centralize BSD version macros in `legacy_bsd/include/bsd_compat.h`
- include the common header from `sys/param.h`, `server/ufs/ffs/fs.h` and `bootstrap/fs.h`
- remove duplicated macro definitions

## Testing
- `make -f Makefile.new test` *(fails: Mach headers not found)*