### PR TITLE
Add strict warnings to Makefile.new

### DIFF
--- a/Makefile.new
+++ b/Makefile.new
@@ -45,6 +45,10 @@ ARCH ?= x86_64
 # Base optimisation flags
 C23_FLAG := $(shell $(CC) -std=c23 -E -x c /dev/null >/dev/null 2>&1 && echo -std=c23 || echo -std=c2x)
 CFLAGS ?= -O2 $(C23_FLAG)
+# Treat all compiler warnings as errors and enable additional checks
+# to enforce strict ISO compliance and flag potentially problematic
+# constructs across architectures.
+CFLAGS += -Wall -Wextra -Werror -pedantic
 # Harden binaries by disallowing executable stacks by appending the
 # noexecstack flag to the existing linker options. This ensures the
 # generated binaries do not allow execution from the stack.


### PR DESCRIPTION
## Summary
- treat compiler warnings as errors by default
- keep cross-arch options unaffected

## Testing
- `make -f Makefile.new` *(fails: missing build sources)*

------
https://chatgpt.com/codex/tasks/task_e_688abc2aae0c8331aa0a773ed5d0156a