### PR TITLE
Build vm fault test with libos

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,10 +23,14 @@ add_executable(test_iommu
     ${_src_dir}/iommu/iommu.c)
 target_compile_options(test_iommu PRIVATE -std=gnu2x -Wall -Wextra -Werror)
 
+add_library(libos STATIC
+    ${_src_dir}/libos/vm.c)
+target_include_directories(libos PUBLIC ${_src_dir}/include)
+
 add_executable(test_vm_fault
     vm_fault/test_vm_fault.c
-    ${_src_dir}/libos/vm.c
     ../posix.c)
+target_link_libraries(test_vm_fault PRIVATE libos)
 target_compile_options(test_vm_fault PRIVATE -std=gnu2x -Wall -Wextra -Werror)
 target_include_directories(test_vm_fault PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 

--- a/tests/vm_fault/Makefile
+++ b/tests/vm_fault/Makefile
@@ -2,6 +2,8 @@ CC ?= clang
 # Additional compile flags from the top-level build system are appended.
 CFLAGS += -std=gnu23 -Wall -Wextra -Werror -I$(SRC_DIR)/include
 
+LIBOS := libos.a
+
 all: test_vm_fault
 
 .PHONY: all clean
@@ -17,8 +19,12 @@ else
 VM_PATH := ../../libos/vm.c
 endif
 
-test_vm_fault: test_vm_fault.c $(VM_PATH) ../../posix.c
+$(LIBOS): $(VM_PATH)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o vm.o
+	ar rcs $@ vm.o
+
+test_vm_fault: test_vm_fault.c $(LIBOS) ../../posix.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 clean:
-	rm -f test_vm_fault
+	rm -f test_vm_fault vm.o $(LIBOS)


### PR DESCRIPTION
## Summary
- compile vm_fault test using new libos library
- expose libos to cmake-based tests

## Testing
- `make -C tests/vm_fault CC=clang LITES_SRC_DIR=../.. clean`
- `make -C tests/vm_fault CC=clang LITES_SRC_DIR=../..` *(fails: unknown type name 'caddr_t')*