### PR TITLE
Replace bcopy/bzero calls with modern equivalents

### DIFF
--- a/i386/boot/boot_start.c
+++ b/i386/boot/boot_start.c
@@ -8,6 +8,7 @@
 #include "gdt.h"
 #include "boot.h"
 #include "phys_mem.h"
+#include <string.h>
 
 extern char do_boot[], do_boot_end[];
 
@@ -34,8 +35,8 @@ void boot_start(void)
 	   Therefore, we must allocate (non-conflicting) memory for a small stub
 	   to copy the kernel image to its final position and invoke it.  */
 	stub_size = do_boot_end - do_boot;
-	stub = mustmalloc(stub_size);
-	bcopy(do_boot, stub, stub_size);
+       stub = mustmalloc(stub_size);
+       memcpy(stub, do_boot, stub_size);
 
 	ptr.seg = LINEAR_CS;
 	ptr.ofs = kvtophys(stub);

--- a/i386/boot/linux/misc.c
+++ b/i386/boot/linux/misc.c
@@ -15,6 +15,7 @@
 #include "gzip.h"
 #include "lzw.h"
 #include "real.h"
+#include <string.h>
 
 #include <linux/config.h>
 #include <linux/segment.h>
@@ -243,7 +244,7 @@ static void flush_rest(void *data, int bytes)
 			size -= (output_ptr + bytes) - (output_start + output_size);
 		}
 
-		bcopy(src, dest, size);
+               memcpy(dest, src, size);
 
 		if (output_start + output_size <= output_ptr + bytes)
 		{

--- a/i386/kernel/i386/fpu.c
+++ b/i386/kernel/i386/fpu.c
@@ -37,6 +37,7 @@
 #include <kern/mach_param.h>
 #include <kern/thread.h>
 #include <kern/zalloc.h>
+#include <string.h>
 
 #include <i386/thread.h>
 #include <i386/fpu.h>
@@ -254,7 +255,7 @@ ASSERT_IPL(SPL0);
 	    /*
 	     * Ensure that reserved parts of the environment are 0.
 	     */
-	    bzero((char *)&ifps->fp_save_state, sizeof(struct i386_fp_save));
+           memset(&ifps->fp_save_state, 0, sizeof(struct i386_fp_save));
 
 	    ifps->fp_save_state.fp_control = user_fp_state->fp_control;
 	    ifps->fp_save_state.fp_status  = user_fp_state->fp_status;
@@ -281,15 +282,15 @@ ASSERT_IPL(SPL0);
 		i = (ifps->fp_save_state.fp_status & FPS_TOS)
 			>> FPS_TOS_SHIFT;	/* physical register
 						   for st(0) */
-		if (i == 0)
-		    bcopy(src, dst, 8 * 10);
-		else {
-		    bcopy(src,
-			  dst + 10 * i,
-			  10 * (8 - i));
-		    bcopy(src + 10 * (8 - i),
-			  dst,
-			  10 * i);
+               if (i == 0)
+                   memcpy(dst, src, 8 * 10);
+               else {
+                   memcpy(dst + 10 * i,
+                          src,
+                          10 * (8 - i));
+                   memcpy(dst,
+                          src + 10 * (8 - i),
+                          10 * i);
 		}
 	    }
 	    else
@@ -331,7 +332,7 @@ ASSERT_IPL(SPL0);
 	     * No valid floating-point state.
 	     */
 	    simple_unlock(&pcb->lock);
-	    bzero((char *)state, sizeof(struct i386_float_state));
+           memset(state, 0, sizeof(struct i386_float_state));
 	    return KERN_SUCCESS;
 	}
 
@@ -356,7 +357,7 @@ ASSERT_IPL(SPL0);
 	    /*
 	     * Ensure that reserved parts of the environment are 0.
 	     */
-	    bzero((char *)user_fp_state,  sizeof(struct i386_fp_save));
+           memset(user_fp_state, 0, sizeof(struct i386_fp_save));
 
 	    user_fp_state->fp_control = ifps->fp_save_state.fp_control;
 	    user_fp_state->fp_status  = ifps->fp_save_state.fp_status;
@@ -383,15 +384,15 @@ ASSERT_IPL(SPL0);
 		i = (ifps->fp_save_state.fp_status & FPS_TOS)
 			>> FPS_TOS_SHIFT;	/* physical register
 						   for st(0) */
