### PR TITLE
Document ddekit_contig_malloc and clarify allocator roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,8 @@ thousand files.
 ## Memory allocation roadmap
 
 The current DDEKit memory API exposes `ddekit_contig_malloc()` for obtaining
-DMA-safe contiguous buffers. Drivers that merely require virtually contiguous
-regions must still rely on this low-level call. A vmalloc-style allocator is
-planned for future versions to handle non-contiguous allocations gracefully.
+DMA-safe contiguous buffers. Drivers that only need virtual contiguity must
+still rely on this low-level call, which is presently a stub returning no
+memory. A dedicated vmalloc-style allocator is planned for future versions to
+handle non-contiguous requests more gracefully while keeping
+`ddekit_contig_malloc()` for strictly contiguous DMA use cases.

--- a/libs/ddekit/memory.c
+++ b/libs/ddekit/memory.c
@@ -115,8 +115,8 @@ void ddekit_vfree(void *addr) {
 }
 
 // Placeholders for existing DDEKit functions
-// These are just to make the library build. The real implementation
-// is somewhere else.
+/* These definitions are placeholders to make the library linkable.
+ * Proper implementations are provided by the hosting environment. */
 struct ddekit_slab * ddekit_slab_init(unsigned size, int contiguous) { return NULL; }
 void ddekit_slab_destroy(struct ddekit_slab * slab) {}
 void *ddekit_slab_alloc(struct ddekit_slab * slab) { return NULL; }
@@ -126,7 +126,35 @@ void *ddekit_slab_get_data(struct ddekit_slab * slab) { return NULL; }
 void ddekit_slab_setup_page_cache(unsigned pages) {}
 void *ddekit_large_malloc(int size) { return NULL; }
 void ddekit_large_free(void *p) {}
-void *ddekit_contig_malloc(unsigned long size, unsigned long low,
-        unsigned long high, unsigned long alignment, unsigned long boundary) { return NULL; }
+
+/**
+ * Allocate a physically contiguous memory region.
+ *
+ * This stub documents the intended semantics for the contiguous allocator used
+ * by device drivers. The final implementation will obtain a DMA-capable buffer
+ * from the memory server such that it lies within the physical address window
+ * \p [low, high), satisfies the power-of-two \p alignment, and does not cross
+ * the \p boundary.
+ *
+ * A vmalloc-style allocator is planned to handle non-contiguous requests in the
+ * future; until then this function is expected to serve only contiguous needs
+ * and currently always returns `NULL`.
+ *
+ * @param size      number of bytes to allocate
+ * @param low       lowest acceptable physical address
+ * @param high      highest acceptable physical address plus one
+ * @param alignment power-of-two alignment requirement
+ * @param boundary  physical boundary the allocation must not cross
+ *
+ * @return Pointer to the allocated memory on success, or `NULL` on failure.
+ */
+void *ddekit_contig_malloc(unsigned long size,
+                           unsigned long low,
+                           unsigned long high,
+                           unsigned long alignment,
+                           unsigned long boundary)
+{
+    return NULL;
+}
 void *ddekit_simple_malloc(unsigned size) { return NULL; }
 void ddekit_simple_free(void *p) {}

--- a/libs/ddekit/memory.h
+++ b/libs/ddekit/memory.h
@@ -115,13 +115,15 @@ void ddekit_large_free(void *p);
 /**
  * Allocate a physically contiguous memory region.
  *
- * This routine is intended for device drivers that require DMA capable
- * buffers.  Memory is obtained from the memory server such that the block is
- * contiguous in physical address space.  The caller may limit the address
- * range, alignment and boundary conditions of the allocation.
+ * This routine targets device drivers that require DMA-capable buffers.  It is
+ * meant to request memory from the system's memory server such that the block
+ * resides within the physical window \p [low, high), satisfies a power-of-two
+ * \p alignment, and does not cross the specified \p boundary.
  *
- * The implementation only supports contiguous mappings.  A vmalloc-style
- * allocator is planned for future work to cover non-contiguous requests.
+ * The current library only ships a stub implementation and therefore returns
+ * `0`.  A vmalloc-style allocator is planned to handle non-contiguous requests
+ * in the future while this call will continue to serve strictly contiguous
+ * needs.
  *
  * \param size       number of bytes to allocate
  * \param low        lowest acceptable physical address

--- a/libs/ddekit/types.h
+++ b/libs/ddekit/types.h
@@ -4,7 +4,9 @@
  * \author  Christian Helmuth <ch12@os.inf.tu-dresden.de>
  * \date    2006-11-09
  *
- * FIXME This is definitely arch-dependent! Move to ARCH-something
+ * These definitions reflect the assumptions of the original x86 port.
+ * Future architectures should provide their own specialised header
+ * if the widths of these types differ.
  */
 
 #ifndef _DDEKIT_TYPES_H


### PR DESCRIPTION
## Summary
- document `ddekit_contig_malloc` with detailed Doxygen notes and forward-looking guidance on vmalloc-style allocator
- replace architecture-specific FIXME in ddekit types header with explanatory comment
- expand README to highlight contiguous allocator limitations and planned vmalloc support

## Testing
- `cmake -S . -B build`
- `cmake --build build --target ddekit`
- `ctest --test-dir build` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b371fc753c8331a4c465d9d3034ef9