### PR TITLE
Improve random_int utility and document package update step

### DIFF
--- a/docs/build_steps.md
+++ b/docs/build_steps.md
@@ -6,6 +6,12 @@ configure the tree and attempt a build with full instrumentation.
 
 ## 1. Environment setup
 
+Before building, ensure your package lists are current:
+
+```bash
+sudo apt update
+```
+
 Follow the [environment setup guide](setup.md) to install compilers,
 debuggers and tracing utilities. The steps require root privileges when
 adding packages.

--- a/util/random_int.c
+++ b/util/random_int.c
@@ -1,13 +1,32 @@
-int main(int argc, char **argv)
-{
-  int mod = atoi(argv[1]), rn;
-  int i, p;
-  
-  srand(p=getpid());
-  rn = (rand() >> 16) &0xffff;
-  srand(rn);
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
 
-  rn = rand() % mod;
-  printf("%d", rn);
-  return 0;
+/**
+ * @brief Generate a pseudo-random integer modulo the supplied argument.
+ *
+ * The generator seeds itself using the current process identifier and a
+ * secondary value derived from the C library `rand` implementation. The
+ * result is printed to standard output.
+ *
+ * @param argc Number of command line arguments.
+ * @param argv Array of command line arguments. The first element after the
+ *             program name is interpreted as the modulus.
+ * @return Zero on success, non-zero if the modulus argument is missing.
+ */
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s <mod>\n", argv[0]);
+        return 1;
+    }
+
+    int mod = atoi(argv[1]);
+
+    srand(getpid());
+    int rn = (rand() >> 16) & 0xffff;
+    srand(rn);
+
+    rn = rand() % mod;
+    printf("%d", rn);
+    return 0;
 }


### PR DESCRIPTION
## Summary
- add standard headers and Doxygen docs to `random_int` utility
- document running `apt update` before installing build tools

## Testing
- `pre-commit run --files util/random_int.c docs/build_steps.md` *(fails: no such file or directory: '-std=c23')*

------
https://chatgpt.com/codex/tasks/task_e_68a7c87e10f88331b97c78c0535a62f5