-		if (i == 0)
-		    bcopy(src, dst, 8 * 10);
-		else {
-		    bcopy(src + 10 * i,
-			  dst,
-			  10 * (8 - i));
-		    bcopy(src,
-			  dst + 10 * (8 - i),
-			  10 * i);
+               if (i == 0)
+                   memcpy(dst, src, 8 * 10);
+               else {
+                   memcpy(dst,
+                          src + 10 * i,
+                          10 * (8 - i));
+                   memcpy(dst + 10 * (8 - i),
+                          src,
+                          10 * i);
 		}
 	    }
 	    else
@@ -619,7 +620,7 @@ ASSERT_IPL(SPL0);
 	ifps = pcb->ims.ifps;
 	if (ifps == 0) {
 	    ifps = (struct i386_fpsave_state *) zalloc(ifps_zone);
-	    bzero(ifps, sizeof *ifps);
+            memset(ifps, 0, sizeof *ifps);
 	    pcb->ims.ifps = ifps;
 	    fpinit();
 #if 1
@@ -662,7 +663,7 @@ fp_state_alloc()
 	struct i386_fpsave_state *ifps;
 
 	ifps = (struct i386_fpsave_state *)zalloc(ifps_zone);
-	bzero(ifps, sizeof *ifps);
+        memset(ifps, 0, sizeof *ifps);
 	pcb->ims.ifps = ifps;
 
 	ifps->fp_valid = TRUE;

--- a/i386/kernel/i386/iopb.c
+++ b/i386/kernel/i386/iopb.c
@@ -33,6 +33,7 @@
 #include <ipc/ipc_port.h>
 
 #include <kern/kalloc.h>
+#include <string.h>
 #include <kern/lock.h>
 #include <kern/queue.h>
 #include <kern/thread.h>
@@ -245,7 +246,7 @@ io_tss_init(
 	vm_offset_t	addr = (vm_offset_t) io_tss;
 	vm_size_t	size = (char *)&io_tss->barrier - (char *)io_tss;
 
-	bzero(&io_tss->tss, sizeof(struct i386_tss));
+       memset(&io_tss->tss, 0, sizeof(struct i386_tss));
 	io_tss->tss.io_bit_map_offset
 			= (char *)&io_tss->bitmap - (char *)io_tss;
 	io_tss->tss.ss0 = KERNEL_DS;
@@ -559,7 +560,7 @@ i386_io_port_list(thread, list, list_count)
 		    return KERN_RESOURCE_SHORTAGE;
 		}
 
-		bcopy((void *)addr, (void *)new_addr, size_needed);
+               memcpy((void *)new_addr, (void *)addr, size_needed);
 		kfree(addr, size);
 		devices = (mach_device_t *)new_addr;
 	    }

--- a/i386/kernel/i386/loose_ends.c
+++ b/i386/kernel/i386/loose_ends.c
@@ -26,6 +26,7 @@
 /*
  */
 #include <mach_assert.h>
+#include <string.h>
 
 
 	/*
@@ -41,22 +42,9 @@ int boothowto = 0;
  * ovbcopy - like bcopy, but recognizes overlapping ranges and handles 
  *           them correctly.
  */
-ovbcopy(from, to, bytes)
-	char *from, *to;
-	int bytes;			/* num bytes to copy */
+ovbcopy(const void *from, void *to, int bytes)
 {
-	/* Assume that bcopy copies left-to-right (low addr first). */
-	if (from + bytes <= to || to + bytes <= from || to == from)
-		bcopy(from, to, bytes);	/* non-overlapping or no-op*/
-	else if (from > to)
-		bcopy(from, to, bytes);	/* overlapping but OK */
-	else {
-		/* to > from: overlapping, and must copy right-to-left. */
-		from += bytes - 1;
-		to += bytes - 1;
-		while (bytes-- > 0)
-			*to-- = *from--;
-	}
+    memmove(to, from, bytes);
 }
 
 /* Someone with time should write code to set cpuspeed automagically */

--- a/i386/kernel/i386/mp_desc.c
+++ b/i386/kernel/i386/mp_desc.c
@@ -31,6 +31,7 @@
 #include <kern/cpu_number.h>
 #include <mach/machine.h>
 #include <vm/vm_kern.h>
+#include <string.h>
 
 #include <i386/mp_desc.h>
 #include <i386/lock.h>
@@ -129,17 +130,10 @@ mp_desc_init(mycpu)
 		/*
 		 * Copy the tables
 		 */
