### PR TITLE
Remove flattened_include and adjust build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,18 +95,19 @@ else()
     set(_default_src "${CMAKE_CURRENT_SOURCE_DIR}/build/lites-1.1.u3")
 endif()
 set(LITES_SRC_DIR "${_default_src}" CACHE PATH "Lites source directory")
+set(LITES_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include" CACHE PATH "Consolidated header directory")
 
 # Ensure an include/machine symlink exists before collecting sources.
-if(EXISTS "${LITES_SRC_DIR}/include")
-    if(NOT EXISTS "${LITES_SRC_DIR}/include/machine")
+if(EXISTS "${LITES_INCLUDE_DIR}")
+    if(NOT EXISTS "${LITES_INCLUDE_DIR}/machine")
         set(_machine_arch "${ARCH}")
         if(_machine_arch STREQUAL "i686")
             set(_machine_arch "i386")
         endif()
-        if(EXISTS "${LITES_SRC_DIR}/include/${_machine_arch}")
+        if(EXISTS "${LITES_INCLUDE_DIR}/${_machine_arch}")
             execute_process(
                 COMMAND "${CMAKE_COMMAND}" -E create_symlink "${_machine_arch}" "machine"
-                WORKING_DIRECTORY "${LITES_SRC_DIR}/include")
+                WORKING_DIRECTORY "${LITES_INCLUDE_DIR}")
         endif()
     endif()
 endif()
@@ -178,7 +179,7 @@ if(EXISTS "${LITES_SRC_DIR}")
 
     add_executable(lites_server ${SERVER_SRC})
     target_include_directories(lites_server PRIVATE
-        "${LITES_SRC_DIR}/include"
+        "${LITES_INCLUDE_DIR}"
         "${LITES_SRC_DIR}/server"
         "${LITES_SRC_DIR}/iommu"
         "${CMAKE_CURRENT_SOURCE_DIR}/libos"
@@ -188,22 +189,22 @@ if(EXISTS "${LITES_SRC_DIR}")
         "${CMAKE_CURRENT_SOURCE_DIR}/include")
     if(ARCH STREQUAL "x86_64")
         target_include_directories(lites_server PRIVATE
-            "${LITES_SRC_DIR}/include/x86_64")
+            "${LITES_INCLUDE_DIR}/x86_64")
     elseif(ARCH STREQUAL "i686")
         target_include_directories(lites_server PRIVATE
-            "${LITES_SRC_DIR}/include/i386")
+            "${LITES_INCLUDE_DIR}/i386")
     elseif(ARCH STREQUAL "arm")
         target_include_directories(lites_server PRIVATE
-            "${LITES_SRC_DIR}/include/arm")
+            "${LITES_INCLUDE_DIR}/arm")
     elseif(ARCH STREQUAL "riscv64")
         target_include_directories(lites_server PRIVATE
-            "${LITES_SRC_DIR}/include/riscv64")
+            "${LITES_INCLUDE_DIR}/riscv64")
     elseif(ARCH STREQUAL "powerpc")
         target_include_directories(lites_server PRIVATE
-            "${LITES_SRC_DIR}/include/powerpc")
+            "${LITES_INCLUDE_DIR}/powerpc")
     elseif(ARCH STREQUAL "ia16")
         target_include_directories(lites_server PRIVATE
-            "${LITES_SRC_DIR}/include/ia16")
+            "${LITES_INCLUDE_DIR}/ia16")
     endif()
     target_compile_options(lites_server PRIVATE ${C23_FLAG} ${CFLAGS})
     target_link_options(lites_server PRIVATE ${LDFLAGS})
@@ -216,7 +217,7 @@ if(EXISTS "${LITES_SRC_DIR}")
     if(EMULATOR_SRC)
         add_executable(lites_emulator ${EMULATOR_SRC})
         target_include_directories(lites_emulator PRIVATE
-            "${LITES_SRC_DIR}/include"
+            "${LITES_INCLUDE_DIR}"
             "${LITES_SRC_DIR}/emulator"
             "${CMAKE_CURRENT_SOURCE_DIR}/libos"
             "${MACH_INCLUDE_DIR}"
@@ -227,22 +228,22 @@ if(EXISTS "${LITES_SRC_DIR}")
 
         if(ARCH STREQUAL "x86_64")
             target_include_directories(lites_emulator PRIVATE
-                "${LITES_SRC_DIR}/include/x86_64")
+                "${LITES_INCLUDE_DIR}/x86_64")
         elseif(ARCH STREQUAL "i686")
             target_include_directories(lites_emulator PRIVATE
-                "${LITES_SRC_DIR}/include/i386")
+                "${LITES_INCLUDE_DIR}/i386")
         elseif(ARCH STREQUAL "arm")
             target_include_directories(lites_emulator PRIVATE
-                "${LITES_SRC_DIR}/include/arm")
+                "${LITES_INCLUDE_DIR}/arm")
         elseif(ARCH STREQUAL "riscv64")
             target_include_directories(lites_emulator PRIVATE
-                "${LITES_SRC_DIR}/include/riscv64")
+                "${LITES_INCLUDE_DIR}/riscv64")
         elseif(ARCH STREQUAL "powerpc")
             target_include_directories(lites_emulator PRIVATE
-                "${LITES_SRC_DIR}/include/powerpc")
+                "${LITES_INCLUDE_DIR}/powerpc")
         elseif(ARCH STREQUAL "ia16")
             target_include_directories(lites_emulator PRIVATE
-                "${LITES_SRC_DIR}/include/ia16")
+                "${LITES_INCLUDE_DIR}/ia16")
         endif()
         target_compile_options(lites_emulator PRIVATE ${C23_FLAG} ${CFLAGS})
         target_link_options(lites_emulator PRIVATE ${LDFLAGS})

