### PR TITLE
Update docs to reference archives directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ services themselves in `servers/`.  Small command line utilities have been
 gathered in `util/` and demonstration programs live in `examples/`.  External
 code that needs to remain in-tree is stored in `third_party/`.  Older release
 snapshots and archived build files (such as `makefile.legacy`) are located in
-the top level `Historical Archives/` directory.
+the top level `archives/` directory.
 Public headers now live in `include/` while kernel-only headers remain in
 `core/include/`.
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,7 +16,7 @@ The `docs/` directory contains notes and background information for the project.
 - **RESTRUCTURE_PLAN.md** - Proposal for reorganising the repository layout.
 - **RESTRUCTURE_LAYOUT.md** - Details the final directory scheme and testing
   instructions.
-- **Historical Archives/** - Preserved snapshots, old build files such as
+- **archives/** - Preserved snapshots, old build files such as
   `makefile.legacy`, and tarballs from earlier releases.
 - **examples/** - Demonstration programs grouped by topic (`ipc/`, `posix/`,
   `security/`).

--- a/docs/RESTRUCTURE_LAYOUT.md
+++ b/docs/RESTRUCTURE_LAYOUT.md
@@ -13,7 +13,7 @@ third_party/ - external dependencies kept in-tree
 cmake/      - common build system logic
 util/       - small command line utilities
 examples/   - demonstration programs
-Historical Archives/ - preserved snapshots, tarballs and legacy build files
+archives/ - preserved snapshots, tarballs and legacy build files
   such as `makefile.legacy`
 ```
 The directory is now named `mach_kernel`. Kernel headers such as `spinlock.h` remain in `core/include/` while
@@ -21,7 +21,7 @@ public headers are provided under `include/`.
 
 Other existing directories such as `tests/` and `docs/` remain at the top level.
 The legacy release trees once stored at the repository root have been moved
-into `Historical Archives/` along with old build scripts such as
+into `archives/` along with old build scripts such as
 `makefile.legacy`.
 
 ## Header organisation

--- a/docs/RESTRUCTURE_PLAN.md
+++ b/docs/RESTRUCTURE_PLAN.md
@@ -9,7 +9,7 @@ maintain.
 - Separate kernel, user space servers and libraries into clear top level
   directories.
 - Move historical snapshots and old build scripts (e.g. `makefile.legacy`)
-  under `Historical Archives/`.
+  under `archives/`.
 - Provide a common `third_party/` directory for external projects.
 - Consolidate build scripts under a single `cmake/` hierarchy.
 - Collect small utilities in `util/` and place example programs in


### PR DESCRIPTION
## Summary
- fix documentation references to `archives/`

## Testing
- `make -f Makefile.new test` *(fails: missing directories)*
- `cmake -B build` *(fails: missing source files)*