### PR TITLE
Add flattened include headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,12 @@ else()
     set(_default_src "${CMAKE_CURRENT_SOURCE_DIR}/build/lites-1.1.u3")
 endif()
 set(LITES_SRC_DIR "${_default_src}" CACHE PATH "Lites source directory")
-set(LITES_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include" CACHE PATH "Consolidated header directory")
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/flattened/include")
+    set(_default_include "${CMAKE_CURRENT_SOURCE_DIR}/flattened/include")
+else()
+    set(_default_include "${CMAKE_CURRENT_SOURCE_DIR}/include")
+endif()
+set(LITES_INCLUDE_DIR "${_default_include}" CACHE PATH "Consolidated header directory")
 
 # Ensure an include/machine symlink exists before collecting sources.
 if(EXISTS "${LITES_INCLUDE_DIR}")

--- a/flattened/include/exokernel/resource.h
+++ b/flattened/include/exokernel/resource.h
@@ -1,0 +1,15 @@
+#ifndef EXOKERNEL_RESOURCE_H
+#define EXOKERNEL_RESOURCE_H
+
+#include <stddef.h>
+
+typedef struct resource {
+    void *start;
+    size_t size;
+    int type;
+} resource_t;
+
+void *resource_alloc(size_t size);
+void resource_free(void *ptr);
+
+#endif /* EXOKERNEL_RESOURCE_H */

--- a/flattened/include/microkernel/thread.h
+++ b/flattened/include/microkernel/thread.h
@@ -1,0 +1,14 @@
+#ifndef MICROKERNEL_THREAD_H
+#define MICROKERNEL_THREAD_H
+
+#include <stddef.h>
+
+struct mk_thread;
+
+typedef void (*mk_thread_entry_t)(void *arg);
+
+int mk_thread_create(struct mk_thread **out, mk_thread_entry_t entry, void *arg,
+                     size_t stack_size);
+void mk_thread_exit(void);
+
+#endif /* MICROKERNEL_THREAD_H */

--- a/flattened/include/userspace/personality.h
+++ b/flattened/include/userspace/personality.h
@@ -1,0 +1,10 @@
+#ifndef USERSPACE_PERSONALITY_H
+#define USERSPACE_PERSONALITY_H
+
+struct userspace_ops {
+    int (*init)(void);
+    int (*exec)(const char *path, char *const argv[]);
+    void (*exit)(int code);
+};
+
+#endif /* USERSPACE_PERSONALITY_H */

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,13 @@ lites_src_dir = run_command('sh', '-c', 'echo "$LITES_SRC_DIR"').stdout().strip(
 if lites_src_dir == ''
   error('LITES_SRC_DIR must be set')
 endif
-inc = include_directories('.', join_paths(lites_src_dir, 'include'))
+fs = import('fs')
+flattened_inc = join_paths(meson.current_source_dir(), 'flattened', 'include')
+if fs.is_dir(flattened_inc)
+  inc = include_directories('.', flattened_inc)
+else
+  inc = include_directories('.', join_paths(lites_src_dir, 'include'))
+endif
 libos = static_library('oslib', 'libos/vm.c')
 executable('ipc-demo',
            ['ipc.c', 'bin/ipc-demo.c'],


### PR DESCRIPTION
## Summary
- add resource_t definition for exokernel
- add microkernel thread API declarations
- add userspace personality abstraction
- use flattened/include when present in both CMake and meson builds

## Testing
- `scripts/run-precommit.sh` *(fails: Could not install pre-commit)*