-		bcopy((char *)idt,
-		  (char *)mpt->idt,
-		  sizeof(idt));
-		bcopy((char *)gdt,
-		  (char *)mpt->gdt,
-		  sizeof(gdt));
-		bcopy((char *)ldt,
-		  (char *)mpt->ldt,
-		  sizeof(ldt));
-		bzero((char *)&mpt->ktss,
-		  sizeof(struct i386_tss));
+               memcpy(mpt->idt, idt, sizeof(idt));
+               memcpy(mpt->gdt, gdt, sizeof(gdt));
+               memcpy(mpt->ldt, ldt, sizeof(ldt));
+               memset(&mpt->ktss, 0, sizeof(struct i386_tss));
 
 		/*
 		 * Fix up the entries in the GDT to point to

--- a/i386/kernel/i386/pcb.c
+++ b/i386/kernel/i386/pcb.c
@@ -36,6 +36,7 @@
 #include <kern/counters.h>
 #include <kern/mach_param.h>
 #include <kern/thread.h>
+#include <string.h>
 #include <kern/sched_prim.h>
 #include <vm/vm_kern.h>
 #include <vm/pmap.h>
@@ -327,7 +328,7 @@ void pcb_init(thread)
 	/*
 	 *	We can't let random values leak out to the user.
 	 */
-	bzero((char *) pcb, sizeof *pcb);
+       memset(pcb, 0, sizeof *pcb);
 	simple_lock_init(&pcb->lock);
 
 	/*
@@ -526,9 +527,9 @@ kern_return_t thread_setstatus(thread, flavor, tstate, count)
 			thread->pcb->ims.io_tss = tss;
 		}
 
-		bcopy((char *) state->pm,
-		      (char *) tss->bitmap,
-		      sizeof state->pm);
+               memcpy(tss->bitmap,
+                      state->pm,
+                      sizeof state->pm);
 #endif
 		break;
 	    }
@@ -687,9 +688,9 @@ kern_return_t thread_getstatus(thread, flavor, tstate, count)
 		     *	The thread has its own ktss.
 		     */
 
-		    bcopy((char *) tss->bitmap,
-			  (char *) state->pm,
-			  sizeof state->pm);
+                   memcpy(state->pm,
+                          tss->bitmap,
+                          sizeof state->pm);
 		}
 
 		*count = i386_ISA_PORT_MAP_STATE_COUNT;

--- a/i386/kernel/i386/phys.c
+++ b/i386/kernel/i386/phys.c
@@ -32,6 +32,7 @@
 #include <mach/vm_prot.h>
 #include <vm/vm_kern.h>
 #include <vm/vm_page.h>
+#include <string.h>
 
 #include <i386/pmap.h>
 #include <mach/machine/vm_param.h>
@@ -43,7 +44,7 @@ pmap_zero_page(p)
 	vm_offset_t p;
 {
 	assert(p != vm_page_fictitious_addr);
-	bzero(phystokv(p), PAGE_SIZE);
+       memset(phystokv(p), 0, PAGE_SIZE);
 }
 
 /*
@@ -55,7 +56,7 @@ pmap_copy_page(src, dst)
 	assert(src != vm_page_fictitious_addr);
 	assert(dst != vm_page_fictitious_addr);
 
-	bcopy(phystokv(src), phystokv(dst), PAGE_SIZE);
+       memcpy(phystokv(dst), phystokv(src), PAGE_SIZE);
 }
 
 /*
@@ -68,7 +69,7 @@ copy_to_phys(src_addr_v, dst_addr_p, count)
 	int count;
 {
 	assert(dst_addr_p != vm_page_fictitious_addr);
-	bcopy(src_addr_v, phystokv(dst_addr_p), count);
+       memcpy(phystokv(dst_addr_p), src_addr_v, count);
 }
 
 /*
@@ -82,7 +83,7 @@ copy_from_phys(src_addr_p, dst_addr_v, count)
 	int count;
 {
 	assert(src_addr_p != vm_page_fictitious_addr);
-	bcopy(phystokv(src_addr_p), dst_addr_v, count);
+       memcpy(dst_addr_v, phystokv(src_addr_p), count);
 }
 
 /*

--- a/i386/kernel/i386/trap.c
+++ b/i386/kernel/i386/trap.c
@@ -33,6 +33,7 @@
 #include <mach_pcsample.h>
 
 #include <sys/types.h>
+#include <string.h>
 #include <mach/machine/eflags.h>
 #include <i386/trap.h>
 #include <machine/machspl.h>	/* for spl_t */
