### PR TITLE
docs: document enclave stubs with Doxygen comments

### DIFF
--- a/ANALYZE.MD
+++ b/ANALYZE.MD
@@ -61,3 +61,8 @@ dot -Tpng trace_graph.dot -o trace_graph.png
 ```
 
 These steps provide a reproducible baseline for further static or dynamic trace investigations.
+## Additional Tooling
+The following packages were installed to facilitate building and documentation:
+
+- `bmake` – BSD make implementation enabling legacy makefiles.
+- `doxygen` – documentation generator for C/C++ sources.

--- a/libs/liblites/enclave.c
+++ b/libs/liblites/enclave.c
@@ -3,10 +3,19 @@
 #include <stdio.h>
 
 /**
- * Create a new enclave instance.
+ * @brief Create a new enclave.
  *
- * @param name Descriptive name for the enclave.
- * @return Positive handle identifying the enclave on success.
+ * @details This stub merely logs creation of an enclave. A production
+ * implementation would allocate and initialize a protected execution
+ * context and return a unique handle representing it.
+ *
+ * @param[in] name Human-readable identifier used for logging and debugging.
+ *                 Must not be `NULL`.
+ *
+ * @return Positive handle to the newly created enclave on success.
+ * @return Negative error code on failure.
+ *
+ * @todo Replace stub with real enclave creation logic.
  */
 int enclave_create(const char *name) {
     printf("enclave '%s' created\n", name);
@@ -14,10 +23,19 @@ int enclave_create(const char *name) {
 }
 
 /**
- * Verify the integrity of an enclave.
+ * @brief Attest to the integrity of an enclave.
  *
- * @param handle Handle previously returned by enclave_create().
- * @return 0 when the enclave attests successfully.
+ * @details This stub simulates verifying the enclave's measurement. A
+ * complete implementation would perform cryptographic checks to ensure
+ * the enclave's code and data have not been tampered with.
+ *
+ * @param[in] handle Handle returned by enclave_create() identifying the
+ *                   enclave to attest.
+ *
+ * @return 0 when attestation succeeds.
+ * @return Negative error code on failure.
+ *
+ * @todo Replace stub with real attestation logic.
  */
 int enclave_attest(int handle) {
     printf("enclave %d attested\n", handle);


### PR DESCRIPTION
## Summary
- refine Doxygen blocks for `enclave_create` and `enclave_attest` stubs, detailing parameter constraints, return values, and future work
- record installation of `bmake` and `doxygen` in `ANALYZE.MD` for reproducible tooling setup

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y bmake doxygen`
- `bmake -C libs/liblites enclave.o` *(fails: Could not find)*
- `echo "// temporary enclave.h" >/tmp/enclave.h`
- `cc -std=c2x -I/tmp -c libs/liblites/enclave.c -o /tmp/enclave.o`


------
https://chatgpt.com/codex/tasks/task_e_6892ea4864348331ae657354e7c648dd

## Summary by Sourcery

Add Doxygen documentation for enclave stub functions and record required tooling in ANALYZE.MD

Documentation:
- Enhance Doxygen comments for enclave_create and enclave_attest stubs with detailed parameter descriptions, return values, and @todo notes
- Document installation of bmake and doxygen in ANALYZE.MD to ensure reproducible tooling setup