--- a/Makefile.new
+++ b/Makefile.new
@@ -62,25 +62,25 @@ endif
 ifeq ($(ARCH),i686)
 CFLAGS += -m32
 LDFLAGS += -m32
-ARCH_INCDIR := -I$(SRCDIR)/include/i386
+ARCH_INCDIR := -Iinclude/i386
 else ifeq ($(ARCH),x86_64)
 CFLAGS += -m64
 LDFLAGS += -m64
-ARCH_INCDIR := -I$(SRCDIR)/include/x86_64
+ARCH_INCDIR := -Iinclude/x86_64
 else ifeq ($(ARCH),arm)
 CFLAGS += -marm
-ARCH_INCDIR := -I$(SRCDIR)/include/arm
+ARCH_INCDIR := -Iinclude/arm
 else ifeq ($(ARCH),riscv64)
 CFLAGS += -march=rv64imac -mabi=lp64
-ARCH_INCDIR := -I$(SRCDIR)/include/riscv64
+ARCH_INCDIR := -Iinclude/riscv64
 else ifeq ($(ARCH),powerpc)
 CFLAGS += -m32
 LDFLAGS += -m32
-ARCH_INCDIR := -I$(SRCDIR)/include/powerpc
+ARCH_INCDIR := -Iinclude/powerpc
 else ifeq ($(ARCH),ia16)
 CFLAGS += -m16
 LDFLAGS += -m16
-ARCH_INCDIR := -I$(SRCDIR)/include/ia16
+ARCH_INCDIR := -Iinclude/ia16
 endif
 
 # Map ARCH to the corresponding directory name
@@ -137,22 +137,22 @@ TEST_SUBDIRS := $(sort $(dir $(wildcard tests/*/Makefile)))
 all: prepare $(LIBOS_A) $(TARGETS)
 
 prepare:
-        @if [ ! -e $(SRCDIR)/include/machine ]; then \
-          arch_dir=$(ARCH); \
-          [ "$$arch_dir" = "i686" ] && arch_dir=i386; \
-          ln -s $$arch_dir $(SRCDIR)/include/machine; \
-        fi
+	@if [ ! -e include/machine ]; then \
+	  arch_dir=$(ARCH); \
+	  [ "$$arch_dir" = "i686" ] && arch_dir=i386; \
+	  ln -s $$arch_dir include/machine; \
+	fi
 
 lites_server: $(SERVER_SRC) $(KERN_SRC) $(LIBOS_A)
-	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(SERVER_INCDIRS) $(KERN_INCDIRS) $^ $(LIBOS_A) $(MACH_LIBS) $(LDFLAGS) -o $@
+	$(CC) $(CFLAGS) -Iinclude $(ARCH_INCDIR) $(MACH_INCDIR) $(SERVER_INCDIRS) $(KERN_INCDIRS) $^ $(LIBOS_A) $(MACH_LIBS) $(LDFLAGS) -o $@
 
 ifneq ($(EMULATOR_SRC),)
-lites_emulator: $(EMULATOR_SRC) $(KERN_SRC) $(LIBOS_A)
-	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(EMULATOR_INCDIRS) $(KERN_INCDIRS) $^ $(LIBOS_A) $(MACH_LIBS) $(LDFLAGS) -o $@
+	lites_emulator: $(EMULATOR_SRC) $(KERN_SRC) $(LIBOS_A)
+	$(CC) $(CFLAGS) -Iinclude $(ARCH_INCDIR) $(MACH_INCDIR) $(EMULATOR_INCDIRS) $(KERN_INCDIRS) $^ $(LIBOS_A) $(MACH_LIBS) $(LDFLAGS) -o $@
 endif
 
 clean:
-	rm -f lites_server lites_emulator
+		rm -f lites_server lites_emulator
 
 test: all
 	@for d in $(TEST_SUBDIRS); do \

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ cmake --build build
 ```
 ## Header inventory
 
-Use `scripts/flatten-headers.sh` to gather all header files from across the repository. The script copies each header into the `flattened_include/` directory and automatically renames duplicates by embedding the original path in the filename.
+Use `scripts/flatten-headers.sh` to gather all header files from across the repository. The script now copies each header into the `include/` directory and automatically renames duplicates by embedding the original path in the filename.
 
 ## Building
 

--- a/scripts/flatten-headers.sh
+++ b/scripts/flatten-headers.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-DEST="$ROOT/flattened_include"
+DEST="$ROOT/include"
 
 mkdir -p "$DEST"
 


### PR DESCRIPTION
## Summary
- move consolidated headers into `include/`
- update Makefile and CMakeLists to point at the new location
- note new location in README
- adjust `scripts/flatten-headers.sh` to write to `include`

## Testing
- `scripts/run-clang-tidy.sh` *(fails: no compilation database)*