### PR TITLE
Add Doxygen notes for audit and ACL

### DIFF
--- a/servers/posix/core/audit.c
+++ b/servers/posix/core/audit.c
@@ -14,6 +14,18 @@ struct audit_entry {
 static struct audit_entry audit_log[AUDIT_LOG_SIZE];
 static int audit_pos;
 
+/**
+ * Record the outcome of a security sensitive operation.
+ *
+ * Each invocation stores the process ID, the operation name and the
+ * result code into a circular buffer limited to AUDIT_LOG_SIZE entries.
+ * The buffer provides a lightweight audit trail of privileged actions.
+ *
+ * @param p      Process that triggered the event or NULL.
+ * @param op     Name of the audited operation.
+ * @param result Non-zero on success, zero on failure.
+ */
+
 void
 audit_record(struct proc *p, const char *op, int result)
 {

--- a/servers/posix/core/auth.c
+++ b/servers/posix/core/auth.c
@@ -13,6 +13,17 @@ static struct acl_entry acl_table[ACL_MAX] = {
 };
 static int acl_count = 3;
 
+/**
+ * Extend the in-memory access control list.
+ *
+ * Inserts a rule that determines whether user @p uid may perform the
+ * operation named by @p op.  Additional entries beyond ACL_MAX are
+ * ignored to keep the table bounded.
+ *
+ * @param uid   User identifier for the rule.
+ * @param op    Operation name to match.
+ * @param allow Set to 1 to permit the action, 0 to deny.
+ */
 void
 acl_add(uid_t uid, const char *op, int allow)
 {
@@ -24,6 +35,17 @@ acl_add(uid_t uid, const char *op, int allow)
         acl_count++;
 }
 
+/**
+ * Validate that a process may invoke a privileged operation.
+ *
+ * The function scans the ACL table for an entry matching the process's
+ * effective user ID and the requested operation.  When no rule exists the
+ * action is allowed by default.
+ *
+ * @param p  Process requesting authorisation or NULL.
+ * @param op Operation name being attempted.
+ * @return   1 if permitted, 0 if denied.
+ */
 int
 authorize(struct proc *p, const char *op)
 {


### PR DESCRIPTION
## Summary
- document `audit_record` in `audit.c`
- document `acl_add` and `authorize` in `auth.c`

## Testing
- `pre-commit run --files servers/posix/core/audit.c servers/posix/core/auth.c`

------
https://chatgpt.com/codex/tasks/task_e_688abc1787848331b88d568248f6dcc5