### PR TITLE
Add missing library cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,22 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libs/libposix")
     add_subdirectory(libs/libposix)
 endif()
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libs/ddekit")
+    add_subdirectory(libs/ddekit)
+endif()
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libs/libcrypto")
+    add_subdirectory(libs/libcrypto)
+endif()
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libs/liblites")
+    add_subdirectory(libs/liblites)
+endif()
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libs/libos")
+    add_subdirectory(libs/libos)
+endif()
+
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests")
     add_subdirectory(tests)
 endif()

--- a/libs/ddekit/CMakeLists.txt
+++ b/libs/ddekit/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(ddekit INTERFACE)
+
+target_include_directories(ddekit INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/badgerferret
+    ${CMAKE_SOURCE_DIR}/include
+)
+

--- a/libs/libcrypto/CMakeLists.txt
+++ b/libs/libcrypto/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(lites_crypto STATIC
+    aes_fallback.c
+    keystore.c
+)
+
+target_include_directories(lites_crypto PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/include
+)
+

--- a/libs/liblites/CMakeLists.txt
+++ b/libs/liblites/CMakeLists.txt
@@ -1,0 +1,48 @@
+set(LIBLITES_SRC
+    exec_file.c
+    enclave.c
+    posix_wrap.c
+)
+
+if(ARCH STREQUAL "i686")
+    list(APPEND LIBLITES_SRC
+        i386/in_cksum.c
+        i386/ntoh.S
+        memcmp.c
+    )
+elseif(ARCH STREQUAL "x86_64")
+    list(APPEND LIBLITES_SRC
+        x86_64/in_cksum.c
+        x86_64/ntoh.S
+        memcmp.c
+    )
+elseif(ARCH STREQUAL "ns532")
+    list(APPEND LIBLITES_SRC
+        ns532/in_cksum.c
+        ns532/misc_asm.S
+        memcmp.c
+        bcmp.c
+    )
+elseif(ARCH STREQUAL "mips")
+    list(APPEND LIBLITES_SRC
+        mips/ntoh.c
+        memcmp.c
+        bcmp.c
+    )
+elseif(ARCH STREQUAL "alpha")
+    list(APPEND LIBLITES_SRC
+        alpha/ntoh.c
+        bcmp.c
+        memcmp.c
+    )
+else()
+    list(APPEND LIBLITES_SRC memcmp.c)
+endif()
+
+add_library(liblites STATIC ${LIBLITES_SRC})
+
+target_include_directories(liblites PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/include
+)
+

--- a/libs/libos/CMakeLists.txt
+++ b/libs/libos/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(lites_os STATIC
+    vm.c
+)
+
+target_include_directories(lites_os PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/include
+)
+


### PR DESCRIPTION
## Summary
- add CMake support for `ddekit`, `libcrypto`, `liblites` and `libos`
- hook new libraries into the main build

## Testing
- `cmake -S . -B build` *(fails: cannot find source files for tests)*