### PR TITLE
docs: add Doxygen comments for VM helpers

### DIFF
--- a/libs/libos/vm.c
+++ b/libs/libos/vm.c
@@ -1,7 +1,7 @@
-#include <sys/mman.h>
-#include <unistd.h>
 #include <string.h>
+#include <sys/mman.h>
 #include <sys/socket.h>
+#include <unistd.h>
 
 #include "vm.h"
 
@@ -10,11 +10,22 @@
  * a future implementation.
  */
 
+/**
+ * @brief Handle a page fault for the given address space.
+ *
+ * Notifies an optional pager about the fault and maps a writable page at the
+ * faulting address.
+ *
+ * @param as   Address space receiving the fault.
+ * @param addr Faulting virtual address.
+ * @param prot Requested protection for the new mapping.
+ * @return KERN_SUCCESS on success, otherwise KERN_FAILURE.
+ */
 kern_return_t vm_fault_entry(aspace_t *as, vm_offset_t addr, vm_prot_t prot) {
     if (!as)
         return KERN_FAILURE;
 
-    pf_info_t info = { .addr = addr, .prot = prot, .flags = 0 };
+    pf_info_t info = {.addr = addr, .prot = prot, .flags = 0};
     if (as->pager_cap >= 0) {
         (void)write(as->pager_cap, &info, sizeof(info));
         char ack;
@@ -22,14 +33,25 @@ kern_return_t vm_fault_entry(aspace_t *as, vm_offset_t addr, vm_prot_t prot) {
     }
 
     size_t psz = (size_t)sysconf(_SC_PAGESIZE);
-    void *res = mmap(addr ? (void *)addr : NULL, psz,
-                     PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE |
-                     (addr ? MAP_FIXED : 0), -1, 0);
+    void *res = mmap(addr ? (void *)addr : NULL, psz, PROT_READ | PROT_WRITE,
+                     MAP_ANON | MAP_PRIVATE | (addr ? MAP_FIXED : 0), -1, 0);
     if (res == MAP_FAILED)
         return KERN_FAILURE;
     return KERN_SUCCESS;
 }
 
+/**
+ * @brief Map a frame into an address space.
+ *
+ * Creates a mapping at the specified virtual address.
+ *
+ * @param as    Target address space.
+ * @param vaddr Desired virtual address; may be 0 for kernel choice.
+ * @param frame Frame capability to map (unused placeholder).
+ * @param prot  Requested memory protection.
+ * @param flags Mapping flags (unused placeholder).
+ * @return KERN_SUCCESS on success, otherwise KERN_FAILURE.
+ */
 kern_return_t map_frame(aspace_t *as, vm_offset_t vaddr, mach_port_t frame, vm_prot_t prot,
                         int flags) {
     (void)as;
@@ -42,6 +64,13 @@ kern_return_t map_frame(aspace_t *as, vm_offset_t vaddr, mach_port_t frame, vm_p
     return res == MAP_FAILED ? KERN_FAILURE : KERN_SUCCESS;
 }
 
+/**
+ * @brief Unmap a previously mapped frame.
+ *
+ * @param as    Address space owning the mapping.
+ * @param vaddr Virtual address of the mapping to remove.
+ * @return KERN_SUCCESS on success, otherwise KERN_FAILURE.
+ */
 kern_return_t unmap_frame(aspace_t *as, vm_offset_t vaddr) {
     (void)as;
     size_t psz = (size_t)sysconf(_SC_PAGESIZE);


### PR DESCRIPTION
## Summary
- document `vm_fault_entry` with a new Doxygen block
- add parameter and return descriptions for `map_frame` and `unmap_frame`

## Testing
- `pre-commit run --files libs/libos/vm.c` *(fails: clang-tidy unknown type names)*

------
https://chatgpt.com/codex/tasks/task_e_6892ea4725b0833193b3d007e29aa2e2

## Summary by Sourcery

Add detailed Doxygen documentation to VM helper functions in libs/libos/vm.c and clean up include ordering

Enhancements:
- Reorder and group include directives in vm.c for consistency

Documentation:
- Add Doxygen comments for vm_fault_entry including parameter and return descriptions
- Add Doxygen comments for map_frame including parameter and return descriptions
- Add Doxygen comments for unmap_frame including parameter and return descriptions