### PR TITLE
Fix pre-commit exclusion pattern

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
 minimum_pre_commit_version: '2.20.0'
-exclude: '.*'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/docs/build_steps.md
+++ b/docs/build_steps.md
@@ -54,3 +54,17 @@ valgrind --track-origins=yes --log-file=valgrind.log \
 Missing headers or packages will be reported in the logs mentioned above.
 Ensure `LITES_MACH_DIR` points at a compatible Mach kernel tree if local
 headers are insufficient.
+
+## 5. Pre-commit hooks
+
+Install the local hooks after cloning the repository and run them
+whenever sources are modified.  They enforce formatting and basic lint
+rules using `clang-format`, `clang-tidy` and standard whitespace checks.
+
+```bash
+pre-commit install        # set up git hooks
+pre-commit run -a         # format and lint the entire tree
+```
+
+These hooks rely on the configuration in `.pre-commit-config.yaml` and
+operate automatically during commits.


### PR DESCRIPTION
## Summary
- remove global exclude from pre-commit config so hooks run on sources
- describe using pre-commit hooks in `build_steps.md`
- install hooks

## Testing
- `pre-commit run --files .pre-commit-config.yaml docs/build_steps.md`
- `pre-commit install`

------
https://chatgpt.com/codex/tasks/task_e_688abc1a2f708331b0bda674f6791f57