@@ -943,9 +944,9 @@ v86_assist(thread, regs)
 #ifdef	gcc_1_36_worked
 		int_vec = ((struct int_vec *)0)[vec];
 #else
-		bcopy((char *) (sizeof(struct int_vec) * vec),
-		      (char *)&int_vec,
-		      sizeof (struct int_vec));
+               memcpy(&int_vec,
+                      (char *) (sizeof(struct int_vec) * vec),
+                      sizeof (struct int_vec));
 #endif
 		if (copyout((char *)&iret_16,
 			    (char *)Addr8086(regs->ss,sp),

--- a/i386/kernel/i386/user_ldt.c
+++ b/i386/kernel/i386/user_ldt.c
@@ -30,6 +30,7 @@
 
 #include <kern/kalloc.h>
 #include <kern/thread.h>
+#include <string.h>
 
 #include <vm/vm_kern.h>
 
@@ -216,10 +217,10 @@ i386_set_ldt(thread, first_selector, desc_list, count, desc_list_inline)
 	    /*
 	     * Have new LDT.  Copy descriptors from current to new.
 	     */
-	    if (cur_ldt)
-		bcopy((char *) &cur_ldt->ldt[0],
-		      (char *) &new_ldt->ldt[0],
-		      cur_ldt->desc.limit_low + 1);
+            if (cur_ldt)
+                memcpy(&new_ldt->ldt[0],
+                       &cur_ldt->ldt[0],
+                       cur_ldt->desc.limit_low + 1);
 
 	    old_ldt = cur_ldt;	/* discard old LDT */
 	    cur_ldt = new_ldt;	/* use new LDT from now on */
@@ -231,9 +232,9 @@ i386_set_ldt(thread, first_selector, desc_list, count, desc_list_inline)
 	/*
 	 * Install new descriptors.
 	 */
-	bcopy((char *) desc_list,
-	      (char *) &cur_ldt->ldt[first_desc],
-	      count * sizeof(struct real_descriptor));
+        memcpy(&cur_ldt->ldt[first_desc],
+               desc_list,
+               count * sizeof(struct real_descriptor));
 
 	simple_unlock(&pcb->lock);
 
@@ -344,9 +345,9 @@ i386_get_ldt(thread, first_selector, selector_count, desc_list, count)
 	/*
 	 * copy out the descriptors
 	 */
-	bcopy((char *)&user_ldt[first_desc],
-	      (char *)*desc_list,
-	      ldt_size);
+        memcpy(*desc_list,
+               &user_ldt[first_desc],
+               ldt_size);
 	*count = ldt_count;
 	simple_unlock(&pcb->lock);
 
@@ -366,8 +367,8 @@ i386_get_ldt(thread, first_selector, selector_count, desc_list, count)
 	     * Zero the remainder of the page being returned.
 	     */
 	    size_left = size_used - ldt_size;
-	    if (size_left > 0)
-		bzero((char *)addr + ldt_size, size_left);
+            if (size_left > 0)
+                memset((char *)addr + ldt_size, 0, size_left);
 
 	    /*
 	     * Make memory into copyin form - this unwires it.

--- a/i386/kernel/i386at/fd.c
+++ b/i386/kernel/i386at/fd.c
@@ -54,6 +54,7 @@ WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #ifdef	MACH_KERNEL
 #include <sys/types.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <device/buf.h>
 #include <device/errno.h>
@@ -1011,7 +1012,7 @@ rwend:		outb(0x0a, 0x06);
 		}
 		/* clear retry count */
 		if (cip->usebuf) {
-			bcopy(cip->b_vbuf, cip->b_xferaddr, cip->b_xferdma);
+                       memcpy(cip->b_xferaddr, cip->b_vbuf, cip->b_xferdma);
 			DD(printf("R(%x, %x, %x)\n",
 				cip->b_vbuf, cip->b_xferaddr, cip->b_xferdma));
 		}
@@ -1554,7 +1555,7 @@ struct unit_info *uip;
 			cip->usebuf = 1;
 			address = (long)cip->b_pbuf;
 			if (cmdp->c_rwdata[0] == WTM || cmdp->c_rwdata[0] == FMTM) {
-				bcopy(cip->b_xferaddr, cip->b_vbuf, dmalen);
+                               memcpy(cip->b_vbuf, cip->b_xferaddr, dmalen);
 				DD(printf("W(%x, %x, %x)\n",
 					cip->b_xferaddr, cip->b_vbuf, dmalen));
 			}

--- a/i386/kernel/i386at/gpl/if_ul.c
+++ b/i386/kernel/i386at/gpl/if_ul.c
@@ -42,6 +42,7 @@
 #include <device/io_req.h>
 #include <device/if_hdr.h>
 #include <device/if_ether.h>
+#include <string.h>
 #include <device/net_status.h>
 #include <device/net_io.h>
 #include <chips/busses.h>
@@ -432,11 +433,11 @@ ul_input(ns, count, buf, ring_offset)
 		/*
 		 * Input move must be wrapped.
 		 */
-		bcopy((char *)phystokv(xfer_start), buf, semi_count);
+               memcpy(buf, (char *)phystokv(xfer_start), semi_count);
 		count -= semi_count;
-		bcopy((char *)phystokv(ul->sc_rmstart), buf+semi_count, count);
+               memcpy(buf + semi_count, (char *)phystokv(ul->sc_rmstart), count);
 	} else
-		bcopy((char *)phystokv(xfer_start), buf, count);
+               memcpy(buf, (char *)phystokv(xfer_start), count);
 }
 
 int
