### PR TITLE
Build libos as library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,8 @@ if(EXISTS "${LITES_SRC_DIR}")
     file(GLOB _libos_src "${CMAKE_CURRENT_SOURCE_DIR}/libos/*.c")
     list(APPEND SERVER_SRC ${_kern_src} ${_posix_src})
     file(GLOB _iommu_src "${LITES_SRC_DIR}/iommu/*.c")
-    list(APPEND SERVER_SRC ${_iommu_src} ${_libos_src})
+    list(APPEND SERVER_SRC ${_iommu_src})
+    add_library(libos STATIC ${_libos_src})
 
     if(BISON_FOUND)
         file(GLOB_RECURSE _y_src
@@ -166,8 +167,7 @@ if(EXISTS "${LITES_SRC_DIR}")
             file(GLOB_RECURSE _dir_src "${dir}/*.c" "${dir}/*.S")
             list(APPEND EMULATOR_SRC ${_dir_src})
         endforeach()
-        list(APPEND EMULATOR_SRC ${_kern_src} ${_iommu_src} ${_posix_src}
-                                ${_libos_src})
+        list(APPEND EMULATOR_SRC ${_kern_src} ${_iommu_src} ${_posix_src})
         if(BISON_FOUND)
             foreach(yfile ${_y_src})
                 get_filename_component(_y_name "${yfile}" NAME_WE)
@@ -181,7 +181,7 @@ if(EXISTS "${LITES_SRC_DIR}")
         "${LITES_SRC_DIR}/include"
         "${LITES_SRC_DIR}/server"
         "${LITES_SRC_DIR}/iommu"
-        "${LITES_SRC_DIR}/libos"
+        "${CMAKE_CURRENT_SOURCE_DIR}/libos"
         "${MACH_INCLUDE_DIR}"
         "${CMAKE_CURRENT_SOURCE_DIR}/kern"
         "${CMAKE_CURRENT_SOURCE_DIR}/posix"
@@ -207,6 +207,7 @@ if(EXISTS "${LITES_SRC_DIR}")
     endif()
     target_compile_options(lites_server PRIVATE ${C23_FLAG} ${CFLAGS})
     target_link_options(lites_server PRIVATE ${LDFLAGS})
+    target_link_libraries(lites_server PRIVATE libos)
 
     if(MACH_LIBS)
         target_link_libraries(lites_server PRIVATE ${MACH_LIBS})
@@ -217,7 +218,7 @@ if(EXISTS "${LITES_SRC_DIR}")
         target_include_directories(lites_emulator PRIVATE
             "${LITES_SRC_DIR}/include"
             "${LITES_SRC_DIR}/emulator"
-            "${LITES_SRC_DIR}/libos"
+            "${CMAKE_CURRENT_SOURCE_DIR}/libos"
             "${MACH_INCLUDE_DIR}"
             "${CMAKE_CURRENT_SOURCE_DIR}/kern"
             "${CMAKE_CURRENT_SOURCE_DIR}/posix"
@@ -245,6 +246,7 @@ if(EXISTS "${LITES_SRC_DIR}")
         endif()
         target_compile_options(lites_emulator PRIVATE ${C23_FLAG} ${CFLAGS})
         target_link_options(lites_emulator PRIVATE ${LDFLAGS})
+        target_link_libraries(lites_emulator PRIVATE libos)
         if(MACH_LIBS)
             target_link_libraries(lites_emulator PRIVATE ${MACH_LIBS})
         endif()

--- a/Makefile.new
+++ b/Makefile.new
@@ -108,11 +108,18 @@ SERVER_COMMON_DIRS := \
 SERVER_DIRS := $(SRCDIR)/server/$(ARCH_DIR) $(SERVER_COMMON_DIRS)
 SERVER_SRC := $(foreach d,$(SERVER_DIRS),$(shell find $(d) -name \*.c -o -name \*.S))
 SERVER_INCDIRS := $(addprefix -I,$(SERVER_DIRS))
-KERN_SRC := $(wildcard kern/*.c) $(wildcard $(SRCDIR)/iommu/*.c) \
-            $(wildcard $(SRCDIR)/libos/*.c)
+KERN_SRC := $(wildcard kern/*.c) $(wildcard $(SRCDIR)/iommu/*.c)
 POSIX_SRC := $(wildcard posix/*.c)
 KERN_SRC += $(POSIX_SRC)
-KERN_INCDIRS := -Ikern -I$(SRCDIR)/iommu -Iposix -I$(SRCDIR)/libos
+KERN_INCDIRS := -Ikern -I$(SRCDIR)/iommu -Iposix -Ilibos
+
+# Build libos as a static library
+LIBOS_SRC := $(wildcard libos/*.c)
+LIBOS_OBJ := $(LIBOS_SRC:.c=.o)
+LIBOS_A   := libos/libos.a
+
+$(LIBOS_A): $(LIBOS_OBJ)
+	$(AR) rcs $@ $^
 
 
 ifneq ($(wildcard $(SRCDIR)/emulator),)
@@ -127,7 +134,7 @@ endif
 
 TEST_SUBDIRS := $(sort $(dir $(wildcard tests/*/Makefile)))
 
