### PR TITLE
chore: remove macOS artifacts and ensure trace graph dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,6 @@ builds/
 # Ignore logs and operating system files
 *.log
 lizard.log
+
+# macOS Finder metadata
 .DS_Store

--- a/scripts/trace_graph.py
+++ b/scripts/trace_graph.py
@@ -21,7 +21,13 @@ import argparse
 import re
 from pathlib import Path
 
-import networkx as nx
+try:
+    import networkx as nx
+    import pydot  # type: ignore[import-not-found]  # Imported for its GraphViz bindings
+except ModuleNotFoundError as exc:
+    raise SystemExit(
+        "networkx and pydot are required to generate trace graphs; install with 'pip install networkx pydot'."
+    ) from exc
 
 
 def find_trace_files(root: Path, exclude: set[str] | None = None) -> set[Path]:

--- a/tests/test_trace_graph.py
+++ b/tests/test_trace_graph.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 import sys
+import pytest
+
+pytest.importorskip("networkx")  # Skip tests if networkx is unavailable
+pytest.importorskip("pydot")     # Skip tests if pydot is unavailable
 
 
 def test_trace_graph_generates_output(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- clearly ignore macOS Finder metadata
- handle missing dependencies for trace graph utility and guard tests

## Testing
- `pre-commit run --files scripts/trace_graph.py tests/test_trace_graph.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b37201f1b48331afc25ec88b7f7f2c