### PR TITLE
Refine pre-commit exclusions and document hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,11 @@
 minimum_pre_commit_version: '2.20.0'
+exclude: |
+  ^(
+    archives/|
+    Historical\ Archives/|
+    offline_packages/|
+    third_party/
+  )
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
@@ -12,7 +19,7 @@ repos:
         name: clang-format
         entry: clang-format -i --style=file
         language: system
-        files: \.(c|h|cpp|hpp|cc)$
+        types_or: [c, c++]
       - id: clang-tidy-c
         name: clang-tidy C
         entry: scripts/run-clang-tidy.sh --extra-arg=-std=c23

--- a/README.md
+++ b/README.md
@@ -171,16 +171,22 @@ endif()
 
 The optional `setup.sh` script installs a wide range of cross-compilers
 and emulators along with standard build utilities such as build-essential,
-GCC, clang, llvm, m4, CMake and Ninja.  BSD make (`bmake`) and the optional `mk-configure` framework are installed as well.  The script also sets up debugging and profiling tools, installs the pre-commit hooks and generates a
-`compile_commands.json` database for clang tooling.  Run `pre-commit run -a`
-after editing sources to keep formatting consistent.  The script installs `pre-commit` via pip when missing and ensures a `.pre-commit-config.yaml` file exists.  It also verifies
-that `yacc` (via `byacc` or `bison`) and the Swift toolchain
-are available, falling back to additional package installs if necessary.
-Any package failures are recorded in `/tmp/setup_failures.log`
-so the remainder of the setup can continue.  The script normally requires
-root privileges and network access.  When invoked with `--offline` it
-installs all `.deb` files from the `offline_packages/` directory instead of
-using the network.
+GCC, clang, llvm, m4, CMake and Ninja. BSD make (`bmake`) and the optional
+`mk-configure` framework are installed as well. The script also sets up
+debugging and profiling tools, installs the pre-commit hooks and generates a
+`compile_commands.json` database for clang tooling. Run `pre-commit run --files
+<path/to/file.c>` to format or analyse individual changes, or `pre-commit run -a`
+to sweep the entire tree. The configuration invokes `clang-format` and
+`clang-tidy` on tracked C and C++ sources while automatically skipping archival
+directories such as `archives/`, `Historical Archives/`, `offline_packages/` and
+`third_party/`. The script installs `pre-commit` via pip when missing and
+ensures a `.pre-commit-config.yaml` file exists. It also verifies that `yacc`
+(via `byacc` or `bison`) and the Swift toolchain are available, falling back to
+additional package installs if necessary. Any package failures are recorded in
+`/tmp/setup_failures.log` so the remainder of the setup can continue. The script
+normally requires root privileges and network access. When invoked with
+`--offline` it installs all `.deb` files from the `offline_packages/` directory
+instead of using the network.
 The package list now includes `tmux` for convenient session management. Cross-compilers for AArch64, ARMv7, PowerPC and RISC-V are installed so the tree can be built for a variety of targets. `gcc-multilib` conflicts with these cross toolchains, so it is omitted. `setup.sh` defaults to **clang-18**, switches to **clang-20** when available and falls back to **clang-14** or **clang-11** on older systems.
 Wrapper symlinks named `cc` and `c++` point to the selected clang version so existing build scripts use clang transparently.
 


### PR DESCRIPTION
## Summary
- narrow pre-commit exclusion to archival directories and enable clang tooling for C/C++ sources
- document clang-format and clang-tidy usage via pre-commit

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md`
- `pre-commit run --files examples/security/keystore-demo.c` *(clang-tidy fails: 'keystore.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892ea4a97588331a1405727dfe14fc7