### PR TITLE
Improve spawn helper linting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,9 @@ find_package(BISON)
 
 # Allow selecting the build architecture with -DARCH=i686 or ARCH=x86_64
 set(ARCH "$ENV{ARCH}" CACHE STRING "Target architecture (x86_64 or i686)")
+if(NOT ARCH)
+    set(ARCH "x86_64")
+endif()
 set(CFLAGS "$ENV{CFLAGS}" CACHE STRING "Additional compiler flags")
 # Harden binaries by disallowing executable stacks
 # Append the noexecstack flag so that resulting binaries are not

--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ cmake -B build -DARCH=ia16
 cmake --build build
 ```
 
+To compile with Clang instead of GCC set the C compiler explicitly:
+
+```sh
+cmake -B build -DCMAKE_C_COMPILER=clang -DCMAKE_C_FLAGS=-O3
+cmake --build build
+```
+
 ### Building with Ninja
 
 Use the Ninja generator for faster incremental builds:
@@ -217,6 +224,28 @@ restrictions. The key compiler options include:
 ```
 
 Codex CLI can keep `setup.sh` in sync with `.codex/setup.sh` automatically. The `postCreateCommand` in `.devcontainer/devcontainer.json` installs Codex and runs `codex -q 'doctor setup.sh'` after container creation. A sample systemd unit `scripts/codex-setup.service` demonstrates how to do the same early in boot.
+
+### Codex environment packages
+
+The [`setup.sh`](setup.sh) helper installs Clang, LLD and auxiliary tools, plus
+debuggers, cross-compilers and QEMU.  The main packages include:
+
+```
+build-essential git wget curl
+clang-<version> lld-<version> llvm-<version>-dev libclang-<version>-dev polly
+clang-tools-<version> clang-tidy-<version> clang-format-<version> clangd-<version>
+ccache lldb gdb bolt llvm-bolt cmake make ninja-build meson
+doxygen graphviz python3-sphinx python3-breathe shellcheck yamllint
+python3 python3-pip python3-venv python3-setuptools python3-wheel
+bison byacc nodejs npm yarnpkg coq coqide tla4tools isabelle
+afl++ honggfuzz cargo-fuzz qemu-system-x86 qemu-utils valgrind lcov gcovr
+tmux cloc cscope libperl-dev gdb-multiarch lizard
+gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf gcc-riscv64-linux-gnu gcc-powerpc-linux-gnu
+```
+
+The script exports 80386-tuned optimisation flags and sets `cc`/`c++` to the
+selected clang version. It also generates `compile_commands.json` so clang tools
+work out of the box.
 
 
 You can also invoke `scripts/run-precommit.sh` which automatically installs

--- a/include/posix.h
+++ b/include/posix.h
@@ -1,7 +1,40 @@
 #pragma once
 #include <sys/types.h>
 
+/**
+ * @brief Spawn a child process running the specified program.
+ *
+ * Forks the current process and executes @p path with the given arguments and
+ * environment in the child.  The parent receives the PID of the new process.
+ *
+ * @param path Executable to run.
+ * @param argv Null-terminated argument vector.
+ * @param envp Null-terminated environment vector or NULL for @c environ.
+ * @return PID of the child on success, -1 on failure.
+ */
 pid_t posix_spawn(const char *path, char *const argv[], char *const envp[]);
-int posix_execve(const char *path, char *const argv[], char *const envp[]);
-pid_t posix_waitpid(pid_t pid, int *status, int options);
 
+/**
+ * @brief Execute a program, replacing the current process image.
+ *
+ * Thin wrapper around execve that falls back to the global @c environ array when
+ * @p envp is NULL.
+ *
+ * @param path Executable path.
+ * @param argv Argument vector.
+ * @param envp Environment vector or NULL.
+ * @return Only returns on failure with -1 and errno set.
+ */
+int posix_execve(const char *path, char *const argv[], char *const envp[]);
+
+/**
+ * @brief Wait for a specific child process to change state.
+ *
+ * Retries the waitpid call if interrupted by a signal.
+ *
+ * @param pid    Child process ID.
+ * @param status Location to store the exit status.
+ * @param options Flags controlling waitpid behaviour.
+ * @return PID of the child on success or -1 on error.
+ */
+pid_t posix_waitpid(pid_t pid, int *status, int options);

--- a/libs/libposix/spawn.c
+++ b/libs/libposix/spawn.c
@@ -6,6 +6,18 @@
 
 extern char **environ;
 
+/**
+ * @brief Spawn a child process running the specified program.
+ *
+ * Forks the current process and executes @p path with the given arguments
+ * and environment in the child. The parent receives the PID of the new
+ * process.
+ *
+ * @param path Executable to run.
+ * @param argv Null-terminated argument vector.
+ * @param envp Null-terminated environment vector or NULL for @c environ.
+ * @return PID of the child on success, -1 on failure.
+ */
 pid_t posix_spawn(const char *path, char *const argv[], char *const envp[]) {
     pid_t pid = fork();
     if (pid == 0) {
@@ -15,13 +27,34 @@ pid_t posix_spawn(const char *path, char *const argv[], char *const envp[]) {
     return pid;
 }
 
-int posix_execve(const char *path, char *const argv[], char *const envp[]) {
-    char **use_env = (char **)envp;
-    if (!use_env)
-        use_env = environ;
+/**
+ * @brief Execute a program, replacing the current process image.
+ *
+ * This is a thin wrapper around execve that falls back to the global
+ * @c environ array when @p envp is NULL.
+ *
+ * @param path Executable path.
+ * @param argv Argument vector.
+ * @param envp Environment vector or NULL.
+ * @return Only returns on failure with -1 and errno set.
+ */
+int posix_execve(const char *path,
+                 char *const argv[],  // NOLINT(bugprone-easily-swappable-parameters)
+                 char *const envp[]) {
+    char *const *use_env = envp ? envp : (char *const *)environ;
     return execve(path, argv, use_env);
 }
 
+/**
+ * @brief Wait for a specific child process to change state.
+ *
+ * Retries the waitpid call if interrupted by a signal.
+ *
+ * @param pid     Child process ID.
+ * @param status  Location to store the exit status.
+ * @param options Flags controlling waitpid behaviour.
+ * @return PID of the child on success or -1 on error.
+ */
 pid_t posix_waitpid(pid_t pid, int *status, int options) {
     pid_t ret;
     do {


### PR DESCRIPTION
## Summary
- suppress clang-tidy false positive for `posix_execve`
- ensure the project builds cleanly with clang and `-O3 -Werror`

## Testing
- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DARCH=x86_64 -DCMAKE_C_COMPILER=clang -DCMAKE_C_FLAGS='-O3 -Wall -Wextra -Werror -pedantic'`
- `cmake --build build --verbose`
- `scripts/run-precommit.sh`

------
https://chatgpt.com/codex/tasks/task_e_6887bd2adb148331ba8b8e9c2dfc630a