@@ -453,7 +454,7 @@ ul_output(ns, count, buf, start_page)
 	DEBUGF(printf("ul%d: start_page = %d\n", ns->sc_unit, start_page));
 
 	shmem = (char *)phystokv(ul->sc_mstart + ((start_page-START_PG) << 8));
-	bcopy(buf, shmem, count);
+       memcpy(shmem, buf, count);
 	while (count <  ETHERMIN + sizeof(struct ether_header)) {
 		*(shmem + count) = 0;
 		count++;

--- a/i386/kernel/i386at/gpl/if_wd.c
+++ b/i386/kernel/i386at/gpl/if_wd.c
@@ -41,6 +41,7 @@
 #include <device/io_req.h>
 #include <device/if_hdr.h>
 #include <device/if_ether.h>
+#include <string.h>
 #include <device/net_status.h>
 #include <device/net_io.h>
 #include <chips/busses.h>
@@ -517,11 +518,11 @@ wd_input(ns, count, buf, ring_offset)
 		/*
 		 * Input move must be wrapped.
 		 */
-		bcopy((char *)phystokv(xfer_start), buf, semi_count);
+               memcpy(buf, (char *)phystokv(xfer_start), semi_count);
 		count -= semi_count;
-		bcopy((char *)phystokv(wd->sc_rmstart),buf+semi_count,count);
+               memcpy(buf + semi_count, (char *)phystokv(wd->sc_rmstart), count);
 	} else
-		bcopy((char *)phystokv(xfer_start), buf, count);
+               memcpy(buf, (char *)phystokv(xfer_start), count);
 	if (ns->sc_word16)
 		outb(port + WD_CMDREG5, wd->sc_reg5);
 }
@@ -542,10 +543,10 @@ wd_output(ns, count, buf, start_page)
 	shmem = (char *)phystokv(wd->sc_mstart+((start_page-WD_START_PG)<<8));
 	if (ns->sc_word16) {
 		outb(port + WD_CMDREG5, ISA16 | wd->sc_reg5);
-		bcopy(buf, shmem, count);
+                memcpy(shmem, buf, count);
 		outb(port + WD_CMDREG5, wd->sc_reg5);
 	} else
