### PR TITLE
refine pre-commit excludes and document usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 minimum_pre_commit_version: '2.20.0'
 exclude: |
-  ^(
+  (?x)^(
     archives/|
     Historical\ Archives/|
     offline_packages/|

--- a/README.md
+++ b/README.md
@@ -262,9 +262,24 @@ The script exports 80386-tuned optimisation flags and sets `cc`/`c++` to the
 selected clang version. It also generates `compile_commands.json` so clang tools
 work out of the box.
 
-
 You can also invoke `scripts/run-precommit.sh` which automatically installs
 `pre-commit` via pip when missing.
+
+### Pre-commit hooks
+
+Install the Git hook once to enable automatic formatting and static analysis:
+
+```sh
+pre-commit install
+```
+
+The configuration in `.pre-commit-config.yaml` registers `clang-format` and
+`clang-tidy` hooks. They operate on all tracked C and C++ sources. Run them
+manually on selected files with:
+
+```sh
+pre-commit run --files path/to/file.c path/to/file.cpp
+```
 
 The clang-tidy hooks rely on `scripts/run-clang-tidy.sh`.  This helper
 ensures a `compile_commands.json` database is generated on demand so


### PR DESCRIPTION
## Summary
- narrow pre-commit exclude to specific archival directories
- explain pre-commit workflow in README

## Testing
- `pre-commit run --files core/qsort.c`
- `pre-commit run --files .pre-commit-config.yaml README.md`


------
https://chatgpt.com/codex/tasks/task_e_68b3720f7f20833188b1a2fd037946a1