### PR TITLE
Clarify header collision handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,13 @@ cmake --build build
 ```
 ## Header inventory
 
-Use `scripts/flatten-headers.sh` to gather all header files from across the repository. The script now copies each header into the `include/` directory and automatically renames duplicates by embedding the original path in the filename.
+Use `scripts/flatten-headers.sh` to gather all header files from across the
+repository.  The script copies each header into the `include/` directory and
+renames files that would otherwise clash.  When two headers share the same
+basename, the relative path to the original file is encoded in the new filename
+by replacing `/` with `_`.  For example a header located at
+`i386/include/mach/machine/asm.h` is written as
+`i386_include_mach_machine_asm.h` when a plain `asm.h` already exists.
 
 ## Building
 


### PR DESCRIPTION
## Summary
- clarify how flatten-headers encodes duplicates

## Testing
- `pre-commit run --files README.md` *(fails: pre-commit not installed)*
- `make -f Makefile.new test` *(fails: Mach headers not found)*