### PR TITLE
Add reorg helper scripts

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -1,0 +1,13 @@
+# Project Plan
+
+This file collects small tasks and utilities used during the
+ongoing reorganisation work.
+
+## Scripts
+
+- **scripts/reorg/flatten_tree.sh** – copies sources from the
+  `exokernel/`, `microkernel/` and `libOS/` directories into
+  `flattened/` with path components encoded using underscores.
+- **scripts/reorg/include_graph.sh** – parses `#include` lines in the
+  tree and writes a simple `source -> header` map to
+  `include_graph.txt` by default.

--- a/scripts/reorg/flatten_tree.sh
+++ b/scripts/reorg/flatten_tree.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copy files from exokernel, microkernel and libOS directories
+# into a single flattened/ directory. Paths are encoded with
+# underscores to avoid collisions.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DEST="$ROOT/flattened"
+
+components=(exokernel microkernel libOS)
+
+mkdir -p "$DEST"
+
+for comp in "${components[@]}"; do
+    src="$ROOT/$comp"
+    [ -d "$src" ] || continue
+    mkdir -p "$DEST/$comp"
+    find "$src" -type f -print0 | while IFS= read -r -d '' file; do
+        rel="${file#$src/}"
+        target="$DEST/$comp/${rel//\//_}"
+        cp "$file" "$target"
+    done
+done
+
+echo "Flattened files copied to $DEST"

--- a/scripts/reorg/include_graph.sh
+++ b/scripts/reorg/include_graph.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Parse #include lines to produce a simple dependency map.
+# Each line of output has the form "<source> -> <header>".
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+OUT_FILE="${1:-$ROOT/include_graph.txt}"
+
+> "$OUT_FILE"
+
+find "$ROOT" -name '*.c' -o -name '*.h' 2>/dev/null | while read -r file; do
+    rel="${file#$ROOT/}"
+    while IFS= read -r line; do
+        if [[ $line =~ ^[[:space:]]*#include[[:space:]]+[<\"]([^\">]+)[\">] ]]; then
+            inc="${BASH_REMATCH[1]}"
+            echo "$rel -> $inc" >> "$OUT_FILE"
+        fi
+    done < "$file"
+done
+
+echo "Include graph written to $OUT_FILE"


### PR DESCRIPTION
## Summary
- add flatten_tree.sh to gather exokernel/microkernel/libOS files
- add include_graph.sh to generate a simple include dependency map
- note both utilities in PROJECT_PLAN.md

## Testing
- `./scripts/run-precommit.sh` *(fails: could not install pre-commit)*