### PR TITLE
Add iinit prototype and documentation

### DIFF
--- a/core/alloc.c
+++ b/core/alloc.c
@@ -9,18 +9,18 @@
 #include "../buf.h"
 #include "../inode.h"
 #include "../user.h"
+#include "alloc.h"
 
-/*
- * iinit is called once (from main)
- * very early in initialization.
- * It reads the root's super block
- * and initializes the current date
- * from the last modified date.
+/**
+ * @brief Initialize the root file system.
  *
- * panic: iinit -- cannot read the super
- * block. Usually because of an IO error.
+ * This routine is invoked once at startup to read the root
+ * super block and to initialize the system time from its
+ * last modification timestamp. It takes no parameters.
+ *
+ * @return void
  */
-iinit()
+void iinit(void)
 {
 	register *cp, *bp;
 

--- a/core/alloc.h
+++ b/core/alloc.h
@@ -1,0 +1,15 @@
+#ifndef CORE_ALLOC_H
+#define CORE_ALLOC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void iinit(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CORE_ALLOC_H */
+

--- a/core/main.c
+++ b/core/main.c
@@ -6,6 +6,7 @@
 #include "../text.h"
 #include "../inode.h"
 #include "../seg.h"
+#include "alloc.h"
 
 #define	CLOCK1	0177546
 #define	CLOCK2	0172540


### PR DESCRIPTION
## Summary
- document `iinit` with a Doxygen block
- modernize `iinit` definition and include new header
- provide `core/alloc.h` with `iinit` prototype
- include header in `main.c`

## Testing
- `clang -fsyntax-only core/alloc.c` *(fails: '../param.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_688abc68d4bc8331a0d0d8e7f4796fa0