### PR TITLE
Place generated docs under docs/html

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1,6 +1,6 @@
 PROJECT_NAME = "Lites"
-# Place generated documentation under docs/html
-OUTPUT_DIRECTORY = html
+# Place generated documentation under docs/html relative to the repository root
+OUTPUT_DIRECTORY = docs/html
 # Source paths are relative to the repository root so Doxygen may be invoked
 # from anywhere.  All main directories are scanned recursively.
 INPUT = arch core drivers include libs


### PR DESCRIPTION
## Summary
- direct Doxygen to deposit generated documentation beneath `docs/html`

## Testing
- `doxygen docs/Doxyfile`


------
https://chatgpt.com/codex/tasks/task_e_6892ea3e09a0833193f4dd4ab441af52

## Summary by Sourcery

Enhancements:
- Update Doxyfile to set the output directory to docs/html