### PR TITLE
Add header mapping and reorg helper

### DIFF
--- a/scripts/flatten-headers.sh
+++ b/scripts/flatten-headers.sh
@@ -3,22 +3,50 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DEST="$ROOT/include"
+MAP_FILE=""
+
+usage() {
+    echo "Usage: $0 [--map <file>]" >&2
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -m|--map)
+            MAP_FILE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--map <file>]"
+            exit 0
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
 
 mkdir -p "$DEST"
+if [ -n "$MAP_FILE" ]; then
+    echo "original,flattened" > "$MAP_FILE"
+fi
 
 copy_header() {
     local src="$1"
     local rel="$2"
-    local base
+    local base target enc dest_name
     base=$(basename "$rel")
-    local target="$DEST/$base"
+    target="$DEST/$base"
     if [ -e "$target" ]; then
         # avoid collisions by encoding the relative path
-        local enc
         enc="${rel//\//_}"
         target="$DEST/$enc"
     fi
     cp "$src" "$target"
+    if [ -n "$MAP_FILE" ]; then
+        dest_name="$(basename "$target")"
+        echo "$rel,$dest_name" >> "$MAP_FILE"
+    fi
 }
 
 if [ -f "$ROOT/headers_inventory.csv" ]; then

--- a/scripts/reorg/update_headers.sh
+++ b/scripts/reorg/update_headers.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+DEST="$ROOT/flattened/include"
+MAP="$DEST/headers.csv"
+
+rm -rf "$DEST"
+mkdir -p "$DEST"
+
+# create mapping header
+echo "original,flattened" > "$MAP"
+
+copy_header() {
+    local src="$1"
+    local rel="$2"
+    local base target enc dest_name
+    base=$(basename "$rel")
+    target="$DEST/$base"
+    if [ -e "$target" ]; then
+        enc="${rel//\//_}"
+        target="$DEST/$enc"
+    fi
+    cp "$src" "$target"
+    dest_name="$(basename "$target")"
+    echo "$rel,$dest_name" >> "$MAP"
+}
+
+if [ -f "$ROOT/headers_inventory.csv" ]; then
+    tail -n +2 "$ROOT/headers_inventory.csv" | while IFS= read -r path; do
+        file="$ROOT/${path#./}"
+        [ -f "$file" ] || continue
+        copy_header "$file" "${path#./}"
+    done
+else
+    find "$ROOT" -name '*.h' -print0 |
+        while IFS= read -r -d '' file; do
+            rel="${file#$ROOT/}"
+            copy_header "$file" "$rel"
+        done
+fi
+
+echo "Flattened headers copied to $DEST"


### PR DESCRIPTION
## Summary
- capture original->flattened mapping in `flatten-headers.sh`
- script to populate `flattened/include` for Phase 5 reorg

## Testing
- `scripts/run-precommit.sh` *(fails: could not install pre-commit)*