-all: prepare $(TARGETS)
+all: prepare $(LIBOS_A) $(TARGETS)
 
 prepare:
         @if [ ! -e $(SRCDIR)/include/machine ]; then \
@@ -136,12 +143,12 @@ prepare:
           ln -s $$arch_dir $(SRCDIR)/include/machine; \
         fi
 
-lites_server: $(SERVER_SRC) $(KERN_SRC)
-	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(SERVER_INCDIRS) $(KERN_INCDIRS) $^ $(MACH_LIBS) $(LDFLAGS) -o $@
+lites_server: $(SERVER_SRC) $(KERN_SRC) $(LIBOS_A)
+	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(SERVER_INCDIRS) $(KERN_INCDIRS) $^ $(LIBOS_A) $(MACH_LIBS) $(LDFLAGS) -o $@
 
 ifneq ($(EMULATOR_SRC),)
-lites_emulator: $(EMULATOR_SRC) $(KERN_SRC)
-	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(EMULATOR_INCDIRS) $(KERN_INCDIRS) $^ $(MACH_LIBS) $(LDFLAGS) -o $@
+lites_emulator: $(EMULATOR_SRC) $(KERN_SRC) $(LIBOS_A)
+	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(EMULATOR_INCDIRS) $(KERN_INCDIRS) $^ $(LIBOS_A) $(MACH_LIBS) $(LDFLAGS) -o $@
 endif
 
 clean:

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,9 @@ if lites_src_dir == ''
   error('LITES_SRC_DIR must be set')
 endif
 inc = include_directories('.', join_paths(lites_src_dir, 'include'))
+libos = static_library('oslib', 'libos/vm.c')
 executable('ipc-demo',
-           ['ipc.c', 'bin/ipc-demo.c', 'libos/vm.c'],
+           ['ipc.c', 'bin/ipc-demo.c'],
            include_directories : inc,
+           link_with : libos,
            dependencies : rt)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,10 +25,10 @@ target_compile_options(test_iommu PRIVATE -std=gnu2x -Wall -Wextra -Werror)
 
 add_executable(test_vm_fault
     vm_fault/test_vm_fault.c
-    ${_src_dir}/libos/vm.c
     ../posix.c)
 target_compile_options(test_vm_fault PRIVATE -std=gnu2x -Wall -Wextra -Werror)
 target_include_directories(test_vm_fault PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_link_libraries(test_vm_fault PRIVATE libos)
 
 
 add_executable(test_pipe

--- a/tests/vm_fault/Makefile
+++ b/tests/vm_fault/Makefile
@@ -10,14 +10,12 @@ ifndef LITES_SRC_DIR
 $(error LITES_SRC_DIR must be set)
 endif
 SRC_DIR := $(LITES_SRC_DIR)
-VM_SRC := $(SRC_DIR)/libos/vm.c
-ifneq ($(wildcard $(VM_SRC)),)
-VM_PATH := $(VM_SRC)
-else
-VM_PATH := ../../libos/vm.c
+LIBOS_LIB := ../../libos/libos.a
+ifneq ($(wildcard $(SRC_DIR)/libos/libos.a),)
+LIBOS_LIB := $(SRC_DIR)/libos/libos.a
 endif
 
-test_vm_fault: test_vm_fault.c $(VM_PATH) ../../posix.c
+test_vm_fault: test_vm_fault.c ../../posix.c $(LIBOS_LIB)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 clean:


### PR DESCRIPTION
## Summary
- compile libos sources into a dedicated static library
- link `libos` into the server, emulator and tests
- adjust include paths and Meson rules for the new library
- update vm fault test makefile to use `libos.a`

## Testing
- `make -f Makefile.new libos/libos.a` *(fails: Mach headers not found)*
- `cmake -B build` *(fails: Mach headers not found)*
- `meson setup buildmeson` *(fails: meson not found)*