### PR TITLE
Implement hardened linker flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,8 @@ find_package(BISON)
 # Allow selecting the build architecture with -DARCH=i686 or ARCH=x86_64
 set(ARCH "$ENV{ARCH}" CACHE STRING "Target architecture (x86_64 or i686)")
 set(CFLAGS "$ENV{CFLAGS}" CACHE STRING "Additional compiler flags")
-set(LDFLAGS "$ENV{LDFLAGS}" CACHE STRING "Additional linker flags")
+# Harden binaries by disallowing executable stacks
+set(LDFLAGS "$ENV{LDFLAGS} -Wl,-z,noexecstack" CACHE STRING "Additional linker flags")
 set(SANITIZE "$ENV{SANITIZE}" CACHE STRING "Enable address sanitizer (1/0)")
 set(MULTICORE_SCHED "$ENV{MULTICORE_SCHED}" CACHE STRING "Enable multicore scheduler (1/0)")
 set(LITES_MACH_LIB_DIR "$ENV{LITES_MACH_LIB_DIR}" CACHE PATH "Directory containing Mach static libraries")

--- a/Makefile.new
+++ b/Makefile.new
@@ -45,6 +45,8 @@ ARCH ?= x86_64
 # Base optimisation flags
 C23_FLAG := $(shell $(CC) -std=c23 -E -x c /dev/null >/dev/null 2>&1 && echo -std=c23 || echo -std=c2x)
 CFLAGS ?= -O2 $(C23_FLAG)
+# Harden binaries by disallowing executable stacks
+LDFLAGS += -Wl,-z,noexecstack
 
 # Optional address sanitizer
 SANITIZE ?= 0

--- a/setup.sh
+++ b/setup.sh
@@ -202,7 +202,8 @@ export CLANG_TIDY="clang-tidy"
 export PATH="/usr/lib/ccache:$PATH"
 export CFLAGS="-Wall -Wextra -Werror -O2"
 export CXXFLAGS="$CFLAGS"
-export LDFLAGS="-fuse-ld=lld -flto"
+# Harden binaries by disallowing executable stacks
+export LDFLAGS="-fuse-ld=lld -flto -Wl,-z,noexecstack"
 export LLVM_PROFILE_FILE="/tmp/profiles/default.profraw"
 export CLANG_EXTRA_FLAGS="-mllvm -polly"
 


### PR DESCRIPTION
## Summary
- harden CMake builds with `-Wl,-z,noexecstack`
- extend Makefile builds with executable stack protection
- export hardened LDFLAGS in setup script

## Testing
- `make -f Makefile.new` *(fails: build directory missing)*
- `scripts/run-qemu.sh` *(fails: `lites_server` not found)*
- `pre-commit run --files Makefile.new CMakeLists.txt setup.sh` *(fails: `pre-commit` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488eb64e348331adfe6dee617cbb0d