### PR TITLE
docs: note legacy_bsd and unified VM

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## lites-1.2
+- Added `legacy_bsd/` with the imported 4.4BSD userland sources.
+- Introduced a unified virtual memory layer in `libos/vm.c` and `vm.h`.
+
 ## lites-1.1.1
 - Derived from lites-1.1
 - Integrated snapshot lites-1.1.u1

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ The file `johannes_helander-unix_under_mach-the_lites_server.pdf` in this
 repository contains a comprehensive thesis describing Lites' design in
 detail.
 
+## Directory layout
+
+The modern tree keeps historical and new code in clearly separated
+subdirectories.
+
+- `legacy_bsd/` holds an import of the original 4.4BSD userland sources
+  used as a reference by the build system.
+- `libos/` provides common runtime helpers.  It now contains a unified
+  virtual memory layer implemented in `vm.c` and `vm.h` that is shared by
+  the server and unit tests.
+
 ## Mach kernel headers
 
 Lites relies on headers from a Mach kernel source tree such as the


### PR DESCRIPTION
## Summary
- document the legacy_bsd directory
- document the unified VM layer under libos
- describe these additions in the CHANGELOG

## Testing
- `scripts/run-precommit.sh -a` *(fails: Could not install pre-commit)*
- `make -f Makefile.new help` *(fails: Mach headers not found)*