-		bcopy(buf, shmem, count);
+               memcpy(shmem, buf, count);
 	while (count <  ETHERMIN + sizeof(struct ether_header)) {
 		*(shmem + count) = 0;
 		count++;

--- a/include/pi/event_monitor.c
+++ b/include/pi/event_monitor.c
@@ -18,6 +18,7 @@
 #include "xk_debug.h"
 #include "event.h"
 #include "event_i.h"
+#include <string.h>
 #include "assert.h"
 #include "x_libc.h"
 
@@ -119,8 +120,8 @@ findEvents( key, val, arg )
     if ( eva->i >= eva->max ) {
 	newSize = eva->max ? eva->max * 2 : MAX_EVENTS;
 	newArray = (Event *)xMalloc(sizeof(Event) * newSize);
-	bzero((char *)newArray, sizeof(Event) * newSize);
-	bcopy((char *)eva->arr, (char *)newArray, sizeof(Event) * eva->max);
+        memset((char *)newArray, 0, sizeof(Event) * newSize);
+        memcpy((char *)newArray, (char *)eva->arr, sizeof(Event) * eva->max);
 	if ( eva->arr ) {
 	    xFree((char *)eva->arr);
 	}

--- a/include/pi/idmap/idmap.c
+++ b/include/pi/idmap/idmap.c
@@ -152,7 +152,7 @@ mapVarBind ( table, ext, len, intern )
      * beginning for the semantics mapForEach to work properly.
      */
     GETVARMAPELEM(table, new_elem, len);
-    bcopy((char *)ext, (char *)new_elem->externalid, len);
+    memcpy(new_elem->externalid, ext, len);
     new_elem->internalid = intern;
     new_elem->next = 0;
     new_elem->elmlen = len;
@@ -280,7 +280,7 @@ mapForEach(m, f, arg)
 		prevElem = 0;
 	    }
 	    if ( elem != 0 ) {
-		bcopy((char *)elem->externalid, key, m->keySize);
+                memcpy(key, (char *)elem->externalid, m->keySize);
 		userResult = f(key, elem->internalid, arg);
 		if ( ! (userResult & MFE_CONTINUE) ) {
 		    return;

--- a/include/pi/idmap/tests/mapTestCor.c
+++ b/include/pi/idmap/tests/mapTestCor.c
@@ -65,7 +65,7 @@ formKey( char *key, char frag )
     int	i;
 
     for ( i=0; i < keySize; i++ ) {
-	bcopy(&frag, key + i, sizeof(char));
+        memcpy(key + i, &frag, sizeof(char));
     }
 }
 
@@ -143,7 +143,7 @@ main( int argc, char **argv )
     for ( j=0; j < 1000; j++ ) {
 	randomKey(key1, keySize);
 	h = generichash(key1, 511, keySize);
-	bcopy(key1, offKey+1, keySize);
+        memcpy(offKey+1, key1, keySize);
 	if ( (hashFunc && h != hashFunc(key1, 511)) ||
 	     h != generichash(offKey+1, 511, keySize) ) {
 	    for ( i=0; i < keySize; i++ ) {

--- a/include/pi/idmap/tests/mapTestCor2.c
+++ b/include/pi/idmap/tests/mapTestCor2.c
@@ -54,7 +54,7 @@ formKey( char *key, char frag )
     int	i;
 
     for ( i=0; i < keySize; i++ ) {
-	bcopy(&frag, key + i, sizeof(char));
+        memcpy(key + i, &frag, sizeof(char));
     }
 }
 
@@ -199,7 +199,7 @@ main( int argc, char **argv )
     m = mapCreate(11, keySize);
     
     randomKey(key1, keySize);
-    bcopy(key1, offKey, keySize);
+    memcpy(offKey, key1, keySize);
 
     b = mapBind(m, key1, 22);
     xAssert( b != ERR_BIND );

--- a/include/pi/idmap/tests/mapTestPerf.c
+++ b/include/pi/idmap/tests/mapTestPerf.c
@@ -55,7 +55,7 @@ formKey( char *key, char frag )
 
 #if 0
     for ( i=0; i < keySize; i++ ) {
-	bcopy(&frag, key + i, sizeof(char)); 
+        memcpy(key + i, &frag, sizeof(char));
 	/* 
 	 * Try to get the same hash values independent of the key size. 
 	 */

--- a/include/pi/msg.c
+++ b/include/pi/msg.c
@@ -23,6 +23,7 @@
 #include "platform.h"
 #include "x_util.h"
 #include "x_libc.h"
+#include <string.h>
 
 /* don't change the order of these includes; MSG_NEW_ALG is defined in
    the first one and needed by the second
@@ -606,11 +607,11 @@ void msgConstructBuffer(this, buf, len)
   this->lastStackTailPtr = this->stackTailPtr;
   this->tailstate.myLastStack = 1;
   /* copy in data */
-  bcopy(buf, this->stackHeadPtr, len);
+  memcpy(this->stackHeadPtr, buf, len);
 #else
   this->length = len;
   this->offset = this->stack->b.leaf.size - roundlen;
-  bcopy(buf, this->stack->b.leaf.data + this->offset, len);
+  memcpy(this->stack->b.leaf.data + this->offset, buf, len);
 #endif MSG_NEW_ALG
   this->attr = 0;
   this->attrLen = 0;
@@ -1136,7 +1137,7 @@ s_copy(buf, len, arg)
   /* bcopy takes an int, so be careful */
   chunki = chunk_size;
   xAssert( (long) chunki == chunk_size);
-  bcopy(buf, a->buf, chunki);
+  memcpy(a->buf, buf, chunki);
   a->buf += chunk_size;
   a->size -= chunk_size;
   return (a->size != 0);
@@ -1520,7 +1521,7 @@ static void msgnrpush(stack, item)
 
     newstack = realloc(stack->bottom, newsize);
     if (newstack != (char *)(stack->bottom)) {
-      bcopy((char *)(stack->bottom), newstack, stack->size);
+      memcpy(newstack, (char *)(stack->bottom), stack->size);
       xFree((char *)stack->bottom);
       stack->top = (MNodePage **)(newstack + ((char *)stack->top - (char *)stack->bottom));
       stack->bottom = (MNodePage **)newstack;
@@ -2139,7 +2140,7 @@ frag2Buf( frag, len, bufPtr )
 {
     xTrace3(msg, TR_FUNCTIONAL_TRACE, "frag2Buf copying %d bytes from %x to %x",
 	    len, (int)frag, (int)(*(char **)bufPtr));
-    bcopy(frag, *(char **)bufPtr, len);
+    memcpy(*(char **)bufPtr, frag, len);
     *(char **)bufPtr += len;
     return TRUE;
 }

--- a/include/pi/part.c
+++ b/include/pi/part.c
@@ -16,6 +16,7 @@
 #include "platform.h"
 #include "x_util.h"
 #include "x_libc.h"
+#include <string.h>
 
 void
 partInit(p, n)
@@ -143,7 +144,7 @@ partExternalize( p, dstBuf, bufLen )
 	    buf += sizeof(int);
 	    if ( len ) {
 		CHECK_BUF_LEN(len);
-		bcopy((char *)p->stack.arr[j].ptr, buf, len);
+                memcpy(buf, (char *)p->stack.arr[j].ptr, len);
 		buf += len;
 	    } else {
 		/* 
@@ -160,7 +161,7 @@ partExternalize( p, dstBuf, bufLen )
 	}
     }
     *bufLen = buf - bufStart;
-    bcopy(bufStart, dstBuf, *bufLen);
+    memcpy(dstBuf, bufStart, *bufLen);
     xFree(bufStart);
     return XK_SUCCESS;
 }

--- a/include/pi/upi.c
+++ b/include/pi/upi.c
@@ -25,6 +25,7 @@
 #include "event.h"
 #ifndef XKMACHKERNEL
 #include "x_stdio.h"
+#include <string.h>
 #include "x_libc.h"
 #endif XKMACHKERNEL
 
@@ -618,8 +619,8 @@ xSetDown( s, i, obj )
 	    newsz = ((n / STD_DOWN) + 1) * STD_DOWN;
 	    newdl = (XObj *) xMalloc(newsz * sizeof(XObj));
 	    if ( s->downlist ) {
-		bcopy((char *)s->downlist, (char *)newdl,
-		      s->downlistsz * sizeof(XObj));
+                memcpy((char *)newdl, (char *)s->downlist,
+                       s->downlistsz * sizeof(XObj));
 		xFree((char *)s->downlist);
 	    }
 	    s->downlist = newdl;

--- a/include/pi/upi_defaults.c
+++ b/include/pi/upi_defaults.c
@@ -11,16 +11,17 @@
  */
 
 #include "xkernel.h"
+#include <string.h>
 
 extern int	traceprotocol;
 int	traceprotdef = 0;
 
 
 #define savePart(pxx, spxx)	\
-    bcopy((char *)(pxx), (char *)(spxx), sizeof(Part) * partLen(p))
+    memcpy((char *)(spxx), (char *)(pxx), sizeof(Part) * partLen(p))
 
 #define restorePart(pxx, spxx)	\
-    bcopy((char *)(spxx), (char *)(pxx), sizeof(Part) * partLen(p))
+    memcpy((char *)(pxx), (char *)(spxx), sizeof(Part) * partLen(p))
 
 /* 
  * Check for a valid participant list
@@ -146,7 +147,7 @@ findHlpEnable( key, val, arg )
 
     if ( e->hlpRcv == fs->hlpRcv ) {
 	fs->e = e;
-	bcopy(key, fs->key, fs->keySize);
+        memcpy(fs->key, key, fs->keySize);
 	return FALSE;
     } else {
 	return TRUE;

--- a/netbsd/drivers/simeth/sim_ether.c
+++ b/netbsd/drivers/simeth/sim_ether.c
@@ -19,6 +19,7 @@
 #include <signal.h>
 
 #include <sys/types.h>
+#include <string.h>
 #include <netinet/in.h>
 #include "x_stdio.h"
 #include "xkernel.h"
@@ -366,7 +367,7 @@ static void
 ethMsgStore( void *hdr, char *netHdr, long len, void *arg )
 {
     xAssert(len == sizeof(ETHhdr));
-    bcopy(hdr, netHdr, sizeof(ETHhdr));
+    memcpy(netHdr, hdr, sizeof(ETHhdr));
 }
 
 
@@ -374,7 +375,7 @@ static long
 ethMsgLoad( void *hdr, char *netHdr, long len, void *arg )
 {
     xAssert(len == sizeof(ETHhdr));
-    bcopy(netHdr, (char *)hdr, sizeof(ETHhdr));
+    memcpy(hdr, netHdr, sizeof(ETHhdr));
     return sizeof(ETHhdr);
 }
 
@@ -607,7 +608,7 @@ readether2demux( arg )
 static bool
 msg2Buf(char *msgPtr, long len, void *bufPtr)
 {
-  bcopy(msgPtr, *(char **)bufPtr, len);
+  memcpy(*(char **)bufPtr, msgPtr, len);
   *(char **)bufPtr += len;
   return TRUE;
 }
@@ -658,7 +659,7 @@ simethControl( s, op, buf, len )
 
       case GETMYHOST:
 	checkLen(len, sizeof(ETHhost));
-	bcopy((char *) &ps->myHost, buf, sizeof(ETHhost));
+        memcpy(buf, (char *) &ps->myHost, sizeof(ETHhost));
 	return (sizeof(ETHhost));
 
       case SIM_SOCK2ADDR:

--- a/netbsd/pxk/alloc.c
+++ b/netbsd/pxk/alloc.c
@@ -17,6 +17,7 @@
 #include "x_util.h"
 #include "x_libc.h"
 #include "event.h"
+#include <string.h>
 
 int	tracemalloc;
 
@@ -201,7 +202,7 @@ dumpBlocks( ev, arg )
     static long	*	lblocks[MAXBLOCKS];
 
     xError("\n\n\nMalloc trace\n");
-    bcopy((char *)blocks, (char *)lblocks, sizeof(blocks));
+    memcpy(lblocks, blocks, sizeof(blocks));
     xIfTrace(malloc, verboseDump) {	
 	for ( i=0; i < MAXBLOCKS; i++, j++ ) {
 	    displayLine(blocks, i);
@@ -230,8 +231,8 @@ dumpBlocks( ev, arg )
 		}
 		xTrace1(malloc, TR_ALWAYS, "%s", buf);
 	    }
-	    if (b) bcopy((char *)(b + MALLOC_EXTRAS), (char *)last,
-			 MALLOC_NPCS * sizeof(long));
+            if (b) memcpy(last, (char *)(b + MALLOC_EXTRAS),
+                         MALLOC_NPCS * sizeof(long));
 	    j = 0;
 	}
 	if (!b) break;

--- a/netbsd/pxk/alloc_old.c
+++ b/netbsd/pxk/alloc_old.c
@@ -86,6 +86,7 @@ extern char *xsbrk();
 #define USESPL
 #ifdef GORP
 #include <stdio.h>
+#include <string.h>
 #endif
 
 /*  An implementation of malloc(3), free(3) using the QuickFit method.
@@ -722,7 +723,7 @@ int n, x;
   static long *lblocks[MAXBLOCKS];
   if (n > MALLOC_NPCS) n = MALLOC_NPCS;
   if (n < 1) n = 1;
-  bcopy(blocks, lblocks, sizeof(blocks));
+  memcpy(lblocks, blocks, sizeof(blocks));
   qsort(lblocks, MAXBLOCKS, sizeof(long *), compareblocks);
   for (i = 0, j = 0; i < MAXBLOCKS; i++, j++) {
     b = lblocks[i];
@@ -734,7 +735,7 @@ int n, x;
 	}
 	printf("\n");
       }
-      if (b) bcopy(b + MALLOC_CHECK + MALLOC_NPCS, last, MALLOC_NPCS * sizeof(long));
+      if (b) memcpy(last, b + MALLOC_CHECK + MALLOC_NPCS, MALLOC_NPCS * sizeof(long));
       j = 0;
     }
     if (!b) break;


### PR DESCRIPTION
## Summary
- modernize memory operations by replacing `bcopy` with `memcpy`
- replace `bzero` with `memset`
- add `<string.h>` where needed for new functions

## Testing
- `make -n` *(fails: `/bin/sh: 1: cd: can't cd to /usr/obj/lites`)*