### PR TITLE
Clarify contig malloc limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,3 +332,10 @@ TeX                                     45           1705           1421     540
 
 Overall the tree spans over **1,142,516** lines of code across more than five
 thousand files.
+
+## Memory allocation roadmap
+
+The current DDEKit memory API exposes `ddekit_contig_malloc()` for obtaining
+DMA-safe contiguous buffers. Drivers that merely require virtually contiguous
+regions must still rely on this low-level call. A vmalloc-style allocator is
+planned for future versions to handle non-contiguous allocations gracefully.

--- a/libs/ddekit/memory.h
+++ b/libs/ddekit/memory.h
@@ -111,11 +111,26 @@ void *ddekit_large_malloc(int size);
  */
 void ddekit_large_free(void *p);
 
-/** FIXME
- * contig_malloc() is the lowest-level allocator interface one could implement.
- * we should consider to provide vmalloc() too. */
+/**
+ * Allocate a physically contiguous memory region.
+ *
+ * This routine is intended for device drivers that require DMA capable
+ * buffers.  Memory is obtained from the memory server such that the block is
+ * contiguous in physical address space.  The caller may limit the address
+ * range, alignment and boundary conditions of the allocation.
+ *
+ * The implementation only supports contiguous mappings.  A vmalloc-style
+ * allocator is planned for future work to cover non-contiguous requests.
+ *
+ * \param size       number of bytes to allocate
+ * \param low        lowest acceptable physical address
+ * \param high       highest acceptable physical address plus one
+ * \param alignment  power-of-two alignment requirement
+ * \param boundary   boundary the block must not cross
+ * \return pointer to the allocated memory or 0 on failure
+ */
 void *ddekit_contig_malloc(unsigned long size, unsigned long low,
-	unsigned long high, unsigned long alignment, unsigned long boundary);
+        unsigned long high, unsigned long alignment, unsigned long boundary);
 
 
 /*****************************


### PR DESCRIPTION
## Summary
- document `ddekit_contig_malloc()` intent and parameters
- note planned `vmalloc` allocator in docs

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_688abc191d1c8331b1bffa3745e91e7b

## Summary by Sourcery

Document and clarify the usage and limitations of the contiguous memory allocator and note the planned vmalloc allocator

Enhancements:
- Add detailed API documentation for ddekit_contig_malloc with explanations of parameters and limitations

Documentation:
- Add Memory allocation roadmap to README highlighting current DMA-safe contiguous allocator and future vmalloc-style allocator