### PR TITLE
Fix Makefile.new indentation

### DIFF
--- a/Makefile.new
+++ b/Makefile.new
@@ -113,7 +113,7 @@ SERVER_DIRS := $(SRCDIR)/server/$(ARCH_DIR) $(SERVER_COMMON_DIRS)
 SERVER_SRC := $(foreach d,$(SERVER_DIRS),$(shell find $(d) -name \*.c -o -name \*.S))
 SERVER_INCDIRS := $(addprefix -I,$(SERVER_DIRS))
 KERN_SRC := $(wildcard kern/*.c) $(wildcard $(SRCDIR)/../drivers/iommu/*.c) \
-            $(wildcard $(SRCDIR)/libos/*.c)
+	    $(wildcard $(SRCDIR)/libos/*.c)
 POSIX_SRC := $(wildcard posix/*.c)
 KERN_SRC += $(POSIX_SRC)
 KERN_INCDIRS := -Iinclude -Ikern -I$(SRCDIR)/../drivers/iommu -Iposix -I$(SRCDIR)/libos
@@ -134,11 +134,11 @@ TEST_SUBDIRS := $(sort $(dir $(wildcard tests/*/Makefile)))
 all: prepare $(TARGETS)
 
 prepare:
-        @if [ ! -e $(SRCDIR)/include/machine ]; then \
-          arch_dir=$(ARCH); \
-          [ "$$arch_dir" = "i686" ] && arch_dir=i386; \
-          ln -s $$arch_dir $(SRCDIR)/include/machine; \
-        fi
+	@if [ ! -e $(SRCDIR)/include/machine ]; then \
+	  arch_dir=$(ARCH); \
+	  [ "$$arch_dir" = "i686" ] && arch_dir=i386; \
+	  ln -s $$arch_dir $(SRCDIR)/include/machine; \
+	fi
 
 lites_server: $(SERVER_SRC) $(KERN_SRC)
 	$(CC) $(CFLAGS) -I$(SRCDIR)/include $(ARCH_INCDIR) $(MACH_INCDIR) $(SERVER_INCDIRS) $(KERN_INCDIRS) $^ $(MACH_LIBS) $(LDFLAGS) -o $@


### PR DESCRIPTION
## Summary
- update `Makefile.new` recipes to use tabs instead of spaces

## Testing
- `cmake -B build -DLITES_SRC_DIR=. ` *(fails: cannot find source file)*
- `make -f Makefile.new` *(fails: build/lites-1.1.u3 not found)*