### PR TITLE
Replace obsolete bcmp calls

### DIFF
--- a/include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/talk/get_addrs.c
+++ b/include/opensolaris-master/usr/src/cmd/cmd-inet/usr.bin/talk/get_addrs.c
@@ -80,8 +80,8 @@ char *rem_machine_name;
 
 	/* if on the same machine, then simply copy */
 
-	if (bcmp((char *)&rem_machine_name, (char *)&my_machine_name,
-		sizeof (rem_machine_name)) == 0) {
+        if (memcmp((char *)&rem_machine_name, (char *)&my_machine_name,
+                sizeof (rem_machine_name)) == 0) {
 	bcopy((char *)&my_machine_addr, (char *)&rem_machine_addr,
 		sizeof (rem_machine_name));
 	} else {

--- a/include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_capture.c
+++ b/include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_capture.c
@@ -621,7 +621,7 @@ cap_open_read(const char *name)
 
 	/* Check if new snoop capture file format */
 
-	cap_new = bcmp(cap_buffp, snoop_id, snoop_idlen) == 0;
+        cap_new = memcmp(cap_buffp, snoop_id, snoop_idlen) == 0;
 
 	/*
 	 * If new file - check version and

--- a/include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_rip6.c
+++ b/include/opensolaris-master/usr/src/cmd/cmd-inet/usr.sbin/snoop/snoop_rip6.c
@@ -109,8 +109,9 @@ interpret_rip6(int flags, struct rip6 *rip6, int fraglen)
 					n->rip6_metric = n->rip6_metric;
 				}
 				dst = &n->rip6_prefix;
-				notdefault = bcmp((caddr_t *)dst,
-				    (caddr_t *)&all_zeroes_addr, sizeof (*dst));
+                                notdefault = memcmp((caddr_t *)dst,
+                                    (caddr_t *)&all_zeroes_addr,
+                                    sizeof (*dst)) != 0;
 				(void) inet_ntop(AF_INET6, (char *)dst, dststr,
 				    INET6_ADDRSTRLEN);
 				(void) sprintf(get_line((char *)n - dlc_header,

--- a/include/pi/idmap/idmap.c
+++ b/include/pi/idmap/idmap.c
@@ -134,7 +134,7 @@ mapVarBind ( table, ext, len, intern )
     prev_elem = elem_posn;
     while (elem_posn != 0) {
 	o_ext = elem_posn->externalid;
-	if (!bcmp(o_ext, (char *)ext, len)) {
+        if (memcmp(o_ext, (char *)ext, len) == 0) {
 	    if (elem_posn->internalid == intern) {
 		return(elem_posn);
 	    } else {
@@ -178,7 +178,7 @@ mapVarResolve ( table, ext, len, resPtr )
     
     if ((elem_posn = table->cache) && elem_posn->elmlen == len) {
 	o_ext = elem_posn->externalid;
-	if (!bcmp(o_ext, (char *)ext, len)) {
+        if (memcmp(o_ext, (char *)ext, len) == 0) {
 	    if ( resPtr ) {
 		*resPtr = elem_posn->internalid;
 	    }
@@ -188,8 +188,8 @@ mapVarResolve ( table, ext, len, resPtr )
     elem_posn = table->table[generichash(ext, table->tableSize, len)];
     while (elem_posn != 0) {
 	o_ext = elem_posn->externalid;
-	if (elem_posn->elmlen == len &&
-	    !bcmp(o_ext, (char *)ext, len)) {
+        if (elem_posn->elmlen == len &&
+            memcmp(o_ext, (char *)ext, len) == 0) {
 	    table->cache = elem_posn;
 	    if ( resPtr ) {
 		*resPtr = elem_posn->internalid;
@@ -311,7 +311,7 @@ static INLINE int	hash16( void *, int );
 #endif /* __STDC__ */
 
 
-#define GENCOMPBYTES(s1, s2) (!bcmp(s1, s2, table->keySize))
+#define GENCOMPBYTES(s1, s2) (memcmp(s1, s2, table->keySize) == 0)
 #define GENCOPYBYTES(s1, s2) bcopy(s2, s1, table->keySize)
 
 #define KEYSIZE 2
@@ -626,7 +626,7 @@ generichash(key, tableSize, keySize)
 #define UNBINDNAME mgenericunbind
 #define HASH(K, tblSize, keySize) generichash(K, tblSize, keySize)
 #define GENHASH(K, T, keySize) generichash(K, tblSize, keySize)
-#define COMPBYTES(s1, s2) (!bcmp(s1, s2, table->keySize))
+#define COMPBYTES(s1, s2) (memcmp(s1, s2, table->keySize) == 0)
 #define COPYBYTES(s1, s2) bcopy(s2, s1, table->keySize)
 
 #include "idmap_templ.c"

--- a/include/svr4/cmd/cmd-inet/usr.bin/rlogin.c
+++ b/include/svr4/cmd/cmd-inet/usr.bin/rlogin.c
@@ -546,7 +546,7 @@ sigwinch()
 	struct winsize ws;
 
 	if (dosigwinch && ioctl(0, TIOCGWINSZ, &ws) == 0 &&
-	    bcmp(&ws, &winsize, sizeof (ws))) {
+            memcmp(&ws, &winsize, sizeof (ws))) {
 		winsize = ws;
 		sendwindow();
 	}

--- a/include/svr4/cmd/cmd-inet/usr.bin/talk/get_addrs.c
+++ b/include/svr4/cmd/cmd-inet/usr.bin/talk/get_addrs.c
@@ -70,8 +70,8 @@ char *rem_machine_name;
 
 	/* if on the same machine, then simply copy */
 
-    if ( bcmp((char *)&rem_machine_name, (char *)&my_machine_name,
-		sizeof(rem_machine_name)) == 0) {
+    if ( memcmp((char *)&rem_machine_name, (char *)&my_machine_name,
+                sizeof(rem_machine_name)) == 0) {
 	bcopy((char *)&my_machine_addr, (char *)&rem_machine_addr,
 		sizeof(rem_machine_name));
     } else {

--- a/include/svr4/cmd/cmd-inet/usr.sbin/in.named/db_update.c
+++ b/include/svr4/cmd/cmd-inet/usr.sbin/in.named/db_update.c
@@ -336,7 +336,7 @@ db_cmp(dp1, dp2)
 #ifdef ALLOW_T_UNSPEC
         case T_UNSPEC:
 #endif ALLOW_T_UNSPEC
-		return(bcmp(dp1->d_data, dp2->d_data, dp1->d_size));
+                return(memcmp(dp1->d_data, dp2->d_data, dp1->d_size));
 
 	case T_NS:
 	case T_CNAME:
@@ -370,7 +370,7 @@ db_cmp(dp1, dp2)
 			return(1);
 		cp1 += strlen(cp1) + 1;
 		cp2 += strlen(cp2) + 1;
-		return(bcmp(cp1, cp2, sizeof(u_long) * 5));
+                return(memcmp(cp1, cp2, sizeof(u_long) * 5));
 	
 	case T_MX:
 		cp1 = dp1->d_data;

--- a/include/svr4/cmd/cmd-inet/usr.sbin/in.named/ns_forw.c
+++ b/include/svr4/cmd/cmd-inet/usr.sbin/in.named/ns_forw.c
@@ -96,12 +96,12 @@ ns_forw(nsp, msg, msglen, fp, qsp, dfd, qpp)
 	hp->rd = 0;
 	/* Look at them all */
 	for (qp = qhead; qp!=QINFO_NULL; qp = qp->q_link) {
-		if (qp->q_id == id &&
-		    bcmp((char *)&qp->q_from, fp, sizeof(qp->q_from)) == 0 &&
-		    (qp->q_cmsglen == 0 && qp->q_msglen == msglen &&
-		     bcmp((char *)qp->q_msg+2, msg+2, msglen-2) == 0) ||
-		    (qp->q_cmsglen == msglen &&
-		     bcmp((char *)qp->q_cmsg+2, msg+2, msglen-2) == 0)) {
+                if (qp->q_id == id &&
+                    memcmp((char *)&qp->q_from, fp, sizeof(qp->q_from)) == 0 &&
+                    (qp->q_cmsglen == 0 && qp->q_msglen == msglen &&
+                     memcmp((char *)qp->q_msg+2, msg+2, msglen-2) == 0) ||
+                    (qp->q_cmsglen == msglen &&
+                     memcmp((char *)qp->q_cmsg+2, msg+2, msglen-2) == 0)) {
 #ifdef DEBUG
 			if (debug >= 3)
 				fprintf(ddt,"forw: dropped DUP id=%d\n", ntohs(id));
@@ -255,9 +255,9 @@ fprintf(ddt, "skipping used NS w/name %s\n", nsdp->d_data);
 			found_arr++;
 			/* don't put in duplicates */
 			qs = qp->q_addr;
-			for (i = 0; i < n; i++, qs++)
-				if (bcmp((char *)&qs->ns_addr.sin_addr,
-				    dp->d_data, sizeof(struct in_addr)) == 0)
+                        for (i = 0; i < n; i++, qs++)
+                                if (memcmp((char *)&qs->ns_addr.sin_addr,
+                                    dp->d_data, sizeof(struct in_addr)) == 0)
 					goto skipaddr;
 			qs->ns_addr.sin_family = AF_INET;
 			qs->ns_addr.sin_port = (u_short)ns_port;

--- a/include/svr4/cmd/cmd-inet/usr.sbin/in.named/ns_req.c
+++ b/include/svr4/cmd/cmd-inet/usr.sbin/in.named/ns_req.c
@@ -460,8 +460,8 @@ fetchns:
 			for (dp = np->n_data; dp != NULL; dp = dp->d_next) {
 				if (!match(dp, class, type))
 					continue;
-				if (dp->d_size != dlen ||
-				    bcmp(dp->d_data, data, dlen))
+                                if (dp->d_size != dlen ||
+                                    memcmp(dp->d_data, data, dlen))
 					continue;
 				getname(np, dnbuf, sizeof(dnbuf));
 #ifdef DEBUG

--- a/include/svr4/cmd/cmd-inet/usr.sbin/in.named/ns_resp.c
+++ b/include/svr4/cmd/cmd-inet/usr.sbin/in.named/ns_resp.c
@@ -160,9 +160,9 @@ ns_resp(msg, msglen)
 	if (qp->q_fwd == (struct fwdinfo *)0) {
 		struct timeval *stp;
 
-		for (n = 0, qs = qp->q_addr; n < qp->q_naddr; n++, qs++)
-			if (bcmp((char *)&qs->ns_addr.sin_addr,
-			    &from_addr.sin_addr, sizeof(struct in_addr)) == 0)
+                for (n = 0, qs = qp->q_addr; n < qp->q_naddr; n++, qs++)
+                        if (memcmp((char *)&qs->ns_addr.sin_addr,
+                            &from_addr.sin_addr, sizeof(struct in_addr)) == 0)
 				break;
 		if (n >= qp->q_naddr) {
 #ifdef DEBUG
@@ -1186,8 +1186,8 @@ sysquery(dname, class, type)
 
 	/* First check for an already pending query for this data */
 	for (oqp = qhead; oqp!=QINFO_NULL; oqp = oqp->q_link) {
-		if (oqp != qp && oqp->q_msglen == qp->q_msglen &&
-	     bcmp((char *)oqp->q_msg+2, qp->q_msg+2, qp->q_msglen-2) == 0) {
+                if (oqp != qp && oqp->q_msglen == qp->q_msglen &&
+             memcmp((char *)oqp->q_msg+2, qp->q_msg+2, qp->q_msglen-2) == 0) {
 #ifdef DEBUG
 			if (debug >= 3)
 				fprintf(ddt, "sysquery: duplicate\n");

--- a/include/svr4/cmd/cmd-inet/usr.sbin/in.rarpd.c
+++ b/include/svr4/cmd/cmd-inet/usr.sbin/in.rarpd.c
@@ -429,8 +429,8 @@ rarp_request (r, shost)
 	/* 
 	 * third party lookups are rare and wonderful
 	 */
-	if (bcmp((char *) r->arp_sha, (char *) r->arp_tha, ETHERADDRL) || 
-	    bcmp((char *) r->arp_sha, (char *) shost, ETHERADDRL)) {
+        if (memcmp((char *) r->arp_sha, (char *) r->arp_tha, ETHERADDRL) != 0 ||
+            memcmp((char *) r->arp_sha, (char *) shost, ETHERADDRL) != 0) {
 		if (dflag)
 			debug("weird (3rd party lookup)");
 		weird++;
@@ -539,7 +539,7 @@ arp_request(r, shost)
 	if (dflag)
 		debug("ARPOP_REQUEST");
 
-	if (bcmp((char *) &my_ipaddr, (char *) r->arp_tpa, IPADDRL))
+        if (memcmp((char *) &my_ipaddr, (char *) r->arp_tpa, IPADDRL) != 0)
 		return;
 
 	r->arp_op = ARPOP_REPLY;

--- a/include/svr4/cmd/cmd-inet/usr.sbin/in.rlogind.c
+++ b/include/svr4/cmd/cmd-inet/usr.sbin/in.rlogind.c
@@ -253,8 +253,8 @@ doit(f, fromp)
 		}
 #ifdef h_addr	/* 4.2 hack */
 		for (; hp->h_addr_list[0]; hp->h_addr_list++) {
-			if (!bcmp(hp->h_addr_list[0], (caddr_t)&fromp->sin_addr,
-			    sizeof(fromp->sin_addr)))
+                        if (memcmp(hp->h_addr_list[0], (caddr_t)&fromp->sin_addr,
+                            sizeof(fromp->sin_addr)) == 0)
 				break;
 			if (hp->h_addr_list[0] == NULL) {
 				syslog(LOG_NOTICE,
@@ -266,8 +266,8 @@ doit(f, fromp)
 			}
 		}
 #else
-		if (bcmp(hp->h_addr, (caddr_t)&fromp->sin_addr,
-			sizeof(fromp->sin_addr))) {
+                if (memcmp(hp->h_addr, (caddr_t)&fromp->sin_addr,
+                        sizeof(fromp->sin_addr)) != 0) {
 			syslog(LOG_NOTICE,
 			  "rlogind: Host addr %s not listed for host %s",
 			    inet_ntoa(fromp->sin_addr),

--- a/include/svr4/cmd/cmd-inet/usr.sbin/in.routed/defs.h
+++ b/include/svr4/cmd/cmd-inet/usr.sbin/in.routed/defs.h
@@ -67,7 +67,7 @@
 
 #define	LOOPBACKNET	0x7F000000
 #define equal(a1, a2) \
-	(bcmp((caddr_t)(a1), (caddr_t)(a2), sizeof (struct sockaddr)) == 0)
+        (memcmp((caddr_t)(a1), (caddr_t)(a2), sizeof (struct sockaddr)) == 0)
 #define	min(a,b)	((a)>(b)?(b):(a))
 
 struct	sockaddr_in addr;	/* address of daemon's socket */

--- a/include/svr4/cmd/cmd-inet/usr.sbin/in.routed/if.c
+++ b/include/svr4/cmd/cmd-inet/usr.sbin/in.routed/if.c
@@ -50,7 +50,7 @@ if_ifwithaddr(addr)
 	register struct interface *ifp;
 
 #define	same(a1, a2) \
-	(bcmp((caddr_t)((a1)->sa_data), (caddr_t)((a2)->sa_data), 14) == 0)
+	(memcmp((caddr_t)((a1)->sa_data), (caddr_t)((a2)->sa_data), 14) == 0)
 	for (ifp = ifnet; ifp; ifp = ifp->int_next) {
 		if (ifp->int_flags & IFF_REMOTE)
 			continue;

--- a/include/svr4/cmd/cmd-inet/usr.sbin/in.routed/tools/query.c
+++ b/include/svr4/cmd/cmd-inet/usr.sbin/in.routed/tools/query.c
@@ -208,7 +208,7 @@ rip_input(from, size)
 			struct in_addr subnaddr, inet_makeaddr();
 
 			subnaddr = inet_makeaddr(subnet, INADDR_ANY);
-			if (bcmp(&sin->sin_addr, &subnaddr, sizeof(subnaddr)) == 0)
+                        if (memcmp(&sin->sin_addr, &subnaddr, sizeof(subnaddr)) == 0)
 				name = np->n_name;
 			else
 				goto host;

--- a/include/svr4/cmd/cmd-inet/usr.sbin/route.c
+++ b/include/svr4/cmd/cmd-inet/usr.sbin/route.c
@@ -654,9 +654,9 @@ struct sockaddr_ns *sns;
 		return (mybuf);
 	}
 
-	if (bcmp(ns_bh, work.x_host.c_host, 6) == 0) { 
+        if (memcmp(ns_bh, work.x_host.c_host, 6) == 0) {
 		host = "any";
-	} else if (bcmp(ns_nullh, work.x_host.c_host, 6) == 0) {
+        } else if (memcmp(ns_nullh, work.x_host.c_host, 6) == 0) {
 		host = "*";
 	} else {
 		q = work.x_host.c_host;

--- a/netbsd/include/x_libc.h
+++ b/netbsd/include/x_libc.h
@@ -22,7 +22,7 @@
 
 #ifndef X_NETBSD
 extern void     bcopy( char *, char *, int );
-extern int	bcmp( char *, char *, int );
+extern int memcmp(const void *, const void *, size_t);
 extern void     bzero( char *, int );
 extern int	qsort( char *, int, int, int(*)());
 
@@ -31,7 +31,7 @@ extern int	lwp_self();
 #else
 
 extern void     bcopy();
-extern int	bcmp();
+extern int memcmp();
 extern void     bzero();
 
 

--- a/netbsd/pxk/alloc.c
+++ b/netbsd/pxk/alloc.c
@@ -214,8 +214,8 @@ dumpBlocks( ev, arg )
 	xIfTrace(malloc, verboseDump) {	
 	    displayLine(lblocks, i);
 	}
-	if ( ! b || bcmp((char *)(b + MALLOC_EXTRAS), (char *)last,
-			 MALLOC_NPCS * sizeof(long)) ) {
+        if ( ! b || memcmp((char *)(b + MALLOC_EXTRAS), (char *)last,
+                           MALLOC_NPCS * sizeof(long)) != 0 ) {
 	    /* 
 	     * Found a different block
 	     */

--- a/netbsd/pxk/alloc_old.c
+++ b/netbsd/pxk/alloc_old.c
@@ -726,7 +726,8 @@ int n, x;
   qsort(lblocks, MAXBLOCKS, sizeof(long *), compareblocks);
   for (i = 0, j = 0; i < MAXBLOCKS; i++, j++) {
     b = lblocks[i];
-    if (!b || bcmp(b + MALLOC_CHECK + MALLOC_NPCS, last, n * sizeof(long))) {
+      if (!b || memcmp(b + MALLOC_CHECK + MALLOC_NPCS, last,
+                       n * sizeof(long)) != 0) {
       if (j >= x) {
 	printf("%d at ", j);
 	for (k = 0; k < MALLOC_NPCS; k++) {

--- a/sunos/include/x_libc.h
+++ b/sunos/include/x_libc.h
@@ -21,7 +21,7 @@
 
 
 extern void     bcopy( char *, char *, int );
-extern int	bcmp( char *, char *, int );
+extern int memcmp(const void *, const void *, size_t);
 extern void     bzero( char *, int );
 extern int	qsort( char *, int, int, int(*)());
 

--- a/sunos/pxk/alloc.c
+++ b/sunos/pxk/alloc.c
@@ -214,8 +214,8 @@ dumpBlocks( ev, arg )
 	xIfTrace(malloc, verboseDump) {	
 	    displayLine(lblocks, i);
 	}
-	if ( ! b || bcmp((char *)(b + MALLOC_EXTRAS), (char *)last,
-			 MALLOC_NPCS * sizeof(long)) ) {
+        if ( ! b || memcmp((char *)(b + MALLOC_EXTRAS), (char *)last,
+                           MALLOC_NPCS * sizeof(long)) != 0 ) {
 	    /* 
 	     * Found a different block
 	     */

--- a/sunos/pxk/alloc_old.c
+++ b/sunos/pxk/alloc_old.c
@@ -727,7 +727,8 @@ int n, x;
   qsort(lblocks, MAXBLOCKS, sizeof(long *), compareblocks);
   for (i = 0, j = 0; i < MAXBLOCKS; i++, j++) {
     b = lblocks[i];
-    if (!b || bcmp(b + MALLOC_CHECK + MALLOC_NPCS, last, n * sizeof(long))) {
+      if (!b || memcmp(b + MALLOC_CHECK + MALLOC_NPCS, last,
+                       n * sizeof(long)) != 0) {
       if (j >= x) {
 	printf("%d at ", j);
 	for (k = 0; k < MALLOC_NPCS; k++) {

--- a/util/make/gmake-3.66/arscan.c
+++ b/util/make/gmake-3.66/arscan.c
@@ -67,8 +67,8 @@
    when FUNCTION is called.  It does not matter how much
    data FUNCTION reads.
 
-   If FUNCTION returns nonzero, we immediately return
-   what FUNCTION returned.
+    if (nread != SARMAG || memcmp (buf, ARMAG, SARMAG))
+    if (nread != FL_HSZ || memcmp (fl_header.fl_magic, AIAMAG, SAIAMAG))
 
    Returns -1 if archive does not exist,
    Returns -2 if archive has invalid format.
@@ -186,8 +186,8 @@ ar_scan (archive, function, arg)
 
 	if (nread != name_len)
 	  {
-	    (void) close (desc);
-	    return -2;
+        if (nread != AR_HDR_SIZE
+            || memcmp (member_header.ar_fmag, ARFMAG, 2)
 	  }
 	
 	name[name_len] = 0;


### PR DESCRIPTION
## Summary
- replace calls to `bcmp` with `memcmp`
- adjust equality checks accordingly

## Testing
- `pre-commit` *(fails: command not found)*
- `make -f Makefile.new test` *(fails: Mach headers not found)*