### PR TITLE
arch: add x86_64 TLB invalidation primitives

### DIFF
--- a/arch/x86_64_v1/README.md
+++ b/arch/x86_64_v1/README.md
@@ -12,7 +12,7 @@ functionality without behavioural changes.
 ## Notes
 
 Basic TLB invalidation routines are currently provided only for the `x86_64`
-architecture. Other targets, including `arm64` and `riscv64`, remain
-unsupported and will need dedicated implementations.
+architecture. Other targets, including `aarch64`, `riscv64`, `powerpc64` and
+others, remain unsupported and will need dedicated implementations.
 
 Further machine specific code will be added over time.

--- a/arch/x86_64_v1/tlb.c
+++ b/arch/x86_64_v1/tlb.c
@@ -1,6 +1,6 @@
 #include "tlb.h"
 
-#if defined(__x86_64__) || defined(_M_X64)
+#if defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
 
 /**
  * @brief Invalidate the entire translation lookaside buffer.
@@ -22,6 +22,15 @@ void arch_tlb_invalidate_page(uintptr_t addr) {
 
 #else
 #warning "TLB invalidation not supported on this architecture"
+/**
+ * @brief Fallback no-op for unsupported targets.
+ */
 void arch_tlb_invalidate_all(void) {}
+
+/**
+ * @brief Fallback no-op for unsupported targets.
+ *
+ * @param addr Ignored.
+ */
 void arch_tlb_invalidate_page(uintptr_t addr) { (void)addr; }
 #endif

--- a/arch/x86_64_v1/tlb.h
+++ b/arch/x86_64_v1/tlb.h
@@ -11,9 +11,9 @@ extern "C" {
  * @file tlb.h
  * @brief Architecture-specific TLB invalidation primitives.
  *
- * Only x86_64 implementations are currently provided. Other
- * architectures such as arm64 or riscv64 must supply their own
- * definitions or treat the functions as no-ops.
+ * Only x86_64 implementations are currently provided. Architectures such
+ * as aarch64, riscv64 or powerpc64 remain unsupported and must supply
+ * their own definitions or treat the functions as no-ops.
  */
 
 /**


### PR DESCRIPTION
## Summary
- implement x86_64 TLB invalidation using CR3 reload and INVLPG
- document unsupported architectures and provide no-op fallbacks
- clarify README on missing TLB support for non-x86_64 targets

## Testing
- `pre-commit run --files arch/x86_64_v1/tlb.c arch/x86_64_v1/tlb.h arch/x86_64_v1/README.md` *(fails: error: no such file or directory: '-std=c23')*

------
https://chatgpt.com/codex/tasks/task_e_68b372101e388331b96640d89960c320