### PR TITLE
Restructure build for POSIX helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,10 @@ if(EXISTS "${LITES_SRC_DIR}")
     endif()
 endif()
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libs/libposix")
+    add_subdirectory(libs/libposix)
+endif()
+
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests")
     add_subdirectory(tests)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,2 @@
-add_subdirectory(../libs/libposix ${CMAKE_CURRENT_BINARY_DIR}/libposix)
 add_subdirectory(unit)
 add_subdirectory(integration)


### PR DESCRIPTION
## Summary
- build libposix from the top-level CMake
- rely on the shared library in the tests

## Testing
- `cmake -B build` *(fails: Mach headers not found)*